### PR TITLE
[#90] Fix release workflow version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,13 @@ jobs:
       - name: Verify version consistency
         run: |
           TAG_VERSION=${{ steps.version.outputs.version }}
-          PY_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml'))['project']['version'])")
+          PY_VERSION=$(uv run python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
           if [ "$TAG_VERSION" != "$PY_VERSION" ]; then
             echo "Error: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PY_VERSION)"
             exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "peneo"
-version = "0.1.0"
+version = "0.1.1"
 description = "A simple Textual-based file manager."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "peneo"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },


### PR DESCRIPTION
## Summary
- fix the release workflow version check to read `pyproject.toml` in binary mode for Python 3.12+
- bump the package version to `0.1.1` so the release can be recovered with a new tag
- refresh `uv.lock` for the new local package version

## Test
- `uv run python -m pytest`
- `uv run ruff check .`
- `uv build --sdist --out-dir dist`
- `uv build --wheel --out-dir dist`
