### PR TITLE
Fix hjkl browsing navigation

### DIFF
--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -111,14 +111,15 @@ def _dispatch_browsing_input(state: AppState, key: str) -> DispatchedActions:
     cursor_entry = _current_entry(state)
     target_paths = select_target_paths(state)
     filter_is_active = state.filter.active and bool(state.filter.query)
+    command = BROWSING_KEYMAP.get(key)
 
-    if key == "up":
+    if command == "cursor_up":
         return _supported(MoveCursor(delta=-1, visible_paths=visible_paths))
 
-    if key == "down":
+    if command == "cursor_down":
         return _supported(MoveCursor(delta=1, visible_paths=visible_paths))
 
-    if key == "space" and state.current_pane.cursor_path is not None:
+    if command == "toggle_selection" and state.current_pane.cursor_path is not None:
         return _supported(
             ToggleSelectionAndAdvance(
                 path=state.current_pane.cursor_path,
@@ -126,43 +127,43 @@ def _dispatch_browsing_input(state: AppState, key: str) -> DispatchedActions:
             )
         )
 
-    if key == "escape":
+    if command == "clear_selection":
         if filter_is_active:
             return _supported(CancelFilterInput())
         return _supported(ClearSelection())
 
-    if key == "/":
+    if command == "begin_filter":
         return _supported(BeginFilterInput())
 
-    if key == "y":
+    if command == "copy_targets":
         return _supported(CopyTargets(target_paths))
 
-    if key == "x":
+    if command == "cut_targets":
         return _supported(CutTargets(target_paths))
 
-    if key == "p":
+    if command == "paste_clipboard":
         return _supported(PasteClipboard())
 
-    if key in {"left", "backspace"}:
+    if command == "go_to_parent":
         return _supported(GoToParentDirectory())
 
-    if key == "f5":
+    if command == "reload_directory":
         return _supported(ReloadDirectory())
 
-    if key == "f2":
+    if command == "begin_rename":
         if not target_paths:
             return _warn("Nothing to rename")
         if len(target_paths) != 1:
             return _warn("Rename requires a single target")
         return _supported(BeginRenameInput(target_paths[0]))
 
-    if key == ":":
+    if command == "begin_command_palette":
         return _supported(BeginCommandPalette())
 
-    if key == "s":
+    if command == "cycle_sort":
         return _supported(_next_sort_action(state))
 
-    if key == "d":
+    if command == "toggle_directories_first":
         return _supported(
             SetSort(
                 field=state.sort.field,
@@ -171,17 +172,17 @@ def _dispatch_browsing_input(state: AppState, key: str) -> DispatchedActions:
             )
         )
 
-    if key == "delete":
+    if command == "delete_targets":
         if not target_paths:
             return _warn("Nothing to delete")
         return _supported(BeginDeleteTargets(target_paths))
 
-    if key == "e":
+    if command == "open_in_editor":
         if cursor_entry is not None and cursor_entry.kind == "file":
             return _supported(OpenPathInEditor(cursor_entry.path))
         return _warn("Editor launch requires a file")
 
-    if key == "right":
+    if command == "enter_directory":
         if cursor_entry is not None and cursor_entry.kind == "dir":
             return _supported(EnterCursorDirectory())
         return ()

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -60,6 +60,42 @@ def test_browsing_down_dispatches_move_cursor() -> None:
     )
 
 
+def test_browsing_j_dispatches_move_cursor() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="j", character="j")
+
+    assert actions[0] == SetNotification(None)
+    assert actions[1] == MoveCursor(
+        delta=1,
+        visible_paths=(
+            "/home/tadashi/develop/peneo/docs",
+            "/home/tadashi/develop/peneo/src",
+            "/home/tadashi/develop/peneo/tests",
+            "/home/tadashi/develop/peneo/pyproject.toml",
+            "/home/tadashi/develop/peneo/README.md",
+        ),
+    )
+
+
+def test_browsing_k_dispatches_move_cursor() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="k", character="k")
+
+    assert actions[0] == SetNotification(None)
+    assert actions[1] == MoveCursor(
+        delta=-1,
+        visible_paths=(
+            "/home/tadashi/develop/peneo/docs",
+            "/home/tadashi/develop/peneo/src",
+            "/home/tadashi/develop/peneo/tests",
+            "/home/tadashi/develop/peneo/pyproject.toml",
+            "/home/tadashi/develop/peneo/README.md",
+        ),
+    )
+
+
 def test_browsing_space_toggles_selection_and_advances_cursor() -> None:
     state = build_initial_app_state()
 
@@ -144,10 +180,26 @@ def test_browsing_p_dispatches_paste_clipboard() -> None:
     assert actions == (SetNotification(None), PasteClipboard())
 
 
+def test_browsing_h_goes_to_parent_directory() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="h", character="h")
+
+    assert actions == (SetNotification(None), GoToParentDirectory())
+
+
 def test_browsing_right_enters_directory() -> None:
     state = build_initial_app_state()
 
     actions = dispatch_key_input(state, key="right")
+
+    assert actions == (SetNotification(None), EnterCursorDirectory())
+
+
+def test_browsing_l_enters_directory() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="l", character="l")
 
     assert actions == (SetNotification(None), EnterCursorDirectory())
 


### PR DESCRIPTION
## Summary
- route browsing-mode keys through `BROWSING_KEYMAP` so `h`, `j`, `k`, and `l` follow the same actions as arrow keys
- add regression tests for vim-style navigation in the input dispatcher

## Testing
- `uv run ruff check src/peneo/state/input.py tests/test_input_dispatch.py`
- `uv run python -m pytest tests/test_input_dispatch.py`
- `uv run python -m pytest`
