### PR TITLE
#69 Fix recursive filter enter handling

### DIFF
--- a/src/plain/models/shell_data.py
+++ b/src/plain/models/shell_data.py
@@ -13,6 +13,7 @@ class PaneEntry:
 
     name: str
     kind: EntryKind
+    name_detail: str | None = None
     size_label: str = "-"
     modified_label: str = "-"
     selected: bool = False

--- a/src/plain/state/input.py
+++ b/src/plain/state/input.py
@@ -290,7 +290,7 @@ def _visible_paths(state: AppState) -> tuple[str, ...]:
 
 def _current_entry(state: AppState) -> DirectoryEntryState | None:
     cursor_path = state.current_pane.cursor_path
-    for entry in state.current_pane.entries:
+    for entry in select_visible_current_entry_states(state):
         if entry.path == cursor_path:
             return entry
     return None

--- a/src/plain/state/selectors.py
+++ b/src/plain/state/selectors.py
@@ -31,6 +31,7 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
         current_entries=tuple(
             _to_pane_entry(
                 entry,
+                name_detail=_format_current_entry_name_detail(state, entry),
                 selected=entry.path in state.current_pane.selected_paths,
                 cut=entry.path in cut_paths,
             )
@@ -70,6 +71,7 @@ def select_current_entries(state: AppState) -> tuple[PaneEntry, ...]:
     return tuple(
         _to_pane_entry(
             entry,
+            name_detail=_format_current_entry_name_detail(state, entry),
             selected=entry.path in state.current_pane.selected_paths,
             cut=entry.path in cut_paths,
         )
@@ -373,12 +375,14 @@ def _select_cut_paths(state: AppState) -> frozenset[str]:
 def _to_pane_entry(
     entry: DirectoryEntryState,
     *,
+    name_detail: str | None = None,
     selected: bool = False,
     cut: bool = False,
 ) -> PaneEntry:
     return PaneEntry(
         name=entry.name,
         kind=entry.kind,
+        name_detail=name_detail,
         size_label=_format_size_label(entry.size_bytes),
         modified_label=_format_modified_label(entry),
         selected=selected,
@@ -410,3 +414,20 @@ def _format_modified_label(entry: DirectoryEntryState) -> str:
     if entry.modified_at is None:
         return "-"
     return entry.modified_at.strftime("%Y-%m-%d %H:%M")
+
+
+def _format_current_entry_name_detail(
+    state: AppState,
+    entry: DirectoryEntryState,
+) -> str | None:
+    if not (state.filter.recursive and state.filter.active):
+        return None
+
+    try:
+        relative_path = Path(entry.path).relative_to(state.current_path)
+    except ValueError:
+        return None
+
+    if str(relative_path.parent) == ".":
+        return None
+    return f"{relative_path.parent.as_posix()}/"

--- a/src/plain/ui/panes.py
+++ b/src/plain/ui/panes.py
@@ -153,7 +153,7 @@ class MainPane(Vertical):
             table.add_row(
                 self._render_cell(entry.selection_marker, entry.selected, entry.cut),
                 self._render_cell(entry.kind_label, entry.selected, entry.cut),
-                self._render_cell(entry.name, entry.selected, entry.cut),
+                self._render_cell(self._render_name(entry), entry.selected, entry.cut),
                 self._render_cell(entry.size_label, entry.selected, entry.cut),
                 self._render_cell(entry.modified_label, entry.selected, entry.cut),
             )
@@ -192,3 +192,9 @@ class MainPane(Vertical):
         if not selected:
             return Text(value)
         return Text(value, style=cls.SELECTED_STYLE)
+
+    @staticmethod
+    def _render_name(entry: PaneEntry) -> str:
+        if entry.name_detail is None:
+            return entry.name
+        return f"{entry.name}  ({entry.name_detail})"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1288,6 +1288,59 @@ async def test_app_recursive_filter_updates_current_entries() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_recursive_filter_shows_relative_path_and_enter_opens_file() -> None:
+    path = "/tmp/plain-recursive-open"
+    docs = f"{path}/docs"
+    launch_service = FakeExternalLaunchService()
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (DirectoryEntryState(docs, "docs", "dir"),),
+                child_path=docs,
+            )
+        },
+        recursive_results={
+            (path, "readme"): (
+                DirectoryEntryState(f"{path}/README.md", "README.md", "file"),
+                DirectoryEntryState(f"{docs}/README.md", "README.md", "file"),
+            ),
+        },
+    )
+    app = create_app(
+        snapshot_loader=loader,
+        external_launch_service=launch_service,
+        initial_path=path,
+    )
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("/")
+        await pilot.press("space")
+        await pilot.press("r", "e", "a", "d", "m", "e")
+        await _wait_for_row_count(app, 2)
+        await pilot.press("enter")
+        await asyncio.sleep(0.05)
+
+        current_table = app.query_one("#current-pane-table", DataTable)
+        first_row = current_table.get_row_at(0)
+        second_row = current_table.get_row_at(1)
+
+        assert isinstance(first_row[2], Text)
+        assert isinstance(second_row[2], Text)
+        assert first_row[2].plain == "README.md"
+        assert second_row[2].plain == "README.md  (docs/)"
+
+        await pilot.press("down")
+        await pilot.press("enter")
+        await _wait_for_external_launch_count(app, 1)
+
+        assert launch_service.executed_requests == [
+            ExternalLaunchRequest(kind="open_file", path=f"{docs}/README.md")
+        ]
+
+
+@pytest.mark.asyncio
 async def test_app_rename_mode_shows_context_input_and_updates_help() -> None:
     path = "/tmp/plain-rename-mode"
     docs = f"{path}/docs"

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -16,6 +16,7 @@ from plain.state import (
     CopyTargets,
     CutTargets,
     DeleteConfirmationState,
+    DirectoryEntryState,
     DismissNameConflict,
     EnterCursorDirectory,
     GoToParentDirectory,
@@ -156,6 +157,65 @@ def test_browsing_enter_on_file_dispatches_open_with_default_app() -> None:
         SetNotification(None),
         OpenPathWithDefaultApp("/home/tadashi/develop/plain/README.md"),
     )
+
+
+def test_browsing_enter_on_recursive_filter_file_dispatches_open_with_default_app() -> None:
+    initial_state = build_initial_app_state()
+    state = replace(
+        initial_state,
+        filter=replace(
+            initial_state.filter,
+            query="readme",
+            active=True,
+            recursive=True,
+        ),
+        recursive_entries=(
+            DirectoryEntryState(
+                "/home/tadashi/develop/plain/docs/README.md",
+                "README.md",
+                "file",
+            ),
+        ),
+        current_pane=replace(
+            initial_state.current_pane,
+            cursor_path="/home/tadashi/develop/plain/docs/README.md",
+        ),
+    )
+
+    actions = dispatch_key_input(state, key="enter")
+
+    assert actions == (
+        SetNotification(None),
+        OpenPathWithDefaultApp("/home/tadashi/develop/plain/docs/README.md"),
+    )
+
+
+def test_browsing_enter_on_recursive_filter_directory_dispatches_enter_cursor_directory() -> None:
+    initial_state = build_initial_app_state()
+    state = replace(
+        initial_state,
+        filter=replace(
+            initial_state.filter,
+            query="src",
+            active=True,
+            recursive=True,
+        ),
+        recursive_entries=(
+            DirectoryEntryState(
+                "/home/tadashi/develop/plain/docs/src",
+                "src",
+                "dir",
+            ),
+        ),
+        current_pane=replace(
+            initial_state.current_pane,
+            cursor_path="/home/tadashi/develop/plain/docs/src",
+        ),
+    )
+
+    actions = dispatch_key_input(state, key="enter")
+
+    assert actions == (SetNotification(None), EnterCursorDirectory())
 
 
 def test_browsing_backspace_goes_to_parent_directory() -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -78,6 +78,32 @@ def test_select_current_entries_uses_recursive_results_when_enabled() -> None:
     assert [entry.name for entry in entries] == ["notes.md", "spec_mvp.md"]
 
 
+def test_select_current_entries_adds_relative_parent_detail_for_recursive_duplicates() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        filter=replace(state.filter, query="readme", active=True, recursive=True),
+        recursive_entries=(
+            DirectoryEntryState("/home/tadashi/develop/plain/README.md", "README.md", "file"),
+            DirectoryEntryState(
+                "/home/tadashi/develop/plain/docs/README.md",
+                "README.md",
+                "file",
+            ),
+        ),
+        current_pane=replace(
+            state.current_pane,
+            cursor_path="/home/tadashi/develop/plain/README.md",
+        ),
+    )
+
+    entries = select_current_entries(state)
+
+    assert [entry.name for entry in entries] == ["README.md", "README.md"]
+    assert entries[0].name_detail is None
+    assert entries[1].name_detail == "docs/"
+
+
 def test_select_current_entries_hides_hidden_by_default() -> None:
     state = replace(
         build_initial_app_state(),


### PR DESCRIPTION
## Summary
- fix Enter handling while recursive filter results are visible so files open and directories can be entered
- show relative parent path suffixes in the Name column for recursive filter results to disambiguate duplicate names
- add input, selector, and app coverage for recursive filter Enter behavior and path display

## Testing
- uv run ruff check .
- uv run pytest

Closes #69