### PR TITLE
#133 Improve WSL launch fallbacks for external launches

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -140,8 +140,9 @@ peneo-cd
 
 - 現時点で動作確認している OS は Ubuntu のみです。
 - 既定アプリ起動、ファイルマネージャ起動、ターミナル起動などの GUI 連携も主にその環境で確認しています。
-- 埋め込み split terminal は現状 POSIX 環境、特に Ubuntu/Linux を前提にしています。
-- コード上は Linux / macOS / Windows 向けの外部起動処理を持っていますが、動作確認済みとは限りません。
+- 埋め込み split terminal は現状 POSIX 環境、特に Ubuntu/Linux と WSL を前提にしています。
+- 外部起動まわりは Linux、macOS、WSL を意識したフォールバックを持ちます。Windows ネイティブ実行はサポート対象外です。
+- WSL では `wslview`、`explorer.exe`、`clip.exe` のような Windows 側ブリッジを優先し、WSLg や Linux デスクトップ向けのフォールバックも維持します。
 - まだ開発途中です。挙動やキーバインドは今後見直す可能性があります。
 - ファイル操作は、選択したディレクトリエントリ自体に対して行われます。選択中の項目が symlink の場合も、リンク先を暗黙に辿って変更せず、symlink エントリ自体を操作します。
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ Commands still under development may appear dimmed and cannot be executed yet.
 
 - The project is currently verified only on Ubuntu.
 - GUI integration paths such as default-app launch, file-manager launch, and terminal launch are currently validated primarily in that environment.
-- The embedded split terminal currently targets POSIX environments such as Ubuntu/Linux.
-- The code contains external-launch implementations for Linux / macOS / Windows, but not every platform path is fully validated.
+- The embedded split terminal currently targets POSIX environments such as Ubuntu/Linux and WSL.
+- External-launch behavior includes Linux, macOS, and WSL-aware fallbacks. Native Windows is not a supported runtime for Peneo.
+- WSL prefers Windows-side bridges such as `wslview`, `explorer.exe`, and `clip.exe` when available, with Linux-side fallbacks kept for WSLg and desktop Linux environments.
 - The application is still under active development, so behavior and keybindings may change.
 - File mutations operate on the selected directory entry. If the selected item is a symlink, Peneo mutates the symlink itself instead of silently following and mutating the link target.
 

--- a/src/peneo/adapters/external_launcher.py
+++ b/src/peneo/adapters/external_launcher.py
@@ -8,7 +8,7 @@ import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 CommandRunner = Callable[[Sequence[str], str | None, str | None], None]
 ForegroundCommandRunner = Callable[[Sequence[str], str | None], None]
@@ -16,6 +16,8 @@ CommandAvailability = Callable[[str], str | None]
 SystemNameResolver = Callable[[], str]
 ClipboardFallback = Callable[[str], None]
 EnvironmentVariableReader = Callable[[str], str | None]
+TextFileReader = Callable[[str], str]
+PlatformKind = Literal["linux", "wsl", "darwin"]
 TERMINAL_EDITOR_NAMES = frozenset(
     {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
 )
@@ -46,14 +48,17 @@ class LocalExternalLaunchAdapter:
     environment_variable: EnvironmentVariableReader = field(
         default_factory=lambda: os.environ.get
     )
+    text_file_reader: TextFileReader = field(default_factory=lambda: _read_text_file)
     clipboard_fallbacks: tuple[ClipboardFallback, ...] = field(
         default_factory=lambda: (_copy_to_clipboard_with_tkinter,)
     )
 
     def open_with_default_app(self, path: str) -> None:
         resolved_path = _resolve_existing_path(path)
-        candidates = self._default_app_candidates(str(resolved_path))
-        self._run_first_available(candidates, context=f"open {resolved_path}")
+        platform_kind = self._platform_kind()
+        candidates = self._default_app_candidates(platform_kind, str(resolved_path))
+        cwd = str(resolved_path if resolved_path.is_dir() else resolved_path.parent)
+        self._run_first_available(candidates, context=f"open {resolved_path}", cwd=cwd)
 
     def open_in_editor(self, path: str) -> None:
         resolved_path = _resolve_existing_path(path)
@@ -70,7 +75,7 @@ class LocalExternalLaunchAdapter:
 
     def open_terminal(self, path: str) -> None:
         resolved_path = _resolve_directory_path(path)
-        candidates = self._terminal_candidates(str(resolved_path))
+        candidates = self._terminal_candidates(self._platform_kind(), str(resolved_path))
         self._run_first_available(
             candidates,
             context=f"open terminal in {resolved_path}",
@@ -78,7 +83,7 @@ class LocalExternalLaunchAdapter:
         )
 
     def copy_to_clipboard(self, text: str) -> None:
-        candidates = self._clipboard_candidates()
+        candidates = self._clipboard_candidates(self._platform_kind())
         available_candidates = [
             command for command in candidates if self.command_available(command[0]) is not None
         ]
@@ -126,15 +131,38 @@ class LocalExternalLaunchAdapter:
 
         raise OSError(errors[-1] if errors else f"Failed to {context}")
 
-    def _default_app_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+    def _platform_kind(self) -> PlatformKind:
         system_name = self.system_name_resolver()
-        if system_name == "Linux":
-            return (("xdg-open", path),)
         if system_name == "Darwin":
-            return (("open", path),)
+            return "darwin"
+        if system_name == "Linux":
+            if _is_wsl_environment(self.environment_variable, self.text_file_reader):
+                return "wsl"
+            return "linux"
         if system_name == "Windows":
-            return (("cmd", "/c", "start", "", path),)
+            raise OSError("Windows native is unsupported; run Peneo from WSL")
         raise OSError(f"Unsupported operating system: {system_name}")
+
+    def _default_app_candidates(
+        self,
+        platform_kind: PlatformKind,
+        path: str,
+    ) -> tuple[tuple[str, ...], ...]:
+        if platform_kind == "linux":
+            return (
+                ("xdg-open", path),
+                ("gio", "open", path),
+            )
+        if platform_kind == "wsl":
+            return (
+                ("wslview", path),
+                ("explorer.exe", path),
+                ("xdg-open", path),
+                ("gio", "open", path),
+            )
+        if platform_kind == "darwin":
+            return (("open", path),)
+        raise OSError(f"Unsupported platform kind: {platform_kind}")
 
     def _editor_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
         editor_commands = [
@@ -162,8 +190,8 @@ class LocalExternalLaunchAdapter:
         return _dedupe_commands(commands)
 
     def _default_terminal_editor_commands(self, path: str) -> tuple[tuple[str, ...], ...]:
-        system_name = self.system_name_resolver()
-        if system_name in {"Linux", "Darwin", "Windows"}:
+        platform_kind = self._platform_kind()
+        if platform_kind in {"linux", "wsl", "darwin"}:
             return (
                 ("nvim", path),
                 ("vim", path),
@@ -172,7 +200,7 @@ class LocalExternalLaunchAdapter:
                 ("micro", path),
                 ("emacs", "-nw", path),
             )
-        raise OSError(f"Unsupported operating system: {system_name}")
+        raise OSError(f"Unsupported platform kind: {platform_kind}")
 
     def _command_exists(self, command: str) -> bool:
         command_path = Path(command)
@@ -180,49 +208,60 @@ class LocalExternalLaunchAdapter:
             return command_path.exists()
         return self.command_available(command) is not None
 
-    def _terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
-        system_name = self.system_name_resolver()
-        if system_name == "Linux":
+    def _terminal_candidates(
+        self,
+        platform_kind: PlatformKind,
+        path: str,
+    ) -> tuple[tuple[str, ...], ...]:
+        if platform_kind == "linux":
             return (
-                ("konsole",),
+                ("kgx",),
+                ("gnome-console",),
                 ("gnome-terminal",),
                 ("xfce4-terminal",),
-                ("xterm",),
+                ("mate-terminal",),
+                ("tilix",),
+                ("konsole",),
+                ("lxterminal",),
                 ("x-terminal-emulator",),
+                ("xterm",),
             )
-        if system_name == "Darwin":
-            return (("open", "-a", "Terminal", path),)
-        if system_name == "Windows":
-            escaped_path = path.replace("'", "''")
-            powershell_command = f"Set-Location -LiteralPath '{escaped_path}'"
+        if platform_kind == "wsl":
             return (
-                ("cmd", "/c", "start", "", "wt", "-d", path),
-                (
-                    "cmd",
-                    "/c",
-                    "start",
-                    "",
-                    "powershell",
-                    "-NoExit",
-                    "-Command",
-                    powershell_command,
-                ),
+                ("wt.exe", "wsl.exe", "--cd", path),
+                ("cmd.exe", "/c", "start", "", "wsl.exe", "--cd", path),
+                ("kgx",),
+                ("gnome-console",),
+                ("gnome-terminal",),
+                ("xfce4-terminal",),
+                ("mate-terminal",),
+                ("tilix",),
+                ("konsole",),
+                ("lxterminal",),
+                ("x-terminal-emulator",),
+                ("xterm",),
             )
-        raise OSError(f"Unsupported operating system: {system_name}")
+        if platform_kind == "darwin":
+            return (("open", "-a", "Terminal", path),)
+        raise OSError(f"Unsupported platform kind: {platform_kind}")
 
-    def _clipboard_candidates(self) -> tuple[tuple[str, ...], ...]:
-        system_name = self.system_name_resolver()
-        if system_name == "Linux":
+    def _clipboard_candidates(self, platform_kind: PlatformKind) -> tuple[tuple[str, ...], ...]:
+        if platform_kind == "linux":
             return (
                 ("wl-copy",),
                 ("xclip", "-in", "-selection", "clipboard"),
                 ("xsel", "--clipboard", "--input"),
             )
-        if system_name == "Darwin":
+        if platform_kind == "wsl":
+            return (
+                ("clip.exe",),
+                ("wl-copy",),
+                ("xclip", "-in", "-selection", "clipboard"),
+                ("xsel", "--clipboard", "--input"),
+            )
+        if platform_kind == "darwin":
             return (("pbcopy",),)
-        if system_name == "Windows":
-            return (("clip",),)
-        raise OSError(f"Unsupported operating system: {system_name}")
+        raise OSError(f"Unsupported platform kind: {platform_kind}")
 
 
 def _run_detached_command(command: Sequence[str], cwd: str | None, input_text: str | None) -> None:
@@ -283,6 +322,10 @@ def _copy_to_clipboard_with_tkinter(text: str) -> None:
             root.destroy()
 
 
+def _read_text_file(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
 def _resolve_existing_path(path: str) -> Path:
     resolved_path = Path(path).expanduser().resolve()
     if not resolved_path.exists():
@@ -310,3 +353,19 @@ def _dedupe_commands(commands: Sequence[tuple[str, ...]]) -> tuple[tuple[str, ..
         seen.add(command)
         unique_commands.append(command)
     return tuple(unique_commands)
+
+
+def _is_wsl_environment(
+    environment_variable: EnvironmentVariableReader,
+    text_file_reader: TextFileReader,
+) -> bool:
+    if environment_variable("WSL_DISTRO_NAME") is not None:
+        return True
+    if environment_variable("WSL_INTEROP") is not None:
+        return True
+
+    try:
+        proc_version = text_file_reader("/proc/version")
+    except OSError:
+        return False
+    return "microsoft" in proc_version.casefold()

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -61,7 +61,64 @@ def test_local_external_launch_adapter_uses_xdg_open_on_linux(tmp_path) -> None:
 
     adapter.open_with_default_app(str(readme))
 
-    assert runner.executed == [(("xdg-open", str(readme.resolve())), None, None)]
+    assert runner.executed == [
+        (("xdg-open", str(readme.resolve())), str(tmp_path.resolve()), None)
+    ]
+
+
+def test_local_external_launch_adapter_falls_back_to_gio_open_on_linux(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubCommandRunner(failing_commands={"xdg-open"})
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command in {"xdg-open", "gio"} else None,
+        command_runner=runner,
+        text_file_reader=lambda _path: "Linux version 6.8.0\n",
+    )
+
+    adapter.open_with_default_app(str(readme))
+
+    assert runner.executed == [
+        (("xdg-open", str(readme.resolve())), str(tmp_path.resolve()), None),
+        (("gio", "open", str(readme.resolve())), str(tmp_path.resolve()), None),
+    ]
+
+
+def test_local_external_launch_adapter_uses_wslview_on_wsl(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "wslview" else None,
+        command_runner=runner,
+        environment_variable=lambda name: "Ubuntu" if name == "WSL_DISTRO_NAME" else None,
+    )
+
+    adapter.open_with_default_app(str(readme))
+
+    assert runner.executed == [
+        (("wslview", str(readme.resolve())), str(tmp_path.resolve()), None)
+    ]
+
+
+def test_local_external_launch_adapter_falls_back_to_explorer_on_wsl(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "explorer.exe" else None,
+        command_runner=runner,
+        environment_variable=lambda name: "Ubuntu" if name == "WSL_DISTRO_NAME" else None,
+    )
+
+    adapter.open_with_default_app(str(readme))
+
+    assert runner.executed == [
+        (("explorer.exe", str(readme.resolve())), str(tmp_path.resolve()), None)
+    ]
 
 
 def test_local_external_launch_adapter_runs_terminal_editor_in_current_terminal(tmp_path) -> None:
@@ -99,20 +156,35 @@ def test_local_external_launch_adapter_ignores_gui_editor_environment_variable(t
 
 
 def test_local_external_launch_adapter_falls_back_terminal_command_on_linux(tmp_path) -> None:
-    runner = StubCommandRunner(failing_commands={"konsole"})
+    runner = StubCommandRunner(failing_commands={"kgx"})
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Linux",
-        command_available=lambda command: (
-            command if command in {"konsole", "gnome-terminal"} else None
-        ),
+        command_available=lambda command: command if command in {"kgx", "gnome-terminal"} else None,
         command_runner=runner,
+        text_file_reader=lambda _path: "Linux version 6.8.0\n",
     )
 
     adapter.open_terminal(str(tmp_path))
 
     assert runner.executed == [
-        (("konsole",), str(tmp_path), None),
+        (("kgx",), str(tmp_path), None),
         (("gnome-terminal",), str(tmp_path), None),
+    ]
+
+
+def test_local_external_launch_adapter_uses_wt_on_wsl_for_terminal(tmp_path) -> None:
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "wt.exe" else None,
+        command_runner=runner,
+        environment_variable=lambda name: "Ubuntu" if name == "WSL_DISTRO_NAME" else None,
+    )
+
+    adapter.open_terminal(str(tmp_path))
+
+    assert runner.executed == [
+        (("wt.exe", "wsl.exe", "--cd", str(tmp_path.resolve())), str(tmp_path), None)
     ]
 
 
@@ -146,16 +218,37 @@ def test_local_external_launch_adapter_copies_to_clipboard_on_linux() -> None:
     ]
 
 
+def test_local_external_launch_adapter_uses_clip_exe_on_wsl() -> None:
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "clip.exe" else None,
+        command_runner=runner,
+        environment_variable=lambda name: "Ubuntu" if name == "WSL_DISTRO_NAME" else None,
+    )
+
+    adapter.copy_to_clipboard("/tmp/peneo/docs\n/tmp/peneo/README.md")
+
+    assert runner.executed == [
+        (("clip.exe",), None, "/tmp/peneo/docs\n/tmp/peneo/README.md")
+    ]
+
+
 def test_local_external_launch_adapter_raises_last_terminal_error_when_all_candidates_fail(
     tmp_path,
 ) -> None:
     runner = StubCommandRunner(
         failing_commands={
-            "konsole",
+            "kgx",
+            "gnome-console",
             "gnome-terminal",
             "xfce4-terminal",
-            "xterm",
+            "mate-terminal",
+            "tilix",
+            "konsole",
+            "lxterminal",
             "x-terminal-emulator",
+            "xterm",
         }
     )
     adapter = LocalExternalLaunchAdapter(
@@ -163,13 +256,25 @@ def test_local_external_launch_adapter_raises_last_terminal_error_when_all_candi
         command_available=lambda command: (
             command
             if command
-            in {"konsole", "gnome-terminal", "xfce4-terminal", "xterm", "x-terminal-emulator"}
+            in {
+                "kgx",
+                "gnome-console",
+                "gnome-terminal",
+                "xfce4-terminal",
+                "mate-terminal",
+                "tilix",
+                "konsole",
+                "lxterminal",
+                "x-terminal-emulator",
+                "xterm",
+            }
             else None
         ),
         command_runner=runner,
+        text_file_reader=lambda _path: "Linux version 6.8.0\n",
     )
 
-    with pytest.raises(OSError, match="x-terminal-emulator failed"):
+    with pytest.raises(OSError, match="xterm failed"):
         adapter.open_terminal(str(tmp_path))
 
 
@@ -185,6 +290,19 @@ def test_local_external_launch_adapter_reports_invalid_editor_value(tmp_path) ->
 
     with pytest.raises(OSError, match="Invalid EDITOR value"):
         adapter.open_in_editor(str(readme))
+
+
+def test_local_external_launch_adapter_rejects_windows_native_support(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command,
+        command_runner=StubCommandRunner(),
+    )
+
+    with pytest.raises(OSError, match="Windows native is unsupported"):
+        adapter.open_with_default_app(str(readme))
 
 
 def test_local_external_launch_adapter_uses_clipboard_fallback_when_commands_missing() -> None:
@@ -279,6 +397,26 @@ def test_live_external_launch_service_formats_terminal_error_for_file(tmp_path) 
         match=f"Failed to open terminal in {readme.resolve()}: Not a directory: ",
     ):
         service.execute(ExternalLaunchRequest(kind="open_terminal", path=str(readme)))
+
+
+def test_live_external_launch_service_formats_windows_native_error(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command,
+        command_runner=StubCommandRunner(),
+    )
+    service = LiveExternalLaunchService(adapter=adapter)
+
+    with pytest.raises(
+        OSError,
+        match=(
+            f"Failed to open {readme.resolve()}: "
+            "Windows native is unsupported; run Peneo from WSL"
+        ),
+    ):
+        service.execute(ExternalLaunchRequest(kind="open_file", path=str(readme)))
 
 
 def test_live_external_launch_service_formats_copy_error() -> None:


### PR DESCRIPTION
## Summary
- add WSL-aware external launch detection and route default-app / clipboard / terminal actions through Windows-side bridges when available
- expand Linux fallback candidates for `gio open` and multiple terminal emulators while keeping macOS behavior unchanged
- document that Windows native is unsupported and that WSL is the supported path for Windows users

## Why
Issue #133 asks for OS / distribution dependent handling to be more resilient. The main gap was that the previous implementation treated Linux generically, assumed a small set of Ubuntu-centric commands, and exposed a Windows-native path even though the application is intended to run in POSIX environments.

## Impact
- Windows users are guided toward WSL instead of an unsupported native runtime
- WSL users can use `wslview`, `explorer.exe`, and `clip.exe` before falling back to Linux desktop commands
- Linux desktop environments get broader terminal fallback coverage

## Validation
- `uv run python -m pytest`
- `uv run ruff check src/peneo/adapters/external_launcher.py tests/test_services_external_launcher.py README.md README.ja.md`

Closes #133
