### PR TITLE
#105 Reduce filesystem I/O for directory scans and child preview

### DIFF
--- a/src/peneo/adapters/filesystem.py
+++ b/src/peneo/adapters/filesystem.py
@@ -1,4 +1,5 @@
 """Filesystem adapter for reading local directory entries."""
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -20,25 +21,27 @@ class LocalFilesystemAdapter:
     def list_directory(self, path: str) -> tuple[DirectoryEntryState, ...]:
         directory = Path(path).expanduser().resolve()
         entries: list[DirectoryEntryState] = []
-        for child in directory.iterdir():
-            entry = _build_directory_entry(child)
-            if entry is not None:
-                entries.append(entry)
+        with os.scandir(directory) as children:
+            for child in children:
+                entry = _build_directory_entry(child)
+                if entry is not None:
+                    entries.append(entry)
         entries.sort(key=lambda entry: (entry.kind != "dir", entry.name.casefold()))
         return tuple(entries)
 
-def _build_directory_entry(path: Path) -> DirectoryEntryState | None:
+
+def _build_directory_entry(entry: os.DirEntry[str]) -> DirectoryEntryState | None:
     try:
-        stat_result = path.stat()
+        stat_result = entry.stat()
+        kind = "dir" if entry.is_dir() else "file"
     except FileNotFoundError:
         # Skip broken symlinks or entries removed during iteration.
         return None
-    kind = "dir" if path.is_dir() else "file"
     return DirectoryEntryState(
-        path=str(path),
-        name=path.name,
+        path=entry.path,
+        name=entry.name,
         kind=kind,
         size_bytes=None if kind == "dir" else stat_result.st_size,
         modified_at=datetime.fromtimestamp(stat_result.st_mtime),
-        hidden=path.name.startswith("."),
+        hidden=entry.name.startswith("."),
     )

--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -10,6 +10,7 @@ from textual.app import App, ComposeResult, SuspendNotSupported
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.css.query import NoMatches
+from textual.timer import Timer
 from textual.worker import Worker, WorkerState
 
 from peneo.models import (
@@ -75,6 +76,8 @@ from peneo.ui import (
 
 class PeneoApp(App[None]):
     """Three-pane shell with reducer-driven file operations."""
+
+    CHILD_PANE_DEBOUNCE_SECONDS = 0.03
 
     TITLE = "Peneo"
     SUB_TITLE = "Three-pane shell"
@@ -229,6 +232,8 @@ class PeneoApp(App[None]):
         self._external_launch_service = external_launch_service or LiveExternalLaunchService()
         self._file_search_service = file_search_service or LiveFileSearchService()
         self._pending_workers: dict[str, Effect] = {}
+        self._pending_child_pane_effect: LoadChildPaneSnapshotEffect | None = None
+        self._child_pane_timer: Timer | None = None
 
     @property
     def app_state(self) -> AppState:
@@ -316,6 +321,8 @@ class PeneoApp(App[None]):
         """Apply reducer actions, refresh the UI, and schedule any effects."""
 
         changed, effects = self._apply_actions(actions)
+        if self._app_state.pending_child_pane_request_id is None:
+            self._cancel_pending_child_pane_snapshot()
         if changed:
             await self._refresh_shell()
         self._schedule_effects(effects)
@@ -376,6 +383,21 @@ class PeneoApp(App[None]):
         self._pending_workers[worker.name] = effect
 
     def _schedule_child_pane_snapshot(self, effect: LoadChildPaneSnapshotEffect) -> None:
+        self._cancel_pending_child_pane_snapshot()
+        self._pending_child_pane_effect = effect
+        self._child_pane_timer = self.set_timer(
+            self.CHILD_PANE_DEBOUNCE_SECONDS,
+            self._flush_child_pane_snapshot,
+            name="child-pane-snapshot-debounce",
+        )
+
+    def _flush_child_pane_snapshot(self) -> None:
+        effect = self._pending_child_pane_effect
+        self._pending_child_pane_effect = None
+        self._child_pane_timer = None
+        if effect is None:
+            return
+
         worker = self.run_worker(
             partial(
                 self._snapshot_loader.load_child_pane_snapshot,
@@ -390,6 +412,12 @@ class PeneoApp(App[None]):
             thread=True,
         )
         self._pending_workers[worker.name] = effect
+
+    def _cancel_pending_child_pane_snapshot(self) -> None:
+        self._pending_child_pane_effect = None
+        if self._child_pane_timer is not None:
+            self._child_pane_timer.stop()
+            self._child_pane_timer = None
 
     def _schedule_clipboard_paste(self, effect: RunClipboardPasteEffect) -> None:
         worker = self.run_worker(

--- a/src/peneo/services/browser_snapshot.py
+++ b/src/peneo/services/browser_snapshot.py
@@ -41,7 +41,7 @@ class LiveBrowserSnapshotLoader:
         path: str,
         cursor_path: str | None = None,
     ) -> BrowserSnapshot:
-        resolved_path = str(Path(path).expanduser().resolve())
+        resolved_path = _resolve_path(path)
         current_entries = self._list_directory(resolved_path)
         resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path)
 
@@ -63,7 +63,11 @@ class LiveBrowserSnapshotLoader:
                 entries=current_entries,
                 cursor_path=resolved_cursor_path,
             ),
-            child_pane=self.load_child_pane_snapshot(resolved_path, resolved_cursor_path),
+            child_pane=self._build_child_pane_snapshot(
+                resolved_path,
+                current_entries,
+                resolved_cursor_path,
+            ),
         )
 
     def load_child_pane_snapshot(
@@ -71,15 +75,35 @@ class LiveBrowserSnapshotLoader:
         current_path: str,
         cursor_path: str | None,
     ) -> PaneState:
+        resolved_current_path = _resolve_path(current_path)
         if cursor_path is None:
-            return PaneState(directory_path=current_path, entries=())
+            return PaneState(directory_path=resolved_current_path, entries=())
 
-        child_path = Path(cursor_path).expanduser().resolve()
+        child_path = Path(_resolve_path(cursor_path))
         if not child_path.is_dir():
-            return PaneState(directory_path=current_path, entries=())
+            return PaneState(directory_path=resolved_current_path, entries=())
 
         child_entries = self._list_directory(str(child_path))
         return PaneState(directory_path=str(child_path), entries=child_entries)
+
+    def _build_child_pane_snapshot(
+        self,
+        current_path: str,
+        current_entries,
+        cursor_path: str | None,
+    ) -> PaneState:
+        if cursor_path is None:
+            return PaneState(directory_path=current_path, entries=())
+
+        cursor_entry = next(
+            (entry for entry in current_entries if entry.path == cursor_path),
+            None,
+        )
+        if cursor_entry is None or cursor_entry.kind != "dir":
+            return PaneState(directory_path=current_path, entries=())
+
+        child_entries = self._list_directory(cursor_path)
+        return PaneState(directory_path=cursor_path, entries=child_entries)
 
     def _list_directory(self, path: str):
         try:
@@ -105,6 +129,7 @@ class FakeBrowserSnapshotLoader:
     default_delay_seconds: float = 0.0
     per_path_delay_seconds: Mapping[str, float] = field(default_factory=dict)
     child_delay_seconds: Mapping[tuple[str, str | None], float] = field(default_factory=dict)
+    loaded_child_requests: list[tuple[str, str | None]] = field(default_factory=list)
 
     def load_browser_snapshot(
         self,
@@ -130,6 +155,7 @@ class FakeBrowserSnapshotLoader:
         cursor_path: str | None,
     ) -> PaneState:
         key = (current_path, cursor_path)
+        self.loaded_child_requests.append(key)
         delay = self.child_delay_seconds.get(key, self.default_delay_seconds)
         if delay > 0:
             sleep(delay)
@@ -189,7 +215,7 @@ def _build_fallback_snapshot(path: str, cursor_path: str | None) -> BrowserSnaps
             )
         return snapshot_from_app_state(state)
 
-    resolved_path = str(Path(path).expanduser().resolve())
+    resolved_path = _resolve_path(path)
     parent_path = str(Path(resolved_path).parent)
     return BrowserSnapshot(
         current_path=resolved_path,
@@ -209,3 +235,7 @@ def _resolve_cursor_path(entries, cursor_path: str | None) -> str | None:
 
 def _contains_path(entries, path: str) -> bool:
     return any(entry.path == path for entry in entries)
+
+
+def _resolve_path(path: str) -> str:
+    return str(Path(path).expanduser().resolve())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -195,6 +195,19 @@ async def _wait_for_child_entries(
         await asyncio.sleep(0.01)
 
 
+async def _wait_for_child_pane_idle(app, timeout: float = 0.5) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        if (
+            app.app_state.pending_child_pane_request_id is None
+            and getattr(app, "_child_pane_timer", None) is None
+        ):
+            return
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("child pane did not become idle")
+        await asyncio.sleep(0.01)
+
+
 async def _wait_for_external_launch_count(app, expected_count: int, timeout: float = 0.5) -> None:
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
@@ -986,6 +999,88 @@ async def test_app_child_snapshot_failure_shows_error() -> None:
         assert str(current_path_bar.renderable) == f"Current Path: {path}"
         assert str(summary_bar.renderable) == "2 items | 0 selected | sort: name asc dirs:on"
         assert str(status_bar.renderable) == "error: permission denied"
+
+
+@pytest.mark.asyncio
+async def test_app_child_pane_debounce_keeps_only_latest_directory_request() -> None:
+    path = "/tmp/peneo-child-debounce"
+    docs = f"{path}/docs"
+    src = f"{path}/src"
+    current_entries = (
+        DirectoryEntryState(docs, "docs", "dir"),
+        DirectoryEntryState(src, "src", "dir"),
+    )
+    docs_entries = (DirectoryEntryState(f"{docs}/spec.md", "spec.md", "file"),)
+    src_entries = (DirectoryEntryState(f"{src}/main.py", "main.py", "file"),)
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+                child_path=docs,
+                child_entries=docs_entries,
+            )
+        },
+        child_panes={
+            (path, docs): PaneState(directory_path=docs, entries=docs_entries),
+            (path, src): PaneState(directory_path=src, entries=src_entries),
+        },
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+    app.CHILD_PANE_DEBOUNCE_SECONDS = 0.2
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 2)
+        await pilot.press("down", "up")
+
+        await _wait_for_child_pane_idle(app)
+
+        assert loader.loaded_child_requests == [(path, docs)]
+        await _wait_for_child_entries(app, ["spec.md"])
+
+
+@pytest.mark.asyncio
+async def test_app_file_cursor_cancels_pending_child_pane_debounce() -> None:
+    path = "/tmp/peneo-child-file-cancel"
+    docs = f"{path}/docs"
+    src = f"{path}/src"
+    readme = f"{path}/README.md"
+    current_entries = (
+        DirectoryEntryState(docs, "docs", "dir"),
+        DirectoryEntryState(src, "src", "dir"),
+        DirectoryEntryState(readme, "README.md", "file", size_bytes=120),
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+                child_path=docs,
+                child_entries=(DirectoryEntryState(f"{docs}/spec.md", "spec.md", "file"),),
+            )
+        },
+        child_panes={
+            (path, src): PaneState(
+                directory_path=src,
+                entries=(DirectoryEntryState(f"{src}/main.py", "main.py", "file"),),
+            )
+        },
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+    app.CHILD_PANE_DEBOUNCE_SECONDS = 0.2
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 3)
+        await pilot.press("down", "down")
+
+        await _wait_for_child_pane_idle(app)
+
+        assert app.app_state.current_pane.cursor_path == readme
+        assert loader.loaded_child_requests == []
+        child_list = app.query_one("#child-pane-list", ListView)
+        assert list(child_list.children) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- switch local directory listing to `os.scandir()` so directory metadata is reused without repeated `Path.stat()` / `Path.is_dir()` calls
- reduce browser snapshot overhead by reusing already-loaded current pane entries when building the initial child pane
- debounce child pane snapshot workers so rapid cursor movement only loads the latest directory preview

## Why
Issue #105 reports repeated filesystem I/O in the three-pane hot path. The current implementation performs redundant stat-style calls per entry and eagerly reloads child previews on every cursor move, which adds noticeable latency on large directories.

## Impact
- lower filesystem syscall pressure during directory listing
- fewer redundant child-pane loads during rapid navigation
- regression coverage for debounce behavior and child pane cancellation

## Validation
- `uv run ruff check .`
- `uv run python -m pytest tests/test_adapters_filesystem.py tests/test_services_browser_snapshot.py tests/test_state_reducer.py tests/test_app.py -q`

Closes #105.
