### PR TITLE
Add Page Down/Up support and expand Find File to 50% screen height (#167)

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -216,6 +216,11 @@ class PeneoApp(App[None]):
         background: $surface;
     }
 
+    #command-palette.file-search {
+        height: 50%;
+        max-height: 50%;
+    }
+
     #command-palette-title {
         color: $accent;
         text-style: bold;

--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -45,7 +45,11 @@ from .actions import (
     ToggleSplitTerminal,
 )
 from .models import AppState, DirectoryEntryState, NotificationState
-from .selectors import select_target_paths, select_visible_current_entry_states
+from .selectors import (
+    FILE_SEARCH_VISIBLE_WINDOW,
+    select_target_paths,
+    select_visible_current_entry_states,
+)
 
 DispatchedActions = tuple[Action, ...]
 
@@ -313,6 +317,12 @@ def _dispatch_command_palette_input(
 
     if key in {"down", "j"}:
         return _supported(MoveCommandPaletteCursor(delta=1))
+
+    if key == "pageup":
+        return _supported(MoveCommandPaletteCursor(delta=-FILE_SEARCH_VISIBLE_WINDOW))
+
+    if key == "pagedown":
+        return _supported(MoveCommandPaletteCursor(delta=FILE_SEARCH_VISIBLE_WINDOW))
 
     if key == "enter":
         return _supported(SubmitCommandPalette())

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -30,7 +30,7 @@ from .models import AppState, DirectoryEntryState, FileSearchResultState, SortSt
 
 SIDE_PANE_SORT = SortState(field="name", descending=False, directories_first=True)
 COMMAND_PALETTE_VISIBLE_WINDOW = 8
-FILE_SEARCH_VISIBLE_WINDOW = 8
+FILE_SEARCH_VISIBLE_WINDOW = 12
 
 
 @dataclass(frozen=True)

--- a/src/peneo/ui/command_palette.py
+++ b/src/peneo/ui/command_palette.py
@@ -38,10 +38,16 @@ class CommandPalette(Container):
         items_widget = self.query_one("#command-palette-items", Static)
 
         if state is None:
+            self.remove_class("file-search")
             title_widget.update("Command Palette")
             query_widget.update("")
             items_widget.update("")
             return
+
+        if state.title.startswith("Find File"):
+            self.add_class("file-search")
+        else:
+            self.remove_class("file-search")
 
         title_widget.update(state.title)
         query_text = Text()

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -405,6 +405,22 @@ def test_palette_printable_key_updates_query() -> None:
     assert actions == (SetNotification(None), SetCommandPaletteQuery("f"))
 
 
+def test_palette_pageup_moves_cursor_by_page() -> None:
+    state = replace(build_initial_app_state(), ui_mode="PALETTE")
+
+    actions = dispatch_key_input(state, key="pageup")
+
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-12))
+
+
+def test_palette_pagedown_moves_cursor_by_page() -> None:
+    state = replace(build_initial_app_state(), ui_mode="PALETTE")
+
+    actions = dispatch_key_input(state, key="pagedown")
+
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=12))
+
+
 def test_split_terminal_focus_sends_printable_input() -> None:
     state = replace(
         build_initial_app_state(),

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -725,8 +725,10 @@ def test_select_command_palette_state_windows_large_file_search_results() -> Non
     palette_state = select_command_palette_state(state)
 
     assert palette_state is not None
-    assert palette_state.title == "Find File (7-14 / 20)"
+    assert palette_state.title == "Find File (5-16 / 20)"
     assert [item.label for item in palette_state.items] == [
+        "src/module_4.py",
+        "src/module_5.py",
         "src/module_6.py",
         "src/module_7.py",
         "src/module_8.py",
@@ -735,8 +737,10 @@ def test_select_command_palette_state_windows_large_file_search_results() -> Non
         "src/module_11.py",
         "src/module_12.py",
         "src/module_13.py",
+        "src/module_14.py",
+        "src/module_15.py",
     ]
-    assert palette_state.items[4].selected is True
+    assert palette_state.items[6].selected is True
 
 
 def test_select_input_bar_state_for_create_mode() -> None:


### PR DESCRIPTION
## Summary
- Find File で Page Down / Page Up によるページ単位のカーソルジャンプを追加
- Find File の表示領域を画面の 50% に拡大（`height: 50%`, `max-height: 50%`）
- `FILE_SEARCH_VISIBLE_WINDOW` を 8 → 12 に増加

## Changes
| ファイル | 変更内容 |
|---|---|
| `src/peneo/state/input.py` | `_dispatch_command_palette_input` に pageup/pagedown ハンドリング追加 |
| `src/peneo/state/selectors.py` | `FILE_SEARCH_VISIBLE_WINDOW` を 8 → 12 に変更 |
| `src/peneo/ui/command_palette.py` | Find File 時に `file-search` CSS クラスを付与 |
| `src/peneo/app.py` | `#command-palette.file-search` CSS ルール追加（`height: 50%`） |
| `tests/test_input_dispatch.py` | pageup/pagedown テスト追加 |
| `tests/test_state_selectors.py` | ウィンドウサイズ変更に伴う期待値更新 |

## Test plan
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pytest` — 382 passed
- [ ] 手動確認: Find File 表示時に画面の50%を占めること
- [ ] 手動確認: Page Down/Up でページ単位ジャンプすること

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)