### PR TITLE
Remove capacity display from Parent/Child directories (Issue #187)

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -84,8 +84,8 @@ def select_parent_entries(state: AppState) -> tuple[PaneEntry, ...]:
     return _select_side_pane_entries(
         visible_entries,
         state.directory_size_cache,
-        state.config.display.show_directory_sizes,
-        _select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+        display_directory_sizes=False,
+        cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
     )
 
 
@@ -120,8 +120,8 @@ def _select_child_entries_for_cursor(
     return _select_side_pane_entries(
         visible_entries,
         state.directory_size_cache,
-        state.config.display.show_directory_sizes,
-        _select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+        display_directory_sizes=False,
+        cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -499,13 +499,14 @@ async def test_app_loads_directory_sizes_when_enabled() -> None:
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
         await _wait_for_table_cell(app, "4.2 KB", 0, 3)
-        await _wait_for_child_list_label(app, "88.0 KB")
 
         table = app.query_one("#current-pane-table", DataTable)
         child_list = app.query_one("#child-pane-list", ListView)
 
         assert str(table.get_cell_at((0, 3))) == "4.2 KB"
-        assert "88.0 KB" in str(child_list.children[0].query_one(Label).renderable)
+        # Child pane does not show directory sizes (Issue #187)
+        # Label should only contain the name, not the size
+        assert "api" in str(child_list.children[0].query_one(Label).renderable)
 
 
 @pytest.mark.asyncio
@@ -551,13 +552,14 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
         await _wait_for_table_cell(app, "4.2 KB", 0, 3)
-        await _wait_for_child_list_label(app, "88.0 KB")
 
         table = app.query_one("#current-pane-table", DataTable)
         child_list = app.query_one("#child-pane-list", ListView)
 
         assert str(table.get_cell_at((0, 3))) == "4.2 KB"
-        assert "88.0 KB" in str(child_list.children[0].query_one(Label).renderable)
+        # Child pane does not show directory sizes (Issue #187)
+        # Label should only contain the name, not the size
+        assert "api" in str(child_list.children[0].query_one(Label).renderable)
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -241,9 +241,12 @@ def test_select_pane_entries_show_directory_sizes_from_cache() -> None:
     current_entries = select_current_entries(state)
     child_entries = select_child_entries(state)
 
-    assert parent_entries[0].name_detail == "3.4 MB"
+    # Parent/Child panes do not show directory sizes (Issue #187)
+    assert parent_entries[0].name_detail is None
+    assert parent_entries[0].size_label == "-"
     assert current_entries[0].size_label == "calculating..."
-    assert child_entries[0].name_detail == "8.2 KB"
+    assert child_entries[0].name_detail is None
+    assert child_entries[0].size_label == "-"
 
 
 def test_select_current_summary_counts_selected_absolute_paths() -> None:


### PR DESCRIPTION
Fixes #187

Remove capacity/disk size display from Parent and Child directory panes to improve readability.

Changes:
- Parent pane: Always show  for size column
- Child pane: Always show  for size column
- Current pane: Capacity display is maintained (respects show_directory_sizes config)

Tests updated to reflect the new behavior.