### PR TITLE
Issue #132 Optimize directory snapshot metadata reads

### DIFF
--- a/src/peneo/adapters/filesystem.py
+++ b/src/peneo/adapters/filesystem.py
@@ -1,5 +1,6 @@
 """Filesystem adapter for reading local directory entries."""
 
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -21,26 +22,27 @@ class LocalFilesystemAdapter:
     def list_directory(self, path: str) -> tuple[DirectoryEntryState, ...]:
         directory = Path(path).expanduser().resolve()
         entries: list[DirectoryEntryState] = []
-        for child in directory.iterdir():
-            entry = _build_directory_entry(child)
-            if entry is not None:
-                entries.append(entry)
+        with os.scandir(directory) as iterator:
+            for child in iterator:
+                entry = _build_directory_entry(child)
+                if entry is not None:
+                    entries.append(entry)
         entries.sort(key=lambda entry: (entry.kind != "dir", entry.name.casefold()))
         return tuple(entries)
 
-def _build_directory_entry(path: Path) -> DirectoryEntryState | None:
+def _build_directory_entry(entry: os.DirEntry[str]) -> DirectoryEntryState | None:
     try:
-        stat_result = path.stat()
+        stat_result = entry.stat()
     except FileNotFoundError:
         # Skip broken symlinks or entries removed during iteration.
         return None
-    kind = "dir" if path.is_dir() else "file"
+    kind = "dir" if entry.is_dir() else "file"
     return DirectoryEntryState(
-        path=str(path),
-        name=path.name,
+        path=entry.path,
+        name=entry.name,
         kind=kind,
         size_bytes=None if kind == "dir" else stat_result.st_size,
         modified_at=datetime.fromtimestamp(stat_result.st_mtime),
-        hidden=path.name.startswith("."),
+        hidden=entry.name.startswith("."),
         permissions_mode=stat_result.st_mode,
     )

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -44,3 +44,19 @@ def test_local_filesystem_adapter_skips_broken_symlink_entries(tmp_path) -> None
     entries = adapter.list_directory(str(tmp_path))
 
     assert [entry.name for entry in entries] == ["docs"]
+
+
+def test_local_filesystem_adapter_treats_directory_symlink_as_dir(tmp_path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    docs_link = tmp_path / "docs-link"
+    docs_link.symlink_to(docs, target_is_directory=True)
+
+    adapter = LocalFilesystemAdapter()
+
+    entries = adapter.list_directory(str(tmp_path))
+
+    assert [entry.name for entry in entries] == ["docs", "docs-link"]
+    assert entries[0].kind == "dir"
+    assert entries[1].kind == "dir"
+    assert entries[1].size_bytes is None


### PR DESCRIPTION
## Summary
- replace `Path.iterdir()` based directory enumeration with `os.scandir()` in `LocalFilesystemAdapter`
- reuse per-entry metadata reads while preserving existing sorting and broken symlink skipping behavior
- add a regression test that keeps directory symlinks classified as `dir`

## Why
Issue #132 identified redundant metadata syscalls during directory snapshot loading. The old implementation called both `Path.stat()` and `Path.is_dir()` for every entry, which adds avoidable I/O when opening large directories.

## Impact
- reduces per-entry filesystem metadata overhead during snapshot loading
- keeps existing `DirectoryEntryState` shape and symlink semantics unchanged
- adds coverage for symlink-to-directory handling to prevent behavior drift

## Validation
- `uv run python -m pytest tests/test_adapters_filesystem.py -q`
- `uv run python -m pytest tests/test_services_browser_snapshot.py -q`
- `uv run ruff check src/peneo/adapters/filesystem.py tests/test_adapters_filesystem.py`

Closes #132
