### PR TITLE
Fix release workflow: use auto-generated notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,37 +59,12 @@ jobs:
             exit 1
           fi
 
-      - name: Generate release notes
-        run: |
-          cat << 'EOF' > release_notes.md
-          ## Peneo ${{ steps.version.outputs.version }}
-
-          Peneo は、GUI のエクスプローラーに近い感覚で使える Textual ベースの TUI ファイルマネージャです。
-
-          ### インストール方法
-
-          \`\`\`bash
-          uv tool install peneo==${{ steps.version.outputs.version }}
-          \`\`\`
-
-          または:
-
-          \`\`\`bash
-          pip install peneo==${{ steps.version.outputs.version }}
-          \`\`\`
-
-          ### 変更点
-
-          詳細は [CHANGELOG.md](https://github.com/devgamesan/peneo/blob/main/CHANGELOG.md) をご確認ください。
-          EOF
-          cat release_notes.md
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: Peneo ${{ steps.version.outputs.version }}
-          body_path: release_notes.md
+          generate_release_notes: true
           files: |
             dist/*
           draft: false


### PR DESCRIPTION
## Summary

- リリース本文からインストール方法・アプリ説明文・404のCHANGELOG.mdリンクを削除
- `generate_release_notes: true` により、マージ済みPRのリストを自動生成するように変更
- 次回リリース以降、PRタイトルとリンクが自動でリリース本文に掲載されます

## 変更イメージ (v0.1.1→v0.2.0 の場合)

```md
## What's Changed
* #170 Back/Forward directory navigation by @devgamesan in #186
* Issue #174 Add directory size display by @devgamesan in #179
* ...

**Full Changelog**: https://github.com/devgamesan/peneo/compare/v0.1.1...v0.2.0
```

## Test plan

- [x] `gh api repos/devgamesan/peneo/releases/generate-notes` で自動生成フォーマットを確認済み
- [ ] 次回タグpush時に正しくリリースが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)