### PR TITLE
Issue #23 Add tests for file operations and OS adapters

### DIFF
--- a/tests/test_adapters_file_operations.py
+++ b/tests/test_adapters_file_operations.py
@@ -1,0 +1,144 @@
+import pytest
+
+from plain.adapters import LocalFileOperationAdapter
+from plain.adapters import file_operations as file_operations_module
+
+
+def test_local_file_operation_adapter_copies_file_contents(tmp_path) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("plain\n", encoding="utf-8")
+    destination = tmp_path / "target.txt"
+
+    adapter = LocalFileOperationAdapter()
+
+    adapter.copy_path(str(source), str(destination))
+
+    assert destination.read_text(encoding="utf-8") == "plain\n"
+
+
+def test_local_file_operation_adapter_copies_directory_recursively(tmp_path) -> None:
+    source_dir = tmp_path / "docs"
+    source_dir.mkdir()
+    nested = source_dir / "guide.txt"
+    nested.write_text("guide\n", encoding="utf-8")
+    destination = tmp_path / "docs-copy"
+
+    adapter = LocalFileOperationAdapter()
+
+    adapter.copy_path(str(source_dir), str(destination))
+
+    assert (destination / "guide.txt").read_text(encoding="utf-8") == "guide\n"
+
+
+def test_local_file_operation_adapter_rejects_copy_to_same_path(tmp_path) -> None:
+    source = tmp_path / "README.md"
+    source.write_text("plain\n", encoding="utf-8")
+
+    adapter = LocalFileOperationAdapter()
+
+    with pytest.raises(OSError, match="Source and destination are the same path"):
+        adapter.copy_path(str(source), str(source))
+
+
+def test_local_file_operation_adapter_moves_paths(tmp_path) -> None:
+    source = tmp_path / "notes.txt"
+    source.write_text("move\n", encoding="utf-8")
+    destination = tmp_path / "renamed.txt"
+
+    adapter = LocalFileOperationAdapter()
+
+    adapter.move_path(str(source), str(destination))
+
+    assert source.exists() is False
+    assert destination.read_text(encoding="utf-8") == "move\n"
+
+
+def test_local_file_operation_adapter_rejects_move_to_same_path(tmp_path) -> None:
+    source = tmp_path / "README.md"
+    source.write_text("plain\n", encoding="utf-8")
+
+    adapter = LocalFileOperationAdapter()
+
+    with pytest.raises(OSError, match="Source and destination are the same path"):
+        adapter.move_path(str(source), str(source))
+
+
+def test_local_file_operation_adapter_creates_file_and_directory(tmp_path) -> None:
+    file_path = tmp_path / "README.md"
+    directory_path = tmp_path / "docs"
+
+    adapter = LocalFileOperationAdapter()
+
+    adapter.create_file(str(file_path))
+    adapter.create_directory(str(directory_path))
+
+    assert file_path.is_file()
+    assert directory_path.is_dir()
+
+
+def test_local_file_operation_adapter_create_file_raises_for_existing_path(tmp_path) -> None:
+    file_path = tmp_path / "README.md"
+    file_path.write_text("plain\n", encoding="utf-8")
+
+    adapter = LocalFileOperationAdapter()
+
+    with pytest.raises(OSError):
+        adapter.create_file(str(file_path))
+
+
+def test_local_file_operation_adapter_create_directory_raises_for_existing_path(tmp_path) -> None:
+    directory_path = tmp_path / "docs"
+    directory_path.mkdir()
+
+    adapter = LocalFileOperationAdapter()
+
+    with pytest.raises(OSError):
+        adapter.create_directory(str(directory_path))
+
+
+def test_local_file_operation_adapter_generates_unique_file_and_directory_names(tmp_path) -> None:
+    file_path = tmp_path / "README.md"
+    file_path.write_text("plain\n", encoding="utf-8")
+    (tmp_path / "README copy.md").write_text("copy\n", encoding="utf-8")
+    directory_path = tmp_path / "docs"
+    directory_path.mkdir()
+
+    adapter = LocalFileOperationAdapter()
+
+    renamed_file = adapter.generate_renamed_path(str(file_path))
+    renamed_directory = adapter.generate_renamed_path(str(directory_path))
+
+    assert renamed_file == str(tmp_path / "README copy 2.md")
+    assert renamed_directory == str(tmp_path / "docs copy")
+
+
+def test_local_file_operation_adapter_send_to_trash_uses_send2trash(tmp_path, monkeypatch) -> None:
+    trashed: list[str] = []
+    target = tmp_path / "README.md"
+    target.write_text("plain\n", encoding="utf-8")
+
+    def fake_send2trash(path: str) -> None:
+        trashed.append(path)
+
+    monkeypatch.setattr(file_operations_module, "send2trash", fake_send2trash)
+    adapter = LocalFileOperationAdapter()
+
+    adapter.send_to_trash(str(target))
+
+    assert trashed == [str(target.resolve())]
+
+
+def test_local_file_operation_adapter_send_to_trash_converts_oserror(
+    tmp_path, monkeypatch
+) -> None:
+    target = tmp_path / "README.md"
+    target.write_text("plain\n", encoding="utf-8")
+
+    def fake_send2trash(path: str) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(file_operations_module, "send2trash", fake_send2trash)
+    adapter = LocalFileOperationAdapter()
+
+    with pytest.raises(OSError, match="permission denied"):
+        adapter.send_to_trash(str(target))

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -29,6 +29,26 @@ class StubForegroundRunner:
             raise OSError(f"{command[0]} failed")
 
 
+@dataclass
+class StubExternalLaunchAdapter:
+    opened_paths: list[str] = field(default_factory=list)
+    edited_paths: list[str] = field(default_factory=list)
+    terminal_paths: list[str] = field(default_factory=list)
+    clipboard_payloads: list[str] = field(default_factory=list)
+
+    def open_with_default_app(self, path: str) -> None:
+        self.opened_paths.append(path)
+
+    def open_in_editor(self, path: str) -> None:
+        self.edited_paths.append(path)
+
+    def open_terminal(self, path: str) -> None:
+        self.terminal_paths.append(path)
+
+    def copy_to_clipboard(self, text: str) -> None:
+        self.clipboard_payloads.append(text)
+
+
 def test_local_external_launch_adapter_uses_xdg_open_on_linux(tmp_path) -> None:
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
@@ -126,6 +146,47 @@ def test_local_external_launch_adapter_copies_to_clipboard_on_linux() -> None:
     ]
 
 
+def test_local_external_launch_adapter_raises_last_terminal_error_when_all_candidates_fail(
+    tmp_path,
+) -> None:
+    runner = StubCommandRunner(
+        failing_commands={
+            "konsole",
+            "gnome-terminal",
+            "xfce4-terminal",
+            "xterm",
+            "x-terminal-emulator",
+        }
+    )
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: (
+            command
+            if command
+            in {"konsole", "gnome-terminal", "xfce4-terminal", "xterm", "x-terminal-emulator"}
+            else None
+        ),
+        command_runner=runner,
+    )
+
+    with pytest.raises(OSError, match="x-terminal-emulator failed"):
+        adapter.open_terminal(str(tmp_path))
+
+
+def test_local_external_launch_adapter_reports_invalid_editor_value(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "nvim" else None,
+        command_runner=StubCommandRunner(),
+        environment_variable=lambda name: "'" if name == "EDITOR" else None,
+    )
+
+    with pytest.raises(OSError, match="Invalid EDITOR value"):
+        adapter.open_in_editor(str(readme))
+
+
 def test_local_external_launch_adapter_uses_clipboard_fallback_when_commands_missing() -> None:
     copied: list[str] = []
 
@@ -152,6 +213,38 @@ def test_live_external_launch_service_formats_open_error(tmp_path) -> None:
 
     with pytest.raises(OSError, match=f"Failed to open {missing.resolve()}: Not found: "):
         service.execute(ExternalLaunchRequest(kind="open_file", path=str(missing)))
+
+
+def test_live_external_launch_service_opens_file_with_adapter() -> None:
+    adapter = StubExternalLaunchAdapter()
+    service = LiveExternalLaunchService(adapter=adapter)
+
+    service.execute(ExternalLaunchRequest(kind="open_file", path="/tmp/plain/README.md"))
+
+    assert adapter.opened_paths == ["/tmp/plain/README.md"]
+
+
+def test_live_external_launch_service_opens_terminal_with_adapter() -> None:
+    adapter = StubExternalLaunchAdapter()
+    service = LiveExternalLaunchService(adapter=adapter)
+
+    service.execute(ExternalLaunchRequest(kind="open_terminal", path="/tmp/plain"))
+
+    assert adapter.terminal_paths == ["/tmp/plain"]
+
+
+def test_live_external_launch_service_copies_paths_with_expected_payload() -> None:
+    adapter = StubExternalLaunchAdapter()
+    service = LiveExternalLaunchService(adapter=adapter)
+
+    service.execute(
+        ExternalLaunchRequest(
+            kind="copy_paths",
+            paths=("/tmp/plain/docs", "/tmp/plain/README.md"),
+        )
+    )
+
+    assert adapter.clipboard_payloads == ["/tmp/plain/docs\n/tmp/plain/README.md"]
 
 
 def test_live_external_launch_service_formats_editor_error(tmp_path) -> None:

--- a/tests/test_services_file_mutations.py
+++ b/tests/test_services_file_mutations.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 import pytest
 
-from plain.models import TrashDeleteRequest
+from plain.models import CreatePathRequest, RenameRequest, TrashDeleteRequest
 from plain.services import LiveFileMutationService
 
 
@@ -10,6 +10,9 @@ from plain.services import LiveFileMutationService
 class StubFileOperationAdapter:
     trashed_paths: list[str] = field(default_factory=list)
     failing_paths: set[str] = field(default_factory=set)
+    moved_paths: list[tuple[str, str]] = field(default_factory=list)
+    created_files: list[str] = field(default_factory=list)
+    created_directories: list[str] = field(default_factory=list)
 
     def path_exists(self, path: str) -> bool:
         return False
@@ -24,16 +27,22 @@ class StubFileOperationAdapter:
         raise NotImplementedError
 
     def move_path(self, source: str, destination: str) -> None:
-        raise NotImplementedError
+        if source in self.failing_paths or destination in self.failing_paths:
+            raise OSError("rename failed")
+        self.moved_paths.append((source, destination))
 
     def generate_renamed_path(self, destination: str) -> str:
         raise NotImplementedError
 
     def create_file(self, path: str) -> None:
-        raise NotImplementedError
+        if path in self.failing_paths:
+            raise OSError("file creation failed")
+        self.created_files.append(path)
 
     def create_directory(self, path: str) -> None:
-        raise NotImplementedError
+        if path in self.failing_paths:
+            raise OSError("directory creation failed")
+        self.created_directories.append(path)
 
     def send_to_trash(self, path: str) -> None:
         if path in self.failing_paths:
@@ -52,6 +61,67 @@ def test_file_mutation_service_trashes_single_path() -> None:
     assert adapter.trashed_paths == ["/tmp/plain/docs"]
     assert result.message == "Trashed 1 item"
     assert result.removed_paths == ("/tmp/plain/docs",)
+
+
+def test_file_mutation_service_renames_single_path() -> None:
+    adapter = StubFileOperationAdapter()
+    service = LiveFileMutationService(adapter=adapter)
+
+    result = service.execute(
+        RenameRequest(source_path="/tmp/plain/docs", new_name="docs-old")
+    )
+
+    assert adapter.moved_paths == [("/tmp/plain/docs", "/tmp/plain/docs-old")]
+    assert result.path == "/tmp/plain/docs-old"
+    assert result.message == "Renamed to docs-old"
+
+
+def test_file_mutation_service_raises_rename_error() -> None:
+    adapter = StubFileOperationAdapter(failing_paths={"/tmp/plain/docs-old"})
+    service = LiveFileMutationService(adapter=adapter)
+
+    with pytest.raises(OSError, match="rename failed"):
+        service.execute(RenameRequest(source_path="/tmp/plain/docs", new_name="docs-old"))
+
+
+def test_file_mutation_service_creates_file() -> None:
+    adapter = StubFileOperationAdapter()
+    service = LiveFileMutationService(adapter=adapter)
+
+    result = service.execute(
+        CreatePathRequest(parent_dir="/tmp/plain", name="README.md", kind="file")
+    )
+
+    assert adapter.created_files == ["/tmp/plain/README.md"]
+    assert result.path == "/tmp/plain/README.md"
+    assert result.message == "Created file README.md"
+
+
+def test_file_mutation_service_creates_directory() -> None:
+    adapter = StubFileOperationAdapter()
+    service = LiveFileMutationService(adapter=adapter)
+
+    result = service.execute(CreatePathRequest(parent_dir="/tmp/plain", name="docs", kind="dir"))
+
+    assert adapter.created_directories == ["/tmp/plain/docs"]
+    assert result.path == "/tmp/plain/docs"
+    assert result.message == "Created directory docs"
+
+
+def test_file_mutation_service_raises_create_file_error() -> None:
+    adapter = StubFileOperationAdapter(failing_paths={"/tmp/plain/README.md"})
+    service = LiveFileMutationService(adapter=adapter)
+
+    with pytest.raises(OSError, match="file creation failed"):
+        service.execute(CreatePathRequest(parent_dir="/tmp/plain", name="README.md", kind="file"))
+
+
+def test_file_mutation_service_raises_create_directory_error() -> None:
+    adapter = StubFileOperationAdapter(failing_paths={"/tmp/plain/docs"})
+    service = LiveFileMutationService(adapter=adapter)
+
+    with pytest.raises(OSError, match="directory creation failed"):
+        service.execute(CreatePathRequest(parent_dir="/tmp/plain", name="docs", kind="dir"))
 
 
 def test_file_mutation_service_reports_partial_delete_failures() -> None:


### PR DESCRIPTION
## Summary
- add LocalFileOperationAdapter tests for copy, move, create, rename-path generation, and trash behavior
- extend file mutation service coverage for rename/create success and failure paths
- extend external launcher coverage for successful adapter delegation and adapter error edge cases

## Testing
- uv run pytest
- uv run ruff check .

Closes #23
