### PR TITLE
Issue #118 Rework help bar layout

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -134,9 +134,14 @@ class PeneoApp(App[None]):
     }
 
     #current-path-bar,
-    #help-bar,
     #status-bar {
         height: 1;
+        padding: 0 1;
+    }
+
+    #help-bar {
+        height: auto;
+        min-height: 1;
         padding: 0 1;
     }
 

--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -51,9 +51,15 @@ class StatusBarState:
 
 @dataclass(frozen=True)
 class HelpBarState:
-    """A single-line help summary rendered above the status bar."""
+    """Compact help summary rendered above the status bar."""
 
-    text: str
+    lines: tuple[str, ...]
+
+    @property
+    def text(self) -> str:
+        """Return the rendered help content."""
+
+        return "\n".join(self.lines)
 
 
 @dataclass(frozen=True)
@@ -154,8 +160,10 @@ def build_dummy_shell_data() -> ThreePaneShellData:
         ),
         current_context_input=None,
         help=HelpBarState(
-            "Right dir | Enter open | e edit | / filter | Space select | y copy | x cut | "
-            "p paste | s sort | d dirs | F2 rename | : palette"
+            (
+                "Enter open | e edit | / filter | : palette | q quit",
+                "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename",
+            )
         ),
         command_palette=None,
         status=StatusBarState(message=None, message_level=None),

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -136,32 +136,33 @@ def select_status_bar_state(state: AppState) -> StatusBarState:
 
 
 def select_help_bar_state(state: AppState) -> HelpBarState:
-    """Return the single-line help content for the active mode."""
+    """Return the help content for the active mode."""
 
     if state.ui_mode == "CONFIRM":
         if state.delete_confirmation is not None:
-            return HelpBarState("enter confirm delete | esc cancel")
+            return HelpBarState(("enter confirm delete | esc cancel",))
         if state.name_conflict is not None:
-            return HelpBarState("enter return to input | esc return to input")
-        return HelpBarState("resolve conflict in dialog")
+            return HelpBarState(("enter return to input | esc return to input",))
+        return HelpBarState(("resolve conflict in dialog",))
     if state.ui_mode == "DETAIL":
-        return HelpBarState("enter close | esc close")
+        return HelpBarState(("enter close | esc close",))
     if state.ui_mode == "FILTER":
-        return HelpBarState("type filter | enter/down apply | esc clear")
+        return HelpBarState(("type filter | enter/down apply | esc clear",))
     if state.ui_mode == "RENAME":
-        return HelpBarState("type name | enter apply | esc cancel")
+        return HelpBarState(("type name | enter apply | esc cancel",))
     if state.ui_mode == "CREATE":
-        return HelpBarState("type name | enter apply | esc cancel")
+        return HelpBarState(("type name | enter apply | esc cancel",))
     if state.ui_mode == "PALETTE":
         if state.command_palette is not None and state.command_palette.source == "file_search":
-            return HelpBarState("type filename | enter jump | esc cancel")
-        return HelpBarState("type command | enter run | esc cancel")
+            return HelpBarState(("type filename | enter jump | esc cancel",))
+        return HelpBarState(("type command | enter run | esc cancel",))
     if state.ui_mode == "BUSY":
-        return HelpBarState("processing...")
+        return HelpBarState(("processing...",))
     return HelpBarState(
-        "Right dir | Enter open | e edit | / filter | Space select | y copy | x cut | "
-        "p paste | q quit | "
-        "s sort | d dirs | F2 rename | : palette"
+        (
+            "Enter open | e edit | / filter | : palette | q quit",
+            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename",
+        )
     )
 
 

--- a/src/peneo/ui/help_bar.py
+++ b/src/peneo/ui/help_bar.py
@@ -1,4 +1,4 @@
-"""One-line help widget."""
+"""Help widget shown above the status bar."""
 
 from textual.widgets import Static
 
@@ -6,7 +6,7 @@ from peneo.models import HelpBarState
 
 
 class HelpBar(Static):
-    """Compact help line shown above the status bar."""
+    """Compact help text shown above the status bar."""
 
     def __init__(
         self,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1020,9 +1020,8 @@ async def test_app_displays_browsing_help_bar() -> None:
         help_bar = app.query_one("#help-bar", HelpBar)
 
         assert str(help_bar.renderable) == (
-            "Right dir | Enter open | e edit | / filter | Space select | y copy | x cut | "
-            "p paste | q quit | "
-            "s sort | d dirs | F2 rename | : palette"
+            "Enter open | e edit | / filter | : palette | q quit\n"
+            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename"
         )
 
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -397,10 +397,13 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
 
     help_state = select_help_bar_state(state)
 
+    assert help_state.lines == (
+        "Enter open | e edit | / filter | : palette | q quit",
+        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename",
+    )
     assert help_state.text == (
-        "Right dir | Enter open | e edit | / filter | Space select | y copy | x cut | "
-        "p paste | q quit | "
-        "s sort | d dirs | F2 rename | : palette"
+        "Enter open | e edit | / filter | : palette | q quit\n"
+        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename"
     )
 
 


### PR DESCRIPTION
## Summary
- switch the browsing help bar from a single string to multi-line help content
- remove the `Right dir` hint and regroup the normal-mode shortcuts into two lines
- update selector and app tests to assert the new two-line help rendering

## Testing
- `uv run python -m ruff check src/peneo/models/shell_data.py src/peneo/state/selectors.py src/peneo/ui/help_bar.py src/peneo/app.py tests/test_state_selectors.py tests/test_app.py`
- `uv run python -m pytest tests/test_state_selectors.py tests/test_app.py`

Closes #118
