### PR TITLE
#162 README の WSL セットアップ案内を更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -41,6 +41,12 @@ cd peneo
 uv tool install --from . peneo
 ```
 
+WSL 環境では、`wslview` などのブリッジコマンドを使えるように `wslu` も追加でインストールしてください。
+
+```bash
+sudo apt install wslu
+```
+
 更新時は最新を pull したあとに同じコマンドを再実行してください。
 
 ## 起動
@@ -180,11 +186,12 @@ paste_conflict_action = "prompt"
 
 ## 対応環境と注意
 
-- 現時点で動作確認している OS は Ubuntu のみです。
+- 現時点で動作確認している OS は Ubuntu と WSL 上の Ubuntu です。
 - 既定アプリ起動、ファイルマネージャ起動、ターミナル起動などの GUI 連携も主にその環境で確認しています。
 - 埋め込み split terminal は現状 POSIX 環境、特に Ubuntu/Linux と WSL を前提にしています。
 - 外部起動まわりは Linux、macOS、WSL を意識したフォールバックを持ちます。Windows ネイティブ実行はサポート対象外です。
 - `config.toml` でターミナルエディタやターミナル起動コマンドを指定した場合は、その設定を組み込みフォールバックより優先します。
+- WSL では、優先ブリッジ動作に使う `wslview` を利用できるよう `wslu` のインストールが必要です。
 - WSL では `wslview`、`explorer.exe`、`clip.exe` のような Windows 側ブリッジを優先し、WSLg や Linux デスクトップ向けのフォールバックも維持します。
 - 挙動やキーバインドは今後見直す可能性があります。
 - ファイル操作は、選択したディレクトリエントリ自体に対して行われます。選択中の項目が symlink の場合も、リンク先を暗黙に辿って変更せず、symlink エントリ自体を操作します。

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ cd peneo
 uv tool install --from . peneo
 ```
 
+On WSL, also install `wslu` so bridge commands such as `wslview` are available:
+
+```bash
+sudo apt install wslu
+```
+
 To update, pull the latest changes and run the same install command again.
 
 ## Run
@@ -180,11 +186,12 @@ Less frequent actions are grouped in the command palette opened with `:`.
 
 ## Platform Notes
 
-- The project is currently verified only on Ubuntu.
-- GUI integration paths such as default-app launch, file-manager launch, and terminal launch are currently validated primarily in that environment.
+- The project is currently verified on Ubuntu and Ubuntu running under WSL.
+- GUI integration paths such as default-app launch, file-manager launch, and terminal launch are currently validated primarily in those environments.
 - The embedded split terminal currently targets POSIX environments such as Ubuntu/Linux and WSL.
 - External-launch behavior includes Linux, macOS, and WSL-aware fallbacks. Native Windows is not a supported runtime for Peneo.
 - `config.toml` can override both the preferred terminal editor and external terminal launch commands before those built-in fallbacks are used.
+- On WSL, install `wslu` to make `wslview` available for the preferred bridge behavior.
 - WSL prefers Windows-side bridges such as `wslview`, `explorer.exe`, and `clip.exe` when available, with Linux-side fallbacks kept for WSLg and desktop Linux environments.
 - Behavior and keybindings may change in future revisions.
 - File mutations operate on the selected directory entry. If the selected item is a symlink, Peneo mutates the symlink itself instead of silently following and mutating the link target.


### PR DESCRIPTION
## 概要
- WSL 環境では `wslu` のインストールが必要なことを README に追記
- Ubuntu に加えて WSL 上の Ubuntu でも動作確認できている旨を追記
- 英語版と日本語版 README の記述をそろえて更新

## テスト
- 未実行（README 更新のみ）

Closes #162