### PR TITLE
Fix: Allow escaping split terminal with Esc key (issue #226)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -187,7 +187,8 @@ paste_conflict_action = "prompt"
 | フィルタ入力中 | `Enter` / `↓` | フィルタを適用して一覧操作へ戻る |
 | フィルタ入力中 | `Esc` | フィルタを解除する |
 | コマンドパレット表示中 | 文字入力 / `↑` / `↓` / `k` / `j` / `Enter` / `Esc` | コマンドを絞り込み、選択、実行、キャンセル |
-| split terminal フォーカス中 | 文字入力 / 矢印 / `Enter` / `Backspace` / `Esc` / `Tab` | 入力を埋め込みシェルへ送る |
+| split terminal フォーカス中 | 文字入力 / 矢印 / `Enter` / `Backspace` / `Tab` | 入力を埋め込みシェルへ送る |
+| split terminal フォーカス中 | `Esc` | 埋め込み split terminal を閉じる |
 | split terminal フォーカス中 | `Ctrl+T` | 埋め込み split terminal を閉じる |
 | split terminal フォーカス中 | `Ctrl+V` | クリップボードの内容をターミナルに貼り付け |
 | 名前入力中 | 文字入力 / `Backspace` / `Enter` / `Esc` | リネームや新規作成の入力値を編集、確定、キャンセル |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ The main keys are listed below.
 | Filter input | `Enter` / `↓` | Apply the filter and return to list navigation |
 | Filter input | `Esc` | Clear the filter |
 | Command palette | Text input / `↑` / `↓` / `k` / `j` / `Enter` / `Esc` | Filter, select, run, or cancel commands |
-| Split terminal focus | Text input / arrows / `Enter` / `Backspace` / `Esc` / `Tab` | Send input directly to the embedded shell |
+| Split terminal focus | Text input / arrows / `Enter` / `Backspace` / `Tab` | Send input directly to the embedded shell |
+| Split terminal focus | `Esc` | Close the embedded split terminal |
 | Split terminal focus | `Ctrl+T` | Close the embedded split terminal |
 | Split terminal focus | `Ctrl+V` | Paste clipboard contents into the terminal |
 | Name input | Text input / `Backspace` / `Enter` / `Esc` | Edit, confirm, or cancel rename/create input |

--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -319,6 +319,9 @@ def _dispatch_split_terminal_input(
     if command == "paste_from_clipboard":
         return _supported(PasteFromClipboardToTerminal())
 
+    if command == "terminal_escape":
+        return _supported(ToggleSplitTerminal())
+
     if key == "enter":
         return _supported(SendSplitTerminalInput("\r"))
 


### PR DESCRIPTION
## Summary
- split terminal で Esc キーを押してフォーカスを抜ける機能を追加

## Testing
- split terminal で Esc キーを押すと、terminal から脱出できることを確認
