### PR TITLE
[#90] Sync release workflow hotfix from main to develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,13 @@ jobs:
       - name: Verify version consistency
         run: |
           TAG_VERSION=${{ steps.version.outputs.version }}
-          PY_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml'))['project']['version'])")
+          PY_VERSION=$(uv run python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
           if [ "$TAG_VERSION" != "$PY_VERSION" ]; then
             echo "Error: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PY_VERSION)"
             exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "peneo"
-version = "0.1.0"
+version = "0.1.1"
 description = "A simple Textual-based file manager."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "peneo"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },


### PR DESCRIPTION
## Summary
- sync the release workflow hotfix from `main` back into `develop`
- carry the `0.1.1` version bump and lockfile update into the development branch

## Source
- merged from PR #160 on `main`
