### PR TITLE
[#138] Add confirm_delete regression tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2170,6 +2170,63 @@ async def test_app_delete_confirmation_round_trip() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_delete_skips_confirmation_when_disabled() -> None:
+    path = "/tmp/peneo-delete-without-confirm"
+    docs = f"{path}/docs"
+    src = f"{path}/src"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (
+                    DirectoryEntryState(docs, "docs", "dir"),
+                    DirectoryEntryState(src, "src", "dir"),
+                ),
+                child_path=docs,
+            )
+        }
+    )
+    delete_request = TrashDeleteRequest(paths=(docs, src))
+    mutation_service = FakeFileMutationService(
+        results={
+            delete_request: FileMutationResult(
+                path=None,
+                message="Trashed 2 items",
+                removed_paths=(docs, src),
+            )
+        }
+    )
+    app = create_app(
+        snapshot_loader=loader,
+        file_mutation_service=mutation_service,
+        initial_path=path,
+        app_config=AppConfig(
+            terminal=TerminalConfig(),
+            display=DisplayConfig(),
+            behavior=BehaviorConfig(
+                confirm_delete=False,
+                paste_conflict_action="prompt",
+            ),
+        ),
+    )
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("space")
+        await pilot.press("space")
+        await pilot.press("delete")
+        await asyncio.sleep(0.05)
+
+        status_bar = await _wait_for_status_bar(app)
+        dialog = app.query_one("#conflict-dialog", ConflictDialog)
+
+        assert app.app_state.ui_mode == "BROWSING"
+        assert app.app_state.delete_confirmation is None
+        assert dialog.display is False
+        assert str(status_bar.renderable) == "info: Trashed 2 items"
+
+
+@pytest.mark.asyncio
 async def test_app_main_flow_round_trip_on_live_filesystem(tmp_path) -> None:
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 import peneo.__main__ as cli
-from peneo.models import AppConfig, ConfigLoadResult
+from peneo.models import AppConfig, BehaviorConfig, ConfigLoadResult
 
 
 class DummyApp:
@@ -51,6 +51,36 @@ def test_main_print_last_dir_falls_back_to_current_path(capsys, monkeypatch) -> 
     assert return_code == 0
     assert app.run_calls == 1
     assert capsys.readouterr().out == "/tmp/peneo-fallback\n"
+
+
+def test_main_passes_loaded_config_and_warnings_to_create_app(monkeypatch) -> None:
+    app = DummyApp()
+    loaded_config = AppConfig(behavior=BehaviorConfig(confirm_delete=False))
+    captured_kwargs: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        cli,
+        "load_app_config",
+        lambda: ConfigLoadResult(
+            config=loaded_config,
+            warnings=("using test config",),
+        ),
+    )
+
+    def fake_create_app(**kwargs):
+        captured_kwargs.update(kwargs)
+        return app
+
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
+
+    return_code = cli.main([])
+
+    assert return_code == 0
+    assert app.run_calls == 1
+    assert captured_kwargs["app_config"] is loaded_config
+    assert captured_kwargs["startup_notification"] is not None
+    assert captured_kwargs["startup_notification"].level == "warning"
+    assert "using test config" in captured_kwargs["startup_notification"].message
 
 
 def test_config_warning_notification_returns_warning_message() -> None:


### PR DESCRIPTION
## Summary
- add a CLI regression test to ensure `main()` passes loaded config and startup warnings into `create_app()`
- add an app-level regression test to ensure `confirm_delete = false` skips the delete confirmation dialog
- keep the existing `confirm_delete = true` confirmation path covered and document in Issue #138 that the bug was not reproducible on current `main`

## Testing
- `uv run python -m pytest tests/test_cli.py -k loaded_config`
- `uv run python -m pytest tests/test_app.py -k 'delete_confirmation_round_trip or delete_skips_confirmation_when_disabled'`

Closes #138
