### PR TITLE
#149 Add configurable editor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Current three-pane UI showing the parent, current, and child directories side b
 - Optional embedded split terminal below the browser panes, opened and closed with a single shortcut and focused immediately
 - Common actions stay visible in the on-screen help, while less frequent actions live in the command palette
 - Keyboard-only navigation, multi-selection, copy, cut, paste, delete-to-trash, rename, and create flows
-- Filter input, recursive file search from the command palette, attribute inspection, config editing, sort switching, and hidden-file visibility toggle
+- Filter input, recursive file search from the command palette, attribute inspection, config editing, editor selection, sort switching, and hidden-file visibility toggle
 - Files open with the OS default app, directories can be opened in the OS file manager, `e` opens the current file in the editor inside the current terminal, and a terminal can also be launched in the current directory
 - Optional shell integration via `peneo-cd` can return your shell to the last directory after quitting
 - Safer file operations with trash deletion and overwrite / skip / rename conflict resolution during paste
@@ -75,7 +75,7 @@ _The read-only attribute dialog showing file details such as path, size, modifie
 - Toggle hidden-file visibility
 - Open files with the OS default app
 - Open files in the editor inside the current terminal
-- Persist display, behavior, and terminal-launch preferences in `config.toml`
+- Persist display, behavior, editor, and terminal-launch preferences in `config.toml`
 - Optionally return the shell to the last visited directory after quitting
 
 ## Installation
@@ -117,7 +117,7 @@ peneo-cd
 
 Use plain `peneo` or `uv run peneo` when you do not need that behavior.
 
-When a file is focused, press `e` to jump into a terminal editor such as `$EDITOR`, `nvim`, `vim`, or `nano` in the current terminal session.
+When a file is focused, press `e` to jump into a terminal editor in the current terminal session. Peneo prefers `config.toml` `editor.command` when set, then falls back to `$EDITOR`, then built-in defaults such as `nvim`, `vim`, or `nano`.
 
 ## Configuration File
 
@@ -135,6 +135,7 @@ The supported settings are:
 | `terminal` | `linux` | Array of shell-style command templates | Optional terminal launch commands for Linux. Use `{path}` as the working-directory placeholder. Invalid or empty entries are ignored. |
 | `terminal` | `macos` | Array of shell-style command templates | Optional terminal launch commands for macOS, validated the same way as Linux entries. |
 | `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. The config key is accepted even though native Windows runtime is not currently supported. |
+| `editor` | `command` | Shell-style string, for example `nvim -u NONE` | Optional terminal editor command used by `e`. Do not include the file path; Peneo appends it automatically. Unsupported GUI editors or invalid commands are ignored. |
 | `display` | `show_hidden_files` | `true` / `false` | Default hidden-file visibility when the app starts. |
 | `display` | `theme` | `textual-dark` / `textual-light` | Default UI theme applied on startup and after saving from the config editor. |
 | `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. |
@@ -150,6 +151,9 @@ Example:
 linux = ["konsole --working-directory {path}", "gnome-terminal --working-directory={path}"]
 macos = ["open -a Terminal {path}"]
 windows = ["wt -d {path}"]
+
+[editor]
+command = "nvim -u NONE"
 
 [display]
 show_hidden_files = false
@@ -176,7 +180,7 @@ The main keys are listed below.
 | Normal | `←` / `h` / `Backspace` | Move to the parent directory |
 | Normal | `→` / `l` | Enter the item if it is a directory |
 | Normal | `Enter` | Enter a directory, or open a file with the default app |
-| Normal | `e` | Switch the focused file into a terminal editor such as `$EDITOR`, `nvim`, `vim`, or `nano` |
+| Normal | `e` | Switch the focused file into the configured terminal editor (`editor.command` -> `$EDITOR` -> built-in defaults) |
 | Normal | `F5` | Reload the current directory |
 | Normal | `Space` | Toggle selection, then move to the next row |
 | Normal | `y` | Copy the selected items, or the focused item if nothing is selected |
@@ -203,7 +207,7 @@ The main keys are listed below.
 | Confirmation dialog | `Enter` / `Esc` | Confirm or cancel delete |
 | Confirmation dialog | `o` / `s` / `r` / `Esc` | Resolve a paste conflict with overwrite / skip / rename / cancel |
 
-When `e` succeeds, Peneo launches a terminal editor in the current terminal session rather than opening a separate GUI app window.
+When `e` succeeds, Peneo launches a terminal editor in the current terminal session rather than opening a separate GUI app window. `editor.command` is preferred over `$EDITOR` when both are set.
 
 ## Command Palette
 
@@ -218,7 +222,7 @@ Less frequent actions are grouped in the command palette opened with `:`.
 | `Open terminal here` | Always | Launches an external terminal rooted at the current directory, using `config.toml` templates before built-in fallbacks. |
 | `Open split terminal` / `Close split terminal` | Always | Toggles the embedded split terminal. The label changes with visibility, and the split terminal keeps the directory where it was started instead of following later browser navigation. |
 | `Show hidden files` / `Hide hidden files` | Always | Toggles hidden-file visibility for the browser panes. The label reflects the current visibility state. |
-| `Edit config` | Always | Opens the config overlay for startup defaults, including hidden-file visibility, theme, sorting, and paste/delete behavior. Use `↑` / `↓` to move, `←` / `→` / `Enter` to change values, `s` to save `config.toml`, and `e` to open the raw config file in a terminal editor. |
+| `Edit config` | Always | Opens the config overlay for startup defaults, including the preferred terminal editor, hidden-file visibility, theme, sorting, and paste/delete behavior. Use `↑` / `↓` to move, `←` / `→` / `Enter` to change values, `s` to save `config.toml`, and `e` to open the raw config file in a terminal editor. |
 | `Create file` | Always | Starts the inline create-file flow in the current directory. |
 | `Create directory` | Always | Starts the inline create-directory flow in the current directory. |
 
@@ -228,7 +232,7 @@ Less frequent actions are grouped in the command palette opened with `:`.
 - GUI integration paths such as default-app launch, file-manager launch, and terminal launch are currently validated primarily in that environment.
 - The embedded split terminal currently targets POSIX environments such as Ubuntu/Linux and WSL.
 - External-launch behavior includes Linux, macOS, and WSL-aware fallbacks. Native Windows is not a supported runtime for Peneo.
-- `config.toml` can override terminal launch commands before those built-in fallbacks are used.
+- `config.toml` can override both the preferred terminal editor and external terminal launch commands before those built-in fallbacks are used.
 - WSL prefers Windows-side bridges such as `wslview`, `explorer.exe`, and `clip.exe` when available, with Linux-side fallbacks kept for WSLg and desktop Linux environments.
 - The application is still under active development, so behavior and keybindings may change.
 - File mutations operate on the selected directory entry. If the selected item is a symlink, Peneo mutates the symlink itself instead of silently following and mutating the link target.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -145,10 +145,10 @@ sequenceDiagram
 
 - `browser_snapshot.py`: builds the three-pane snapshot from the real filesystem
 - `clipboard_operations.py`: handles copy / cut / paste execution and conflict detection
-- `config.py`: loads, validates, saves, and renders `config.toml`
+- `config.py`: loads, validates, saves, and renders `config.toml`, including normalized startup editor settings such as `editor.command`
 - `file_search.py`: handles recursive file search under the current directory and filters results according to hidden-file visibility
 - `file_mutations.py`: handles rename / create / trash delete
-- `external_launcher.py`: handles default-app open, editor-in-current-terminal launch, terminal launch, and copying a path to the system clipboard
+- `external_launcher.py`: handles default-app open, editor-in-current-terminal launch, terminal launch, and copying a path to the system clipboard, resolving editors in config -> `$EDITOR` -> built-in order
 - `split_terminal.py`: starts PTY-backed embedded terminal sessions, forwards I/O, and reports exit events
 
 ### `src/peneo/adapters/`
@@ -201,7 +201,7 @@ Notes:
 - `PALETTE`
   - Handles query updates, candidate cursor movement, command execution, and cancel
 - `CONFIG`
-  - Edits startup defaults in the config overlay, saves with `s`, and opens the raw `config.toml` in a terminal editor with `e`
+  - Edits startup defaults in the config overlay, including terminal-editor presets, saves with `s`, and opens the raw `config.toml` in a terminal editor with `e`
 - `RENAME` / `CREATE`
   - Edits names in the input bar and issues a mutation effect on `Enter`
 - `CONFIRM`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,10 +145,10 @@ sequenceDiagram
 
 - `browser_snapshot.py`: 実 filesystem から 3 ペイン用 snapshot を構築
 - `clipboard_operations.py`: copy / cut / paste の実処理と競合検出を担当
-- `config.py`: `config.toml` の読み込み、検証、保存、既定値レンダリングを担当
+- `config.py`: `config.toml` の読み込み、検証、保存、既定値レンダリングを担当し、`editor.command` を含む起動設定を正規化する
 - `file_search.py`: 現在ディレクトリ以下の再帰ファイル検索を担当し、hidden 設定に応じて結果を絞る
 - `file_mutations.py`: rename / create / trash delete を担当
-- `external_launcher.py`: 既定アプリ起動、現在のターミナル内エディタ起動、ターミナル起動、システムクリップボードへのパスコピーを担当
+- `external_launcher.py`: 既定アプリ起動、現在のターミナル内エディタ起動、ターミナル起動、システムクリップボードへのパスコピーを担当し、editor config -> `$EDITOR` -> 既定値の順でエディタ候補を解決する
 - `split_terminal.py`: 埋め込み split terminal の PTY セッション起動、入出力、終了通知を担当
 
 ### `src/peneo/adapters/`
@@ -201,7 +201,7 @@ stateDiagram-v2
 - `PALETTE`
   - query 更新、候補カーソル移動、コマンド実行、キャンセルを処理する
 - `CONFIG`
-  - config overlay 上で起動時設定を編集し、`s` で保存、`e` で生の `config.toml` をターミナル内エディタで開く
+  - config overlay 上で起動時設定を編集し、terminal editor のプリセット選択を含めて `s` で保存し、`e` で生の `config.toml` をターミナル内エディタで開く
 - `RENAME` / `CREATE`
   - 入力バーで名前を編集し、`Enter` で mutation effect を発行する
 - `CONFIRM`

--- a/src/peneo/adapters/external_launcher.py
+++ b/src/peneo/adapters/external_launcher.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol
 
-from peneo.models import TerminalConfig
+from peneo.models import EditorConfig, TerminalConfig
 
 CommandRunner = Callable[[Sequence[str], str | None, str | None], None]
 ForegroundCommandRunner = Callable[[Sequence[str], str | None], None]
@@ -55,6 +55,7 @@ class LocalExternalLaunchAdapter:
         default_factory=lambda: (_copy_to_clipboard_with_tkinter,)
     )
     terminal_command_templates: TerminalConfig = field(default_factory=TerminalConfig)
+    editor_command_template: EditorConfig = field(default_factory=EditorConfig)
 
     def open_with_default_app(self, path: str) -> None:
         resolved_path = _resolve_existing_path(path)
@@ -180,6 +181,12 @@ class LocalExternalLaunchAdapter:
 
     def _terminal_editor_commands(self, path: str) -> tuple[tuple[str, ...], ...]:
         commands: list[tuple[str, ...]] = []
+        configured_editor_command = self.editor_command_template.command
+        if configured_editor_command:
+            parsed_command = tuple(shlex.split(configured_editor_command))
+            if parsed_command and _is_terminal_editor_command(parsed_command[0]):
+                commands.append(parsed_command + (path,))
+
         editor_command = self.environment_variable("EDITOR")
         if editor_command:
             try:

--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -365,10 +365,9 @@ class PeneoApp(App[None]):
         self._clipboard_service = clipboard_service or LiveClipboardOperationService()
         self._config_save_service = config_save_service or LiveConfigSaveService()
         self._file_mutation_service = file_mutation_service or LiveFileMutationService()
-        self._external_launch_service = external_launch_service or LiveExternalLaunchService(
-            adapter=LocalExternalLaunchAdapter(
-                terminal_command_templates=self._app_config.terminal,
-            )
+        self._uses_live_external_launch_service = external_launch_service is None
+        self._external_launch_service = (
+            external_launch_service or self._build_external_launch_service(self._app_config)
         )
         self._file_search_service = file_search_service or LiveFileSearchService()
         self._split_terminal_service = split_terminal_service or LiveSplitTerminalService()
@@ -490,9 +489,24 @@ class PeneoApp(App[None]):
         self._sync_file_search_state(previous_state, self._app_state)
         if previous_state.config.display.theme != self._app_state.config.display.theme:
             self.theme = self._app_state.config.display.theme
+        if previous_state.config != self._app_state.config:
+            self._sync_external_launch_service()
         if changed:
             await self._refresh_shell()
         self._schedule_effects(effects)
+
+    def _build_external_launch_service(self, app_config: AppConfig) -> LiveExternalLaunchService:
+        return LiveExternalLaunchService(
+            adapter=LocalExternalLaunchAdapter(
+                terminal_command_templates=app_config.terminal,
+                editor_command_template=app_config.editor,
+            )
+        )
+
+    def _sync_external_launch_service(self) -> None:
+        if not self._uses_live_external_launch_service:
+            return
+        self._external_launch_service = self._build_external_launch_service(self._app_state.config)
 
     def _apply_actions(self, actions: Sequence[Action]) -> tuple[bool, tuple[Effect, ...]]:
         state = self._app_state

--- a/src/peneo/models/__init__.py
+++ b/src/peneo/models/__init__.py
@@ -7,6 +7,7 @@ from .config import (
     ConfigSortField,
     ConfigTheme,
     DisplayConfig,
+    EditorConfig,
     PasteConflictAction,
     TerminalConfig,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "CreateKind",
     "CreatePathRequest",
     "DisplayConfig",
+    "EditorConfig",
     "ExternalLaunchKind",
     "ExternalLaunchRequest",
     "FileMutationResult",

--- a/src/peneo/models/config.py
+++ b/src/peneo/models/config.py
@@ -18,6 +18,13 @@ class TerminalConfig:
 
 
 @dataclass(frozen=True)
+class EditorConfig:
+    """Terminal editor launch command configured by the user."""
+
+    command: str | None = None
+
+
+@dataclass(frozen=True)
 class DisplayConfig:
     """Display-related startup defaults."""
 
@@ -41,6 +48,7 @@ class AppConfig:
     """Normalized application configuration."""
 
     terminal: TerminalConfig = field(default_factory=TerminalConfig)
+    editor: EditorConfig = field(default_factory=EditorConfig)
     display: DisplayConfig = field(default_factory=DisplayConfig)
     behavior: BehaviorConfig = field(default_factory=BehaviorConfig)
 

--- a/src/peneo/services/config.py
+++ b/src/peneo/services/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Callable, Protocol
 
-from peneo.models import AppConfig, ConfigLoadResult, DisplayConfig, TerminalConfig
+from peneo.models import AppConfig, ConfigLoadResult, DisplayConfig, EditorConfig, TerminalConfig
 from peneo.models.config import BehaviorConfig
 
 SystemNameResolver = Callable[[], str]
@@ -28,6 +28,9 @@ class ConfigSaveService(Protocol):
 _VALID_SORT_FIELDS = frozenset({"name", "modified", "size"})
 _VALID_THEMES = frozenset({"textual-dark", "textual-light"})
 _VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
+_VALID_TERMINAL_EDITOR_NAMES = frozenset(
+    {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
+)
 _VALIDATION_PATH = "/tmp/peneo"
 
 
@@ -74,10 +77,16 @@ class AppConfigLoader:
             )
 
         terminal = _load_terminal_config(document.get("terminal"), warnings)
+        editor = _load_editor_config(document.get("editor"), warnings)
         display = _load_display_config(document.get("display"), warnings)
         behavior = _load_behavior_config(document.get("behavior"), warnings)
         return ConfigLoadResult(
-            config=AppConfig(terminal=terminal, display=display, behavior=behavior),
+            config=AppConfig(
+                terminal=terminal,
+                editor=editor,
+                display=display,
+                behavior=behavior,
+            ),
             path=str(path),
             warnings=tuple(warnings),
         )
@@ -188,6 +197,39 @@ def _load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
     return config
 
 
+def _load_editor_config(section: object, warnings: list[str]) -> EditorConfig:
+    if section is None:
+        return EditorConfig()
+    if not isinstance(section, dict):
+        warnings.append("editor must be a table; using defaults.")
+        return EditorConfig()
+
+    command = section.get("command")
+    if command is None:
+        return EditorConfig()
+    if not isinstance(command, str) or not command.strip():
+        warnings.append("editor.command must be a non-empty string; using default.")
+        return EditorConfig()
+
+    try:
+        parsed = tuple(shlex.split(command))
+    except ValueError as error:
+        warnings.append(
+            f"editor.command is not a valid shell-style command: {error}; using default."
+        )
+        return EditorConfig()
+
+    if not parsed:
+        warnings.append("editor.command did not produce an executable command; using default.")
+        return EditorConfig()
+    if Path(parsed[0]).name.casefold() not in _VALID_TERMINAL_EDITOR_NAMES:
+        warnings.append(
+            "editor.command must target a supported terminal editor; using default."
+        )
+        return EditorConfig()
+    return EditorConfig(command=command)
+
+
 def _load_behavior_config(section: object, warnings: list[str]) -> BehaviorConfig:
     config = BehaviorConfig()
     if section is None:
@@ -292,6 +334,14 @@ def render_app_config(config: AppConfig) -> str:
         macos = [{macos}]
         windows = [{windows}]
 
+        [editor]
+        # Optional terminal editor command for `e`.
+        # Use a shell-style command without the file path; Peneo appends it automatically.
+        # Examples:
+        # command = "nvim -u NONE"
+        # command = "emacs -nw"
+        command = {editor_command}
+
         [display]
         show_hidden_files = {show_hidden_files}
         theme = "{theme}"
@@ -307,6 +357,7 @@ def render_app_config(config: AppConfig) -> str:
         linux=_render_command_array(config.terminal.linux),
         macos=_render_command_array(config.terminal.macos),
         windows=_render_command_array(config.terminal.windows),
+        editor_command=_render_optional_toml_string(config.editor.command),
         show_hidden_files=_render_bool(config.display.show_hidden_files),
         theme=config.display.theme,
         default_sort_field=config.display.default_sort_field,
@@ -328,3 +379,9 @@ def _render_bool(value: bool) -> str:
 def _render_toml_string(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
+
+
+def _render_optional_toml_string(value: str | None) -> str:
+    if value is None:
+        return '""'
+    return _render_toml_string(value)

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -23,6 +23,7 @@ CommandPaletteSource = Literal["commands", "file_search"]
 SplitTerminalStatus = Literal["closed", "starting", "running"]
 SplitTerminalFocusTarget = Literal["browser", "terminal"]
 ConfigFieldId = Literal[
+    "editor.command",
     "display.show_hidden_files",
     "display.theme",
     "display.default_sort_field",

--- a/src/peneo/state/reducer.py
+++ b/src/peneo/state/reducer.py
@@ -125,6 +125,7 @@ from .selectors import select_target_paths, select_visible_current_entry_states
 _CONFIG_SORT_FIELDS = ("name", "modified", "size")
 _CONFIG_THEMES = ("textual-dark", "textual-light")
 _CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
+_CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
 
 
 def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
@@ -1546,6 +1547,14 @@ def _normalize_config_editor_cursor(cursor_index: int) -> int:
 
 def _cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) -> AppConfig:
     field_id = _config_editor_field_ids()[_normalize_config_editor_cursor(cursor_index)]
+    if field_id == "editor.command":
+        return replace(
+            config,
+            editor=replace(
+                config.editor,
+                command=_cycle_editor_command(config.editor.command, delta),
+            ),
+        )
     if field_id == "display.show_hidden_files":
         return replace(
             config,
@@ -1620,8 +1629,17 @@ def _cycle_choice(options: tuple[str, ...], current: str, delta: int) -> str:
     return options[(current_index + delta) % len(options)]
 
 
+def _cycle_editor_command(current: str | None, delta: int) -> str | None:
+    if current in _CONFIG_EDITOR_COMMANDS:
+        current_index = _CONFIG_EDITOR_COMMANDS.index(current)
+    else:
+        current_index = len(_CONFIG_EDITOR_COMMANDS)
+    return _CONFIG_EDITOR_COMMANDS[(current_index + delta) % len(_CONFIG_EDITOR_COMMANDS)]
+
+
 def _config_editor_field_ids() -> tuple[str, ...]:
     return (
+        "editor.command",
         "display.show_hidden_files",
         "display.theme",
         "display.default_sort_field",
@@ -1634,6 +1652,7 @@ def _config_editor_field_ids() -> tuple[str, ...]:
 
 def _config_editor_labels() -> tuple[str, ...]:
     return (
+        "Editor command",
         "Show hidden files",
         "Theme",
         "Default sort field",

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -362,31 +362,38 @@ def select_config_dialog_state(state: AppState) -> ConfigDialogState | None:
         f"Path: {state.config_editor.path}",
         "",
         _format_config_line(
-            0, selected_index, "Show hidden files", _format_bool(config.display.show_hidden_files)
+            0, selected_index, "Editor command", _format_editor_command_value(config.editor.command)
         ),
-        _format_config_line(1, selected_index, "Theme", config.display.theme),
         _format_config_line(
-            2,
+            1,
+            selected_index,
+            "Show hidden files",
+            _format_bool(config.display.show_hidden_files),
+        ),
+        _format_config_line(2, selected_index, "Theme", config.display.theme),
+        _format_config_line(
+            3,
             selected_index,
             "Default sort field",
             config.display.default_sort_field,
         ),
         _format_config_line(
-            3,
+            4,
             selected_index,
             "Default sort descending",
             _format_bool(config.display.default_sort_descending),
         ),
         _format_config_line(
-            4, selected_index, "Directories first", _format_bool(config.display.directories_first)
+            5, selected_index, "Directories first", _format_bool(config.display.directories_first)
         ),
         _format_config_line(
-            5, selected_index, "Confirm delete", _format_bool(config.behavior.confirm_delete)
+            6, selected_index, "Confirm delete", _format_bool(config.behavior.confirm_delete)
         ),
         _format_config_line(
-            6, selected_index, "Paste conflict action", config.behavior.paste_conflict_action
+            7, selected_index, "Paste conflict action", config.behavior.paste_conflict_action
         ),
         "",
+        _format_custom_editor_hint(config.editor.command),
         "Terminal launch templates: edit config.toml with e",
         f"  Linux templates: {len(config.terminal.linux)}",
         f"  macOS templates: {len(config.terminal.macos)}",
@@ -701,6 +708,20 @@ def _format_permissions_label(mode: int | None) -> str:
         return "-"
     normalized_mode = S_IMODE(mode)
     return f"{filemode(mode)} ({normalized_mode:03o})"
+
+
+def _format_editor_command_value(command: str | None) -> str:
+    if command is None:
+        return "system default"
+    if command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw"}:
+        return command
+    return "custom (raw config only)"
+
+
+def _format_custom_editor_hint(command: str | None) -> str:
+    if command is None or command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw"}:
+        return "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw"
+    return f"Custom editor command: {command}"
 
 
 def _format_current_entry_name_detail(entry: DirectoryEntryState) -> str | None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ import asyncio
 import threading
 import time
 from contextlib import nullcontext
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from peneo.models import (
     AppConfig,
     BehaviorConfig,
     DisplayConfig,
+    EditorConfig,
     ExternalLaunchRequest,
     FileMutationResult,
     PasteConflict,
@@ -31,8 +33,15 @@ from peneo.services import (
     FakeFileMutationService,
     FakeFileSearchService,
     FakeSplitTerminalService,
+    LiveExternalLaunchService,
 )
-from peneo.state import BrowserSnapshot, DirectoryEntryState, FileSearchResultState, PaneState
+from peneo.state import (
+    BrowserSnapshot,
+    ConfigSaveCompleted,
+    DirectoryEntryState,
+    FileSearchResultState,
+    PaneState,
+)
 from peneo.ui import (
     AttributeDialog,
     CommandPalette,
@@ -1453,8 +1462,9 @@ async def test_app_command_palette_opens_config_dialog_and_saves_changes() -> No
         assert app.app_state.ui_mode == "CONFIG"
         assert "Config Editor" in str(title.renderable)
         assert "Path: /tmp/peneo/config.toml" in str(lines.renderable)
-        assert "> Show hidden files: false" in str(lines.renderable)
+        assert "> Editor command: system default" in str(lines.renderable)
 
+        await pilot.press("down")
         await pilot.press("enter")
         await pilot.press("s")
         await _wait_for_notification_message(app, "Config saved: /tmp/peneo/config.toml")
@@ -1498,6 +1508,7 @@ async def test_app_config_dialog_save_updates_theme() -> None:
 
         assert app.theme == "textual-dark"
 
+        await pilot.press("down")
         await pilot.press("down")
         await pilot.press("enter")
         await pilot.press("s")
@@ -1545,6 +1556,52 @@ async def test_app_config_dialog_e_opens_config_file_in_editor() -> None:
         assert launch_service.executed_requests == [
             ExternalLaunchRequest(kind="open_editor", path="/tmp/peneo/config.toml")
         ]
+
+
+@pytest.mark.asyncio
+async def test_app_config_save_refreshes_live_external_launch_service() -> None:
+    path = "/tmp/peneo-refresh-editor-config"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (
+                    DirectoryEntryState(f"{path}/docs", "docs", "dir"),
+                    DirectoryEntryState(f"{path}/README.md", "README.md", "file", size_bytes=120),
+                ),
+                child_path=f"{path}/docs",
+            )
+        }
+    )
+    app = create_app(
+        snapshot_loader=loader,
+        config_path="/tmp/peneo/config.toml",
+        initial_path=path,
+    )
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+
+        assert isinstance(app._external_launch_service, LiveExternalLaunchService)
+        assert app._external_launch_service.adapter.editor_command_template.command is None
+
+        app._app_state = replace(app.app_state, pending_config_save_request_id=7)
+        saved_config = replace(app.app_state.config, editor=EditorConfig(command="nvim -u NONE"))
+        await app.dispatch_actions(
+            (
+                ConfigSaveCompleted(
+                    request_id=7,
+                    path="/tmp/peneo/config.toml",
+                    config=saved_config,
+                ),
+            )
+        )
+
+        assert isinstance(app._external_launch_service, LiveExternalLaunchService)
+        assert (
+            app._external_launch_service.adapter.editor_command_template.command
+            == "nvim -u NONE"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from peneo.models import AppConfig, BehaviorConfig, DisplayConfig, TerminalConfig
+from peneo.models import AppConfig, BehaviorConfig, DisplayConfig, EditorConfig, TerminalConfig
 from peneo.services.config import AppConfigLoader, LiveConfigSaveService, resolve_config_path
 
 
@@ -26,6 +26,7 @@ def test_loader_creates_default_config_when_missing(tmp_path) -> None:
     assert '# linux = [' in written
     assert '#   "konsole --working-directory {path}",' in written
     assert '#   "gnome-terminal --working-directory={path}",' in written
+    assert '# command = "nvim -u NONE"' in written
     assert 'theme = "textual-dark"' in written
     assert 'default_sort_field = "name"' in written
 
@@ -36,6 +37,9 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
         """
         [terminal]
         linux = ["konsole --working-directory {path}"]
+
+        [editor]
+        command = "nvim -u NONE"
 
         [display]
         show_hidden_files = true
@@ -56,6 +60,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
     assert result.created is False
     assert result.warnings == ()
     assert result.config.terminal.linux == ("konsole --working-directory {path}",)
+    assert result.config.editor.command == "nvim -u NONE"
     assert result.config.display.show_hidden_files is True
     assert result.config.display.theme == "textual-light"
     assert result.config.display.default_sort_field == "modified"
@@ -72,6 +77,9 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
         [terminal]
         linux = ["konsole --working-directory {path}", "{broken"]
 
+        [editor]
+        command = "code --wait"
+
         [display]
         show_hidden_files = true
         theme = "bad-theme"
@@ -87,12 +95,31 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
     result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
 
     assert result.config.terminal.linux == ("konsole --working-directory {path}",)
+    assert result.config.editor.command is None
     assert result.config.display.show_hidden_files is True
     assert result.config.display.theme == "textual-dark"
     assert result.config.display.default_sort_field == "name"
     assert result.config.behavior.confirm_delete is True
     assert result.config.behavior.paste_conflict_action == "prompt"
-    assert len(result.warnings) == 5
+    assert len(result.warnings) == 6
+
+
+def test_loader_warns_for_invalid_editor_command_syntax(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [editor]
+        command = "'"
+        """,
+        encoding="utf-8",
+    )
+
+    result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+    assert result.config.editor.command is None
+    assert result.warnings == (
+        "editor.command is not a valid shell-style command: No closing quotation; using default.",
+    )
 
 
 def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
@@ -103,6 +130,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
         path=str(config_path),
         config=AppConfig(
             terminal=TerminalConfig(linux=("konsole --working-directory {path}",)),
+            editor=EditorConfig(command="nvim -u NONE"),
             display=DisplayConfig(
                 show_hidden_files=True,
                 theme="textual-light",
@@ -122,6 +150,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
     assert '# macos = ["open -a Terminal {path}"]' in written
     assert '# windows = ["wt -d {path}"]' in written
     assert 'linux = ["konsole --working-directory {path}"]' in written
+    assert 'command = "nvim -u NONE"' in written
     assert "show_hidden_files = true" in written
     assert 'theme = "textual-light"' in written
     assert 'default_sort_field = "size"' in written

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 import pytest
 
 from peneo.adapters import LocalExternalLaunchAdapter
-from peneo.models import ExternalLaunchRequest, TerminalConfig
+from peneo.models import EditorConfig, ExternalLaunchRequest, TerminalConfig
 from peneo.services import LiveExternalLaunchService
 
 
@@ -139,6 +139,25 @@ def test_local_external_launch_adapter_runs_terminal_editor_in_current_terminal(
     ]
 
 
+def test_local_external_launch_adapter_prefers_configured_editor_command(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command in {"nvim", "vim"} else None,
+        foreground_command_runner=runner,
+        environment_variable=lambda _name: "vim" ,
+        editor_command_template=EditorConfig(command="nvim -u NONE"),
+    )
+
+    adapter.open_in_editor(str(readme))
+
+    assert runner.executed == [
+        (("nvim", "-u", "NONE", str(readme.resolve())), str(tmp_path.resolve()))
+    ]
+
+
 def test_local_external_launch_adapter_ignores_gui_editor_environment_variable(tmp_path) -> None:
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
@@ -148,6 +167,23 @@ def test_local_external_launch_adapter_ignores_gui_editor_environment_variable(t
         command_available=lambda command: command if command == "vim" else None,
         foreground_command_runner=runner,
         environment_variable=lambda name: "code" if name == "EDITOR" else None,
+    )
+
+    adapter.open_in_editor(str(readme))
+
+    assert runner.executed == [(("vim", str(readme.resolve())), str(tmp_path.resolve()))]
+
+
+def test_local_external_launch_adapter_ignores_gui_configured_editor_command(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "vim" else None,
+        foreground_command_runner=runner,
+        editor_command_template=EditorConfig(command="code --wait"),
+        environment_variable=lambda _name: None,
     )
 
     adapter.open_in_editor(str(readme))

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -481,7 +481,25 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     next_state = _reduce_state(state, MoveConfigEditorCursor(delta=99))
 
     assert next_state.config_editor is not None
-    assert next_state.config_editor.cursor_index == 6
+    assert next_state.config_editor.cursor_index == 7
+
+
+def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:
+    state = replace(
+        build_initial_app_state(config_path="/tmp/peneo/config.toml"),
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/peneo/config.toml",
+            draft=build_initial_app_state().config,
+            cursor_index=0,
+        ),
+    )
+
+    next_state = _reduce_state(state, CycleConfigEditorValue(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.draft.editor.command == "nvim"
+    assert next_state.config_editor.dirty is True
 
 
 def test_cycle_config_editor_value_updates_draft_and_dirty_state() -> None:
@@ -491,7 +509,7 @@ def test_cycle_config_editor_value_updates_draft_and_dirty_state() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/peneo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=0,
+            cursor_index=1,
         ),
     )
 
@@ -509,7 +527,7 @@ def test_cycle_config_editor_theme_updates_draft_and_dirty_state() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/peneo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=1,
+            cursor_index=2,
         ),
     )
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 from stat import S_IFREG
 
 import peneo.state.selectors as selectors_module
-from peneo.models import PasteConflict, PasteRequest
+from peneo.models import AppConfig, EditorConfig, PasteConflict, PasteRequest
 from peneo.state import (
     AttributeInspectionState,
     BeginCommandPalette,
@@ -606,7 +606,7 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/peneo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=1,
+            cursor_index=2,
             dirty=True,
         ),
     )
@@ -616,10 +616,29 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     assert dialog is not None
     assert dialog.title == "Config Editor*"
     assert "Path: /tmp/peneo/config.toml" in dialog.lines
+    assert "  Editor command: system default" in dialog.lines
     assert "> Theme: textual-dark" in dialog.lines
     assert "  Default sort field: name" in dialog.lines
+    assert "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw" in dialog.lines
     assert "Terminal launch templates: edit config.toml with e" in dialog.lines
     assert dialog.options == ("left/right/enter change", "s save", "e edit file", "esc close")
+
+
+def test_select_config_dialog_state_shows_custom_editor_command_hint() -> None:
+    state = replace(
+        build_initial_app_state(config_path="/tmp/peneo/config.toml"),
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/peneo/config.toml",
+            draft=AppConfig(editor=EditorConfig(command="nvim -u NONE")),
+        ),
+    )
+
+    dialog = select_config_dialog_state(state)
+
+    assert dialog is not None
+    assert "> Editor command: custom (raw config only)" in dialog.lines
+    assert "Custom editor command: nvim -u NONE" in dialog.lines
 
 
 def test_select_command_palette_state_for_file_search_results() -> None:


### PR DESCRIPTION
Closes #149

## Summary
- add `editor.command` to `config.toml` and validate/load/save it
- prefer config editor setting over `$EDITOR` when handling `e`, with built-in terminal-editor fallbacks kept intact
- add editor selection to the config overlay and update README/architecture docs

## Testing
- `uv run ruff check .`
- `uv run python -m pytest -q`
