### PR TITLE
Remove split terminal from command palette and improve help bar text (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Less frequent actions are grouped in the command palette opened with `:`.
 | `Copy path` | At least one target is selected or focused | Copies the selected path list, or the focused path when nothing is selected, to the system clipboard. |
 | `Open in file manager` | Always | Opens the current directory in the OS file manager. |
 | `Open terminal here` | Always | Launches an external terminal rooted at the current directory, using `config.toml` templates before built-in fallbacks. |
-| `Open split terminal` / `Close split terminal` | Always | Toggles the embedded split terminal. The label changes with visibility, and the split terminal keeps the directory where it was started instead of following later browser navigation. |
 | `Show hidden files` / `Hide hidden files` | Always | Toggles hidden-file visibility for the browser panes. The label reflects the current visibility state. |
 | `Edit config` | Always | Opens the settings overlay for startup defaults. You can edit the preferred terminal editor, hidden-file visibility, theme, sorting, default paste-conflict behavior, and delete confirmation. Use `↑` / `↓` to move, `←` / `→` / `Enter` to change values, `s` to save `config.toml`, and `e` to open the raw config file in a terminal editor. |
 | `Create file` | Always | Starts the inline create-file flow in the current directory. |

--- a/src/peneo/state/command_palette.py
+++ b/src/peneo/state/command_palette.py
@@ -99,12 +99,6 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                 enabled=True,
             ),
             CommandPaletteItem(
-                id="toggle_split_terminal",
-                label=_split_terminal_label(state),
-                shortcut=None,
-                enabled=True,
-            ),
-            CommandPaletteItem(
                 id="toggle_hidden",
                 label=_hidden_files_label(state),
                 shortcut=None,
@@ -143,10 +137,6 @@ def _matches_query(item: CommandPaletteItem, query: str) -> bool:
 
 def _hidden_files_label(state: AppState) -> str:
     return "Hide hidden files" if state.show_hidden else "Show hidden files"
-
-
-def _split_terminal_label(state: AppState) -> str:
-    return "Close split terminal" if state.split_terminal.visible else "Open split terminal"
 
 
 def _select_target_paths(state: AppState) -> tuple[str, ...]:

--- a/src/peneo/state/reducer.py
+++ b/src/peneo/state/reducer.py
@@ -504,8 +504,6 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
             return reduce_app_state(next_state, OpenPathWithDefaultApp(next_state.current_path))
         if selected_item.id == "open_terminal":
             return reduce_app_state(next_state, OpenTerminalAtPath(next_state.current_path))
-        if selected_item.id == "toggle_split_terminal":
-            return reduce_app_state(next_state, ToggleSplitTerminal())
         if selected_item.id == "toggle_hidden":
             return reduce_app_state(next_state, ToggleHiddenFiles())
         if selected_item.id == "edit_config":

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -161,7 +161,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
     return HelpBarState(
         (
             "Enter open | e edit | / filter | ctrl+f find | : palette | q quit",
-            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t split",
+            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term",
         )
     )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1135,7 +1135,7 @@ async def test_app_displays_browsing_help_bar() -> None:
 
         assert str(help_bar.renderable) == (
             "Enter open | e edit | / filter | ctrl+f find | : palette | q quit\n"
-            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t split"
+            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term"
         )
 
 

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -414,7 +414,7 @@ def test_move_command_palette_cursor_clamps_to_visible_commands() -> None:
     next_state = _reduce_state(state, MoveCommandPaletteCursor(delta=10))
 
     assert next_state.command_palette is not None
-    assert next_state.command_palette.cursor_index == 8
+    assert next_state.command_palette.cursor_index == 7
 
 
 def test_set_command_palette_query_resets_cursor() -> None:
@@ -762,23 +762,6 @@ def test_open_path_in_editor_allows_non_browser_file_path() -> None:
                 kind="open_editor",
                 path="/tmp/peneo/config.toml",
             ),
-        ),
-    )
-
-
-def test_submit_command_palette_toggles_split_terminal() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("split"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BROWSING"
-    assert result.state.split_terminal.visible is True
-    assert result.state.split_terminal.status == "starting"
-    assert result.effects == (
-        StartSplitTerminalEffect(
-            session_id=1,
-            cwd="/home/tadashi/develop/peneo",
         ),
     )
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -450,11 +450,11 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
 
     assert help_state.lines == (
         "Enter open | e edit | / filter | ctrl+f find | : palette | q quit",
-        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t split",
+        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term",
     )
     assert help_state.text == (
         "Enter open | e edit | / filter | ctrl+f find | : palette | q quit\n"
-        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t split"
+        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term"
     )
 
 
@@ -524,7 +524,7 @@ def test_select_command_palette_state_marks_selected_and_enabled_items() -> None
     palette_state = select_command_palette_state(state)
 
     assert palette_state is not None
-    assert palette_state.title == "Command Palette (1-8 / 9)"
+    assert palette_state.title == "Command Palette"
     assert [item.label for item in palette_state.items[:2]] == [
         "Show attributes",
         "Copy path",
@@ -536,7 +536,6 @@ def test_select_command_palette_state_marks_selected_and_enabled_items() -> None
     )
     assert any(item.label == "Edit config" and item.enabled for item in palette_state.items)
     assert any(item.label == "Open terminal here" and item.enabled for item in palette_state.items)
-    assert any(item.label == "Open split terminal" and item.enabled for item in palette_state.items)
 
 
 def test_select_command_palette_state_filters_query() -> None:


### PR DESCRIPTION
## Summary
- コマンドパレットから "Open split terminal" / "Close split terminal" エントリを削除（Ctrl+Tで直接起動できるため冗長）
- ヘルプバーの表記を `ctrl+t split` → `ctrl+t term` に変更し、何が起きるか分かりやすく改善
- README のコマンドパレット一覧表から該当行を削除

## Test plan
- [x] `uv run pytest` — 380 tests passed
- [x] `uv run ruff check .` — All checks passed
- [ ] `uv run peneo` でコマンドパレット（`:`）に split terminal が表示されないことを確認
- [ ] Ctrl+T で split terminal が開閉することを確認
- [ ] ヘルプバーに `ctrl+t term` と表示されることを確認

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)