### PR TITLE
Issue #153: Enable regex Find file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Less frequent actions are grouped in the command palette opened with `:`.
 
 | Command | Shown when | Behavior / Notes |
 | --- | --- | --- |
-| `Find file` | Always | Switches the palette into recursive file-search mode. Searches the current directory tree with a case-insensitive partial filename match, excludes hidden paths unless hidden files are currently visible, and `Enter` jumps to the selected result by opening its parent directory and focusing that file. |
+| `Find file` | Always | Switches the palette into recursive file-search mode. Plain input searches the current directory tree with a case-insensitive partial basename match. Prefix the query with `re:` to run a Python regular expression against basenames instead; regex is case-sensitive unless you use inline flags such as `(?i)`. Hidden paths are excluded unless hidden files are currently visible, invalid regex patterns are shown inline in the palette, and `Enter` jumps to the selected result by opening its parent directory and focusing that file. |
 | `Show attributes` | Exactly one target is selected or focused | Opens a read-only dialog with `Name`, `Type`, `Path`, `Size`, `Modified`, `Hidden`, and `Permissions`. |
 | `Copy path` | At least one target is selected or focused | Copies the selected path list, or the focused path when nothing is selected, to the system clipboard. |
 | `Open in file manager` | Always | Opens the current directory in the OS file manager. |

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -139,6 +139,8 @@ sequenceDiagram
 - The current palette includes `Find file`, `Show attributes`, `Copy path`, `Open in file manager`, `Open terminal here`, `Open/Close split terminal`, `Show/Hide hidden files`, `Edit config`, `Create file`, and `Create directory`
 - `Show attributes` appears only for a single target and opens a read-only attribute dialog with `Name`, `Type`, `Path`, `Size`, `Modified`, `Hidden`, and `Permissions`
 - `Find file` switches the palette into file-search mode and reuses the same UI to show recursive matches under the current directory
+  - Plain input runs a case-insensitive partial basename match
+  - `re:`-prefixed input is treated as a Python regex against basenames, and invalid regex patterns are surfaced inline in the palette
 - The split-terminal and hidden-files entries change their labels to reflect the current state
 
 ### `src/peneo/services/`
@@ -146,7 +148,7 @@ sequenceDiagram
 - `browser_snapshot.py`: builds the three-pane snapshot from the real filesystem
 - `clipboard_operations.py`: handles copy / cut / paste execution and conflict detection
 - `config.py`: loads, validates, saves, and renders `config.toml`, including normalized startup editor settings such as `editor.command`
-- `file_search.py`: handles recursive file search under the current directory and filters results according to hidden-file visibility
+- `file_search.py`: handles recursive file search under the current directory, interpreting both plain input and `re:` regex input before filtering results according to hidden-file visibility
 - `file_mutations.py`: handles rename / create / trash delete
 - `external_launcher.py`: handles default-app open, editor-in-current-terminal launch, terminal launch, and copying a path to the system clipboard, resolving editors in config -> `$EDITOR` -> built-in order
 - `split_terminal.py`: starts PTY-backed embedded terminal sessions, forwards I/O, and reports exit events

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,6 +139,8 @@ sequenceDiagram
 - 現在の palette には `Find file`、`Show attributes`、`Copy path`、`Open in file manager`、`Open terminal here`、`Open/Close split terminal`、`Show/Hide hidden files`、`Edit config`、`Create file`、`Create directory` がある
 - `Show attributes` は単一対象がある場合にだけ表示し、`Name` / `Type` / `Path` / `Size` / `Modified` / `Hidden` / `Permissions` を持つ read-only の属性ダイアログを開く
 - `Find file` 選択後は palette をファイル検索モードに切り替え、現在ディレクトリ以下を再帰検索した結果を同じ UI で表示する
+  - 通常入力は basename 対象の大文字小文字を無視した部分一致
+  - `re:` 接頭辞付き入力は basename 対象の Python regex として扱い、無効な regex は palette 内メッセージで表示する
 - split terminal と hidden files のトグルは状態に応じてラベルを切り替える
 
 ### `src/peneo/services/`
@@ -146,7 +148,7 @@ sequenceDiagram
 - `browser_snapshot.py`: 実 filesystem から 3 ペイン用 snapshot を構築
 - `clipboard_operations.py`: copy / cut / paste の実処理と競合検出を担当
 - `config.py`: `config.toml` の読み込み、検証、保存、既定値レンダリングを担当し、`editor.command` を含む起動設定を正規化する
-- `file_search.py`: 現在ディレクトリ以下の再帰ファイル検索を担当し、hidden 設定に応じて結果を絞る
+- `file_search.py`: 現在ディレクトリ以下の再帰ファイル検索を担当し、通常入力と `re:` regex 入力を解釈したうえで hidden 設定に応じて結果を絞る
 - `file_mutations.py`: rename / create / trash delete を担当
 - `external_launcher.py`: 既定アプリ起動、現在のターミナル内エディタ起動、ターミナル起動、システムクリップボードへのパスコピーを担当し、editor config -> `$EDITOR` -> 既定値の順でエディタ候補を解決する
 - `split_terminal.py`: 埋め込み split terminal の PTY セッション起動、入出力、終了通知を担当
@@ -225,7 +227,7 @@ stateDiagram-v2
 - ゴミ箱への削除と複数対象削除時の確認ダイアログ
 - ファイルの既定アプリ起動
 - `e` による現在のターミナル内エディタ起動
-- コマンドパレットからの再帰ファイル検索、属性表示、path copy、既定ファイラー起動、terminal 起動、hidden files 切り替え
+- コマンドパレットからの再帰ファイル検索（通常部分一致と `re:` regex、invalid regex の inline 表示を含む）、属性表示、path copy、既定ファイラー起動、terminal 起動、hidden files 切り替え
 - config overlay による起動時設定の編集と `config.toml` 保存
 - 埋め込み split terminal の起動、入力、終了通知
 - status bar / help bar / input bar / conflict dialog / attribute dialog / config dialog / split terminal の状態連動表示

--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -31,6 +31,7 @@ from peneo.services import (
     ExternalLaunchService,
     FileMutationService,
     FileSearchService,
+    InvalidFileSearchQueryError,
     LiveBrowserSnapshotLoader,
     LiveClipboardOperationService,
     LiveConfigSaveService,
@@ -1043,12 +1044,14 @@ class PeneoApp(App[None]):
             return
 
         if isinstance(effect, RunFileSearchEffect):
+            invalid_query = isinstance(event.worker.error, InvalidFileSearchQueryError)
             await self.dispatch_actions(
                 (
                     FileSearchFailed(
                         request_id=effect.request_id,
                         query=effect.query,
                         message=message,
+                        invalid_query=invalid_query,
                     ),
                 )
             )

--- a/src/peneo/services/__init__.py
+++ b/src/peneo/services/__init__.py
@@ -29,7 +29,12 @@ from .file_mutations import (
     FileMutationService,
     LiveFileMutationService,
 )
-from .file_search import FakeFileSearchService, FileSearchService, LiveFileSearchService
+from .file_search import (
+    FakeFileSearchService,
+    FileSearchService,
+    InvalidFileSearchQueryError,
+    LiveFileSearchService,
+)
 from .split_terminal import (
     FakeSplitTerminalService,
     LiveSplitTerminalService,
@@ -46,6 +51,7 @@ __all__ = [
     "FileSearchService",
     "FakeFileMutationService",
     "FakeFileSearchService",
+    "InvalidFileSearchQueryError",
     "FakeBrowserSnapshotLoader",
     "FakeClipboardOperationService",
     "FakeExternalLaunchService",

--- a/src/peneo/services/file_search.py
+++ b/src/peneo/services/file_search.py
@@ -1,9 +1,10 @@
 """Recursive file-search services for the command palette."""
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 from peneo.state.models import FileSearchResultState
 
@@ -21,6 +22,60 @@ class FileSearchService(Protocol):
     ) -> tuple[FileSearchResultState, ...]: ...
 
 
+_REGEX_QUERY_PREFIX = "re:"
+
+
+class InvalidFileSearchQueryError(ValueError):
+    """Raised when the file-search query cannot be interpreted."""
+
+
+@dataclass(frozen=True)
+class ParsedFileSearchQuery:
+    """Normalized file-search query used by the search service."""
+
+    raw_query: str
+    mode: Literal["plain", "regex"]
+    normalized_plain_query: str = ""
+    pattern: re.Pattern[str] | None = None
+
+    @property
+    def is_regex(self) -> bool:
+        return self.mode == "regex"
+
+    def matches(self, filename: str) -> bool:
+        if self.pattern is not None:
+            return self.pattern.search(filename) is not None
+        return self.normalized_plain_query in filename.casefold()
+
+
+def is_regex_file_search_query(query: str) -> bool:
+    """Return whether the trimmed query uses regex mode."""
+
+    return query.strip().startswith(_REGEX_QUERY_PREFIX)
+
+
+def parse_file_search_query(query: str) -> ParsedFileSearchQuery:
+    """Parse a file-search query into plain or regex matching mode."""
+
+    stripped_query = query.strip()
+    if is_regex_file_search_query(stripped_query):
+        pattern_source = stripped_query[len(_REGEX_QUERY_PREFIX) :]
+        try:
+            pattern = re.compile(pattern_source)
+        except re.error as error:
+            raise InvalidFileSearchQueryError(f"Invalid regex: {error}") from error
+        return ParsedFileSearchQuery(
+            raw_query=stripped_query,
+            mode="regex",
+            pattern=pattern,
+        )
+    return ParsedFileSearchQuery(
+        raw_query=stripped_query,
+        mode="plain",
+        normalized_plain_query=stripped_query.casefold(),
+    )
+
+
 @dataclass(frozen=True)
 class LiveFileSearchService:
     """Search the local filesystem for matching filenames."""
@@ -33,8 +88,8 @@ class LiveFileSearchService:
         show_hidden: bool,
         is_cancelled: Callable[[], bool] | None = None,
     ) -> tuple[FileSearchResultState, ...]:
-        normalized_query = query.strip().casefold()
-        if not normalized_query:
+        parsed_query = parse_file_search_query(query)
+        if not parsed_query.raw_query:
             return ()
 
         root = Path(root_path).expanduser().resolve()
@@ -63,7 +118,7 @@ class LiveFileSearchService:
                 if child.is_dir():
                     stack.append(child)
                     continue
-                if normalized_query not in child.name.casefold():
+                if not parsed_query.matches(child.name):
                     continue
                 results.append(
                     FileSearchResultState(
@@ -83,6 +138,7 @@ class FakeFileSearchService:
         default_factory=dict
     )
     failure_messages: dict[tuple[str, str, bool], str] = field(default_factory=dict)
+    invalid_query_messages: dict[tuple[str, str, bool], str] = field(default_factory=dict)
     executed_requests: list[tuple[str, str, bool]] = field(default_factory=list)
 
     def search(
@@ -97,6 +153,8 @@ class FakeFileSearchService:
         self.executed_requests.append(key)
         if is_cancelled is not None and is_cancelled():
             return ()
+        if key in self.invalid_query_messages:
+            raise InvalidFileSearchQueryError(self.invalid_query_messages[key])
         if key in self.failure_messages:
             raise OSError(self.failure_messages[key])
         return self.results_by_query.get(key, ())

--- a/src/peneo/state/actions.py
+++ b/src/peneo/state/actions.py
@@ -144,6 +144,7 @@ class FileSearchFailed:
     request_id: int
     query: str
     message: str
+    invalid_query: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -172,6 +172,7 @@ class CommandPaletteState:
     query: str = ""
     cursor_index: int = 0
     file_search_results: tuple[FileSearchResultState, ...] = ()
+    file_search_error_message: str | None = None
     file_search_cache_query: str = ""
     file_search_cache_results: tuple[FileSearchResultState, ...] = ()
     file_search_cache_root_path: str | None = None

--- a/src/peneo/state/reducer.py
+++ b/src/peneo/state/reducer.py
@@ -126,6 +126,7 @@ _CONFIG_SORT_FIELDS = ("name", "modified", "size")
 _CONFIG_THEMES = ("textual-dark", "textual-light")
 _CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
 _CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
+_REGEX_FILE_SEARCH_PREFIX = "re:"
 
 
 def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
@@ -315,21 +316,29 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
             state.command_palette,
             query=action.query,
             cursor_index=0,
+            file_search_error_message=None,
         )
         if state.command_palette.source != "file_search":
             return done(replace(state, command_palette=next_palette))
 
-        normalized_query = action.query.strip().casefold()
-        if not normalized_query:
+        stripped_query = action.query.strip()
+        if not stripped_query:
             return done(
                 replace(
                     state,
-                    command_palette=replace(next_palette, file_search_results=()),
+                    command_palette=replace(
+                        next_palette,
+                        file_search_results=(),
+                        file_search_error_message=None,
+                    ),
                     pending_file_search_request_id=None,
                 )
             )
+        is_regex_query = _is_regex_file_search_query(stripped_query)
+        normalized_query = stripped_query.casefold()
         if (
-            state.command_palette.file_search_cache_query
+            not is_regex_query
+            and state.command_palette.file_search_cache_query
             and normalized_query.startswith(state.command_palette.file_search_cache_query)
             and state.command_palette.file_search_cache_root_path == state.current_path
             and state.command_palette.file_search_cache_show_hidden == state.show_hidden
@@ -359,7 +368,7 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
             RunFileSearchEffect(
                 request_id=request_id,
                 root_path=state.current_path,
-                query=normalized_query,
+                query=stripped_query,
                 show_hidden=state.show_hidden,
             ),
         )
@@ -370,12 +379,16 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
         if state.command_palette.source == "file_search":
             results = state.command_palette.file_search_results
             if not results:
+                message = (
+                    state.command_palette.file_search_error_message
+                    or "No matching files"
+                )
                 return done(
                     replace(
                         state,
                         notification=NotificationState(
                             level="warning",
-                            message="No matching files",
+                            message=message,
                         ),
                     )
                 )
@@ -1142,18 +1155,24 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
             action.request_id != state.pending_file_search_request_id
             or state.command_palette is None
             or state.command_palette.source != "file_search"
-            or state.command_palette.query.strip().casefold() != action.query
+            or state.command_palette.query.strip() != action.query
         ):
             return done(state)
+        cache_query = ""
+        cache_results: tuple[FileSearchResultState, ...] = ()
+        if not _is_regex_file_search_query(action.query):
+            cache_query = action.query.casefold()
+            cache_results = action.results
         return done(
             replace(
                 state,
                 command_palette=replace(
                     state.command_palette,
                     file_search_results=action.results,
+                    file_search_error_message=None,
                     cursor_index=0,
-                    file_search_cache_query=action.query,
-                    file_search_cache_results=action.results,
+                    file_search_cache_query=cache_query,
+                    file_search_cache_results=cache_results,
                     file_search_cache_root_path=state.current_path,
                     file_search_cache_show_hidden=state.show_hidden,
                 ),
@@ -1164,6 +1183,18 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
     if isinstance(action, FileSearchFailed):
         if action.request_id != state.pending_file_search_request_id:
             return done(state)
+        if state.command_palette is not None and action.invalid_query:
+            return done(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        file_search_results=(),
+                        file_search_error_message=action.message,
+                    ),
+                    pending_file_search_request_id=None,
+                )
+            )
         return done(
             replace(
                 state,
@@ -1753,6 +1784,10 @@ def _filter_file_search_results(
         for result in results
         if normalized_query in Path(result.path).name.casefold()
     )
+
+
+def _is_regex_file_search_query(query: str) -> bool:
+    return query.strip().startswith(_REGEX_FILE_SEARCH_PREFIX)
 
 
 def _format_clipboard_message(prefix: str, paths: tuple[str, ...]) -> str:

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -637,6 +637,12 @@ def _select_command_palette_window(
 def _file_search_empty_message(state: AppState) -> str:
     if state.pending_file_search_request_id is not None:
         return "Searching files..."
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "file_search"
+        and state.command_palette.file_search_error_message is not None
+    ):
+        return state.command_palette.file_search_error_message
     return "No matching files"
 
 

--- a/src/peneo/ui/command_palette.py
+++ b/src/peneo/ui/command_palette.py
@@ -46,7 +46,11 @@ class CommandPalette(Container):
         title_widget.update(state.title)
         query_text = Text()
         query_text.append("> ", style="bold")
-        placeholder = "type a filename" if state.title == "Find File" else "type a command"
+        placeholder = (
+            "type a filename or re:pattern"
+            if state.title == "Find File"
+            else "type a command"
+        )
         query_text.append(state.query or placeholder, style="bold" if state.query else "dim")
         query_widget.update(query_text)
         items_widget.update(self._render_items(state))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1298,6 +1298,52 @@ async def test_app_file_search_debounces_rapid_query_updates(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_file_search_passes_regex_queries_through_to_service(tmp_path) -> None:
+    path = str(tmp_path)
+    (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")
+    file_search_service = FakeFileSearchService(
+        results_by_query={
+            (path, r"re:^README\.md$", False): (
+                FileSearchResultState(
+                    path=f"{path}/README.md",
+                    display_path="README.md",
+                ),
+            )
+        }
+    )
+    app = create_app(file_search_service=file_search_service, initial_path=path)
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press(":")
+        await pilot.press("enter")
+        await pilot.press(
+            "r",
+            "e",
+            ":",
+            "^",
+            "R",
+            "E",
+            "A",
+            "D",
+            "M",
+            "E",
+            "\\",
+            ".",
+            "m",
+            "d",
+            "$",
+        )
+        await _wait_for_request_count(file_search_service, 1)
+
+        assert file_search_service.executed_requests == [(path, r"re:^README\.md$", False)]
+        assert app.app_state.command_palette is not None
+        assert [
+            result.display_path for result in app.app_state.command_palette.file_search_results
+        ] == ["README.md"]
+
+
+@pytest.mark.asyncio
 async def test_app_file_search_prefix_extension_reuses_cached_results(tmp_path) -> None:
     path = str(tmp_path)
     (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")
@@ -1380,6 +1426,32 @@ async def test_app_file_search_cancels_superseded_request_without_notification(t
         assert [
             result.display_path for result in app.app_state.command_palette.file_search_results
         ] == ["guide.md"]
+
+
+@pytest.mark.asyncio
+async def test_app_file_search_shows_invalid_regex_message_in_palette(tmp_path) -> None:
+    path = str(tmp_path)
+    (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")
+    file_search_service = FakeFileSearchService(
+        invalid_query_messages={
+            (path, "re:[", False): "Invalid regex: unterminated character set"
+        }
+    )
+    app = create_app(file_search_service=file_search_service, initial_path=path)
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press(":")
+        await pilot.press("enter")
+        await pilot.press("r", "e", ":", "[")
+        await _wait_for_request_count(file_search_service, 1)
+        await asyncio.sleep(0.05)
+
+        palette = await _wait_for_command_palette(app)
+        items = palette.query_one("#command-palette-items", Static)
+
+        assert "Invalid regex: unterminated character set" in str(items.renderable)
+        assert app.app_state.notification is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_services_file_search.py
+++ b/tests/test_services_file_search.py
@@ -1,4 +1,6 @@
-from peneo.services import LiveFileSearchService
+import pytest
+
+from peneo.services import InvalidFileSearchQueryError, LiveFileSearchService
 
 
 def test_live_file_search_service_matches_files_recursively(tmp_path) -> None:
@@ -45,6 +47,43 @@ def test_live_file_search_service_matches_case_insensitively_and_ignores_directo
     results = service.search(str(root), "read", show_hidden=False)
 
     assert [result.display_path for result in results] == ["README.MD"]
+
+
+def test_live_file_search_service_supports_regex_queries_with_re_prefix(tmp_path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "README.md").write_text("readme\n", encoding="utf-8")
+    (root / "guide.txt").write_text("guide\n", encoding="utf-8")
+
+    service = LiveFileSearchService()
+
+    results = service.search(str(root), r"re:^README\.md$", show_hidden=False)
+
+    assert [result.display_path for result in results] == ["README.md"]
+
+
+def test_live_file_search_service_uses_python_regex_case_rules(tmp_path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "README.md").write_text("readme\n", encoding="utf-8")
+
+    service = LiveFileSearchService()
+
+    case_sensitive = service.search(str(root), r"re:^readme\.md$", show_hidden=False)
+    case_insensitive = service.search(str(root), r"re:(?i)^readme\.md$", show_hidden=False)
+
+    assert case_sensitive == ()
+    assert [result.display_path for result in case_insensitive] == ["README.md"]
+
+
+def test_live_file_search_service_raises_invalid_query_for_bad_regex(tmp_path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+
+    service = LiveFileSearchService()
+
+    with pytest.raises(InvalidFileSearchQueryError, match="Invalid regex"):
+        service.search(str(root), "re:[", show_hidden=False)
 
 
 def test_live_file_search_service_stops_when_cancelled(tmp_path) -> None:

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -52,6 +52,7 @@ from peneo.state import (
     FileMutationCompleted,
     FileMutationFailed,
     FileSearchCompleted,
+    FileSearchFailed,
     FileSearchResultState,
     FocusSplitTerminal,
     GoToParentDirectory,
@@ -1067,6 +1068,41 @@ def test_set_command_palette_query_runs_new_search_when_query_is_not_prefix_exte
     )
 
 
+def test_set_command_palette_query_runs_new_search_for_regex_queries() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("find"))
+    state = _reduce_state(state, SubmitCommandPalette())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="read",
+            file_search_cache_query="read",
+            file_search_cache_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/peneo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+            file_search_cache_root_path="/home/tadashi/develop/peneo",
+            file_search_cache_show_hidden=False,
+        ),
+        next_request_id=4,
+    )
+
+    result = reduce_app_state(state, SetCommandPaletteQuery(r"re:^README\.md$"))
+
+    assert result.state.pending_file_search_request_id == 4
+    assert result.effects == (
+        RunFileSearchEffect(
+            request_id=4,
+            root_path="/home/tadashi/develop/peneo",
+            query=r"re:^README\.md$",
+            show_hidden=False,
+        ),
+    )
+
+
 def test_file_search_completed_updates_palette_results() -> None:
     state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
     state = _reduce_state(state, SetCommandPaletteQuery("find"))
@@ -1102,6 +1138,101 @@ def test_file_search_completed_updates_palette_results() -> None:
     assert next_state.command_palette.file_search_cache_root_path == "/home/tadashi/develop/peneo"
     assert next_state.command_palette.file_search_cache_show_hidden is False
     assert next_state.pending_file_search_request_id is None
+
+
+def test_file_search_completed_does_not_cache_regex_queries() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("find"))
+    state = _reduce_state(state, SubmitCommandPalette())
+    search_state = replace(
+        state,
+        command_palette=replace(state.command_palette, query=r"re:^README\.md$"),
+        pending_file_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        FileSearchCompleted(
+            request_id=4,
+            query=r"re:^README\.md$",
+            results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/peneo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.file_search_results == (
+        FileSearchResultState(
+            path="/home/tadashi/develop/peneo/README.md",
+            display_path="README.md",
+        ),
+    )
+    assert next_state.command_palette.file_search_cache_query == ""
+    assert next_state.command_palette.file_search_cache_results == ()
+
+
+def test_file_search_failed_sets_inline_error_for_invalid_regex() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("find"))
+    state = _reduce_state(state, SubmitCommandPalette())
+    search_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="re:[",
+            file_search_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/peneo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+        pending_file_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        FileSearchFailed(
+            request_id=4,
+            query="re:[",
+            message="Invalid regex: unterminated character set",
+            invalid_query=True,
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.file_search_results == ()
+    assert (
+        next_state.command_palette.file_search_error_message
+        == "Invalid regex: unterminated character set"
+    )
+    assert next_state.notification is None
+    assert next_state.pending_file_search_request_id is None
+
+
+def test_submit_command_palette_uses_inline_error_message_when_present() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("find"))
+    state = _reduce_state(state, SubmitCommandPalette())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="re:[",
+            file_search_error_message="Invalid regex: unterminated character set",
+        ),
+    )
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.notification == NotificationState(
+        level="warning",
+        message="Invalid regex: unterminated character set",
+    )
 
 
 def test_submit_command_palette_file_search_result_requests_snapshot() -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -686,6 +686,25 @@ def test_select_command_palette_state_shows_searching_message_while_file_search_
     assert palette_state.items == ()
 
 
+def test_select_command_palette_state_shows_regex_error_message() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = replace(
+        state,
+        command_palette=CommandPaletteState(
+            source="file_search",
+            query="re:[",
+            file_search_error_message="Invalid regex: unterminated character set",
+        ),
+    )
+
+    palette_state = select_command_palette_state(state)
+
+    assert palette_state is not None
+    assert palette_state.title == "Find File"
+    assert palette_state.empty_message == "Invalid regex: unterminated character set"
+    assert palette_state.items == ()
+
+
 def test_select_command_palette_state_windows_large_file_search_results() -> None:
     results = tuple(
         FileSearchResultState(


### PR DESCRIPTION
## Summary
- keep plain `Find file` input as case-insensitive basename partial match and add `re:` prefix for regex queries
- show invalid regex errors in the palette, avoid caching regex runs, and document the new syntax
- add regression tests for regex parsing, caching behavior, and palette messaging

## Testing
- `uv run ruff check .`
- `uv run pytest tests/test_services_file_search.py tests/test_state_reducer.py tests/test_state_selectors.py tests/test_app.py`
