### PR TITLE
Remove capacity display from Parent/Child directories (Issue #191)

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -84,8 +84,8 @@ def select_parent_entries(state: AppState) -> tuple[PaneEntry, ...]:
     return _select_side_pane_entries(
         visible_entries,
         state.directory_size_cache,
-        state.config.display.show_directory_sizes,
-        _select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+        display_directory_sizes=False,
+        cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
     )
 
 
@@ -120,8 +120,8 @@ def _select_child_entries_for_cursor(
     return _select_side_pane_entries(
         visible_entries,
         state.directory_size_cache,
-        state.config.display.show_directory_sizes,
-        _select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+        display_directory_sizes=False,
+        cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -499,13 +499,10 @@ async def test_app_loads_directory_sizes_when_enabled() -> None:
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
         await _wait_for_table_cell(app, "4.2 KB", 0, 3)
-        await _wait_for_child_list_label(app, "88.0 KB")
 
         table = app.query_one("#current-pane-table", DataTable)
-        child_list = app.query_one("#child-pane-list", ListView)
 
         assert str(table.get_cell_at((0, 3))) == "4.2 KB"
-        assert "88.0 KB" in str(child_list.children[0].query_one(Label).renderable)
 
 
 @pytest.mark.asyncio
@@ -551,13 +548,10 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
         await _wait_for_table_cell(app, "4.2 KB", 0, 3)
-        await _wait_for_child_list_label(app, "88.0 KB")
 
         table = app.query_one("#current-pane-table", DataTable)
-        child_list = app.query_one("#child-pane-list", ListView)
 
         assert str(table.get_cell_at((0, 3))) == "4.2 KB"
-        assert "88.0 KB" in str(child_list.children[0].query_one(Label).renderable)
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -241,9 +241,9 @@ def test_select_pane_entries_show_directory_sizes_from_cache() -> None:
     current_entries = select_current_entries(state)
     child_entries = select_child_entries(state)
 
-    assert parent_entries[0].name_detail == "3.4 MB"
+    assert parent_entries[0].name_detail is None
     assert current_entries[0].size_label == "calculating..."
-    assert child_entries[0].name_detail == "8.2 KB"
+    assert child_entries[0].name_detail is None
 
 
 def test_select_current_summary_counts_selected_absolute_paths() -> None:


### PR DESCRIPTION
## Summary

- PR #190 マージ時に revert が優先され、Parent/Child Directory の容量表示削除が main に反映されなかった問題を修正
- `select_parent_entries()` と `_select_child_entries_for_cursor()` で `display_directory_sizes=False` をハードコードし、設定に関わらずサイドペインでは容量を表示しない

## 変更内容

- `src/peneo/state/selectors.py`: 2箇所で `state.config.display.show_directory_sizes` → `display_directory_sizes=False`
- `tests/test_state_selectors.py`, `tests/test_app.py`: テストの期待値を更新

## Test plan

- [x] `uv run pytest` 全443テストパス
- [ ] マージ後、Parent/Child ペインでディレクトリ容量が表示されないことを確認

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)