### PR TITLE
[Issue #131] Coalesce split terminal rendering

### DIFF
--- a/src/peneo/ui/split_terminal.py
+++ b/src/peneo/ui/split_terminal.py
@@ -9,6 +9,7 @@ from textual import events
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.geometry import Size
+from textual.timer import Timer
 from textual.widgets import Static
 
 from peneo.models import SplitTerminalViewState
@@ -19,6 +20,7 @@ class SplitTerminalPane(Static):
 
     DEFAULT_COLUMNS = 80
     DEFAULT_ROWS = 8
+    RENDER_COALESCE_SECONDS = 1 / 30
 
     DEFAULT_STATE = SplitTerminalViewState(
         visible=False,
@@ -44,6 +46,8 @@ class SplitTerminalPane(Static):
         self._pending_escape_sequence = ""
         self._screen_columns = self.DEFAULT_COLUMNS
         self._screen_rows = self.DEFAULT_ROWS
+        self._render_timer: Timer | None = None
+        self._render_pending = False
 
     def compose(self) -> ComposeResult:
         yield Static("", id="split-terminal-title")
@@ -53,6 +57,9 @@ class SplitTerminalPane(Static):
 
     def on_mount(self) -> None:
         self.set_state(self.state)
+
+    def on_unmount(self) -> None:
+        self._cancel_pending_render()
 
     def on_resize(self, _event: events.Resize) -> None:
         if not self.state.visible:
@@ -113,9 +120,10 @@ class SplitTerminalPane(Static):
                 pass
             else:
                 self._has_terminal_output = True
-        self._render_body()
+                self._schedule_render()
 
     def _render_body(self) -> None:
+        self._cancel_pending_render()
         body = self.query_one("#split-terminal-body", Static)
         rendered = Text("")
         if self.state.visible:
@@ -126,6 +134,27 @@ class SplitTerminalPane(Static):
         else:
             self._reset_terminal_screen()
         body.update(rendered)
+
+    def _schedule_render(self) -> None:
+        if self._render_pending:
+            return
+        self._render_pending = True
+        self._render_timer = self.set_timer(
+            self.RENDER_COALESCE_SECONDS,
+            self._flush_render,
+            name="split-terminal-render",
+        )
+
+    def _flush_render(self) -> None:
+        self._render_timer = None
+        self._render_pending = False
+        self._render_body()
+
+    def _cancel_pending_render(self) -> None:
+        if self._render_timer is not None:
+            self._render_timer.stop()
+            self._render_timer = None
+        self._render_pending = False
 
     def _ensure_terminal_screen(self, *, columns: int, rows: int) -> None:
         if self._screen is None or self._stream is None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1818,6 +1818,54 @@ async def test_app_split_terminal_handles_full_screen_terminal_output() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_split_terminal_coalesces_rapid_output_updates() -> None:
+    path = "/tmp/peneo-split-terminal-coalesce"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (DirectoryEntryState(f"{path}/docs", "docs", "dir"),),
+                child_path=f"{path}/docs",
+            )
+        }
+    )
+    split_terminal_service = FakeSplitTerminalService()
+    app = create_app(
+        snapshot_loader=loader,
+        split_terminal_service=split_terminal_service,
+        initial_path=path,
+    )
+
+    async with app.run_test(size=(72, 16)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("ctrl+t")
+        await asyncio.sleep(0.05)
+
+        session = split_terminal_service.sessions[0]
+        body = app.query_one("#split-terminal-body", Static)
+        update_calls: list[str] = []
+        original_update = body.update
+
+        def tracked_update(content=""):
+            update_calls.append(str(content))
+            return original_update(content)
+
+        body.update = tracked_update  # type: ignore[method-assign]
+
+        session.emit_output("a")
+        session.emit_output("b")
+        session.emit_output("c")
+        await asyncio.sleep(0.01)
+
+        assert update_calls == []
+
+        await asyncio.sleep(0.05)
+
+        assert len(update_calls) == 1
+        assert str(body.renderable).splitlines()[0].startswith("abc")
+
+
+@pytest.mark.asyncio
 async def test_app_split_terminal_ignores_unsupported_private_sgr_sequences() -> None:
     path = "/tmp/peneo-split-terminal-private-sgr"
     loader = FakeBrowserSnapshotLoader(


### PR DESCRIPTION
## Summary
- add timer-based render coalescing to `SplitTerminalPane`
- keep pyte screen updates immediate while batching expensive `body.update()` calls
- add a regression test that verifies rapid terminal output is rendered in a single coalesced update

## Testing
- `uv run ruff check .`
- `uv run pytest -q`

Closes #131
