### PR TITLE
#35 Switch UI copy to English

### DIFF
--- a/src/plain/app.py
+++ b/src/plain/app.py
@@ -146,20 +146,20 @@ class PlainApp(App[None]):
     def _build_body(self, shell: ThreePaneShellData) -> Horizontal:
         return Horizontal(
             SidePane(
-                "親ディレクトリ",
+                "Parent Directory",
                 shell.parent_entries,
                 id="parent-pane",
                 classes="pane side-pane",
             ),
             MainPane(
-                "カレントディレクトリ",
+                "Current Directory",
                 shell.current_entries,
                 cursor_index=shell.current_cursor_index,
                 id="current-pane",
                 classes="pane main-pane",
             ),
             SidePane(
-                "子ディレクトリ",
+                "Child Directory",
                 shell.child_entries,
                 id="child-pane",
                 classes="pane side-pane",
@@ -284,7 +284,7 @@ class PlainApp(App[None]):
             )
             return
 
-        message = str(event.worker.error) or "ディレクトリ読み込みに失敗しました"
+        message = str(event.worker.error) or "Failed to load directory"
         if isinstance(effect, LoadBrowserSnapshotEffect):
             await self.dispatch_actions(
                 (

--- a/src/plain/services/browser_snapshot.py
+++ b/src/plain/services/browser_snapshot.py
@@ -80,13 +80,13 @@ class LiveBrowserSnapshotLoader:
         try:
             return self.filesystem.list_directory(path)
         except PermissionError as error:
-            raise OSError(f"アクセスできません: {path}") from error
+            raise OSError(f"Permission denied: {path}") from error
         except FileNotFoundError as error:
-            raise OSError(f"見つかりません: {path}") from error
+            raise OSError(f"Not found: {path}") from error
         except NotADirectoryError as error:
-            raise OSError(f"ディレクトリではありません: {path}") from error
+            raise OSError(f"Not a directory: {path}") from error
         except OSError as error:
-            raise OSError(str(error) or f"ディレクトリ読み込みに失敗しました: {path}") from error
+            raise OSError(str(error) or f"Failed to load directory: {path}") from error
 
 
 @dataclass(frozen=True)

--- a/src/plain/state/input.py
+++ b/src/plain/state/input.py
@@ -37,7 +37,7 @@ def dispatch_key_input(
         return _dispatch_confirm_input(key)
 
     if state.ui_mode == "BUSY":
-        return _warn("処理中のため入力を無視しました")
+        return _warn("Input ignored while processing")
 
     if state.ui_mode in {"RENAME", "CREATE"}:
         return _dispatch_unwired_input_mode(state.ui_mode, key)
@@ -78,7 +78,7 @@ def _dispatch_browsing_input(state: AppState, key: str) -> DispatchedActions:
     if key in {"right", "enter"}:
         if cursor_entry is not None and cursor_entry.kind == "dir":
             return _supported(EnterCursorDirectory())
-        return _warn("ファイルオープンは未実装です")
+        return _warn("Opening files is not implemented yet")
 
     return ()
 
@@ -105,7 +105,7 @@ def _dispatch_filter_input(
     if character and character.isprintable() and not character.isspace():
         return _supported(SetFilterQuery(f"{state.filter.query}{character}", active=True))
 
-    return _warn("フィルタ入力ではこのキーを使えません")
+    return _warn("This key is unavailable while editing the filter")
 
 
 def _dispatch_confirm_input(key: str) -> DispatchedActions:
@@ -116,17 +116,17 @@ def _dispatch_confirm_input(key: str) -> DispatchedActions:
         return (
             SetUiMode("BROWSING"),
             SetNotification(
-                NotificationState(level="warning", message="確認ダイアログは未接続です")
+                NotificationState(level="warning", message="Confirmation dialog is not wired yet")
             ),
         )
 
-    return _warn("確認待ちのためこの入力は無効です")
+    return _warn("This input is unavailable while waiting for confirmation")
 
 
 def _dispatch_unwired_input_mode(mode: str, key: str) -> DispatchedActions:
     if key == "escape":
         return _supported(SetUiMode("BROWSING"))
-    return _warn(f"{mode} モードの入力処理は未実装です")
+    return _warn(f"Input handling for {mode} mode is not implemented yet")
 
 
 def _visible_paths(state: AppState) -> tuple[str, ...]:

--- a/src/plain/ui/panes.py
+++ b/src/plain/ui/panes.py
@@ -62,7 +62,7 @@ class SidePane(Vertical):
 class MainPane(Vertical):
     """Center pane with detailed columns for the current directory."""
 
-    COLUMN_LABELS = ("種別", "名前", "サイズ", "更新日時")
+    COLUMN_LABELS = ("Type", "Name", "Size", "Modified")
 
     def __init__(
         self,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -163,13 +163,19 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
         parent_list = app.query_one("#parent-pane-list", ListView)
         current_table = app.query_one("#current-pane-table", DataTable)
         child_list = app.query_one("#child-pane-list", ListView)
+        parent_title = app.query_one("#parent-pane .pane-title", Label)
+        current_title = app.query_one("#current-pane .pane-title", Label)
+        child_title = app.query_one("#child-pane .pane-title", Label)
         status_bar = await _wait_for_status_bar(app)
         parent_entries = [str(item.query_one(Label).renderable) for item in parent_list.children]
         child_entries = [str(item.query_one(Label).renderable) for item in child_list.children]
         headers = [str(column.label) for column in current_table.ordered_columns]
 
+        assert str(parent_title.renderable) == "Parent Directory"
+        assert str(current_title.renderable) == "Current Directory"
+        assert str(child_title.renderable) == "Child Directory"
         assert parent_entries == ["plain-app", "sibling"]
-        assert headers == ["種別", "名前", "サイズ", "更新日時"]
+        assert headers == ["Type", "Name", "Size", "Modified"]
         assert current_table.row_count == 2
         assert child_entries == ["spec.md"]
         assert str(status_bar.renderable) == (

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -93,7 +93,9 @@ def test_browsing_enter_on_file_shows_warning() -> None:
     actions = dispatch_key_input(state, key="enter")
 
     assert actions == (
-        SetNotification(NotificationState(level="warning", message="ファイルオープンは未実装です")),
+        SetNotification(
+            NotificationState(level="warning", message="Opening files is not implemented yet")
+        ),
     )
 
 
@@ -187,6 +189,6 @@ def test_busy_key_shows_warning_message() -> None:
 
     assert actions == (
         SetNotification(
-            NotificationState(level="warning", message="処理中のため入力を無視しました")
+            NotificationState(level="warning", message="Input ignored while processing")
         ),
     )

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -76,7 +76,7 @@ def test_live_browser_snapshot_loader_normalizes_not_found_error() -> None:
         filesystem=StubFilesystemAdapter(errors_by_path={"/missing": FileNotFoundError("nope")})
     )
 
-    with pytest.raises(OSError, match="見つかりません: /missing"):
+    with pytest.raises(OSError, match="Not found: /missing"):
         loader.load_browser_snapshot("/missing")
 
 
@@ -85,7 +85,7 @@ def test_live_browser_snapshot_loader_normalizes_permission_error() -> None:
         filesystem=StubFilesystemAdapter(errors_by_path={"/secret": PermissionError("blocked")})
     )
 
-    with pytest.raises(OSError, match="アクセスできません: /secret"):
+    with pytest.raises(OSError, match="Permission denied: /secret"):
         loader.load_browser_snapshot("/secret")
 
 


### PR DESCRIPTION
## Summary
- switch pane titles and table headers to English
- translate warning and directory-loading error messages to English
- update tests to cover the new English UI strings

## Testing
- uv run pytest
- uv run ruff check .

Closes #35