### PR TITLE
#66 Add Enter open to browsing help

### DIFF
--- a/src/plain/models/shell_data.py
+++ b/src/plain/models/shell_data.py
@@ -142,8 +142,8 @@ def build_dummy_shell_data() -> ThreePaneShellData:
         ),
         current_context_input=None,
         help=HelpBarState(
-            "/ filter | s sort | d dirs | Space select | y copy | x cut | p paste | "
-            "F2 rename | : palette"
+            "Enter open | / filter | Space select | y copy | x cut | p paste | "
+            "s sort | d dirs | F2 rename | : palette"
         ),
         command_palette=None,
         status=StatusBarState(message=None, message_level=None),

--- a/src/plain/state/selectors.py
+++ b/src/plain/state/selectors.py
@@ -135,8 +135,8 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
     if state.ui_mode == "BUSY":
         return HelpBarState("processing...")
     return HelpBarState(
-        "/ filter | s sort | d dirs | Space select | y copy | x cut | p paste | "
-        "F2 rename | : palette"
+        "Enter open | / filter | Space select | y copy | x cut | p paste | "
+        "s sort | d dirs | F2 rename | : palette"
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -918,8 +918,8 @@ async def test_app_displays_browsing_help_bar() -> None:
         help_bar = app.query_one("#help-bar", HelpBar)
 
         assert str(help_bar.renderable) == (
-            "/ filter | s sort | d dirs | Space select | y copy | x cut | p paste | "
-            "F2 rename | : palette"
+            "Enter open | / filter | Space select | y copy | x cut | p paste | "
+            "s sort | d dirs | F2 rename | : palette"
         )
 
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -439,8 +439,8 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     help_state = select_help_bar_state(state)
 
     assert help_state.text == (
-        "/ filter | s sort | d dirs | Space select | y copy | x cut | p paste | "
-        "F2 rename | : palette"
+        "Enter open | / filter | Space select | y copy | x cut | p paste | "
+        "s sort | d dirs | F2 rename | : palette"
     )
 
 


### PR DESCRIPTION
## Summary
- add `Enter open` guidance to the browsing help line
- reorder the one-line help so primary browsing actions appear earlier
- update selector and app expectations for the revised help text

## Testing
- uv run ruff check .
- uv run pytest

## Links
- Closes #66