### PR TITLE
[#232] Refine help bar and add history navigation to command palette

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -206,6 +206,8 @@ paste_conflict_action = "prompt"
 | `Find files` | 常に表示 | 再帰ファイル検索を開きます。 |
 | `Grep search` | 常に表示 | 再帰 grep 検索を開きます（`ripgrep` / `rg` が `PATH` 上に必要）。 |
 | `History search` | 常に表示 | ディレクトリ履歴リストを開き、選択したディレクトリへ移動します。 |
+| `Go back` | ディレクトリ履歴に戻り先があるとき | 履歴を一つ戻ります。 |
+| `Go forward` | ディレクトリ履歴に進み先があるとき | 履歴を一つ進みます。 |
 | `Go to path` | 常に表示 | 特定のパスへ移動するための入力を開きます。 |
 | `Go to home directory` | 常に表示 | ホームディレクトリへ移動します。 |
 | `Reload directory` | 常に表示 | 現在ディレクトリを再読み込みします。 |

--- a/README.md
+++ b/README.md
@@ -206,11 +206,12 @@ Less frequent actions are grouped in the command palette opened with `:`.
 | `Find files` | Always | Opens recursive file search. |
 | `Grep search` | Always | Opens recursive grep search (`ripgrep` / `rg` required on `PATH`). |
 | `History search` | Always | Opens directory history list and jump to a selected directory. |
+| `Go back` | Directory history has a previous entry | Moves to the previous directory in history. |
+| `Go forward` | Directory history has a forward entry | Moves to the next directory in history. |
 | `Go to path` | Always | Opens go-to-path input to navigate to a specific path. |
 | `Go to home directory` | Always | Navigates to the home directory. |
 | `Reload directory` | Always | Reloads the current directory. |
 | `Toggle split terminal` | Always | Opens or closes the embedded split terminal. |
-| `Paste to terminal` | Split terminal is visible and focused | Pastes clipboard contents into the active split terminal session. |
 | `Rename` | Exactly one target is selected or focused | Starts rename input for a single target. |
 | `Open in editor` | Exactly one file is selected or focused | Opens the focused file in a terminal editor, using `editor.command` -> `$EDITOR` -> built-in defaults. |
 | `Copy path` | At least one target is selected or focused | Copies the selected path list, or the focused path when nothing is selected, to the system clipboard. |

--- a/src/peneo/state/command_palette.py
+++ b/src/peneo/state/command_palette.py
@@ -129,6 +129,18 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
             enabled=True,
         ),
         CommandPaletteItem(
+            id="go_back",
+            label="Go back",
+            shortcut="Alt+Left",
+            enabled=bool(state.history.back),
+        ),
+        CommandPaletteItem(
+            id="go_forward",
+            label="Go forward",
+            shortcut="Alt+Right",
+            enabled=bool(state.history.forward),
+        ),
+        CommandPaletteItem(
             id="go_to_path",
             label="Go to path",
             shortcut="Ctrl+J",

--- a/src/peneo/state/reducer.py
+++ b/src/peneo/state/reducer.py
@@ -651,6 +651,10 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
             return reduce_app_state(next_state, BeginGrepSearch())
         if selected_item.id == "history_search":
             return reduce_app_state(next_state, BeginHistorySearch())
+        if selected_item.id == "go_back":
+            return reduce_app_state(next_state, GoBack())
+        if selected_item.id == "go_forward":
+            return reduce_app_state(next_state, GoForward())
         if selected_item.id == "go_to_path":
             return reduce_app_state(next_state, BeginGoToPath())
         if selected_item.id == "go_to_home_directory":

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -181,8 +181,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
     return HelpBarState(
         (
             "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit",
-            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term",
-            "alt+\u2190 back | alt+\u2192 fwd | ctrl+o history",
+            "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term",
         )
     )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1321,8 +1321,7 @@ async def test_app_displays_browsing_help_bar() -> None:
 
         assert str(help_bar.renderable) == (
             "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit\n"
-            "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term\n"
-            "alt+\u2190 back | alt+\u2192 fwd | ctrl+o history"
+            "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term"
         )
 
 
@@ -1372,7 +1371,7 @@ async def test_app_colon_shows_command_palette() -> None:
 
         assert app.app_state.ui_mode == "PALETTE"
         assert palette.display is True
-        assert "Show attributes" in str(items.renderable)
+        assert "Go back" in str(items.renderable)
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -563,7 +563,7 @@ def test_move_command_palette_cursor_clamps_to_visible_commands() -> None:
     next_state = _reduce_state(state, MoveCommandPaletteCursor(delta=20))
 
     assert next_state.command_palette is not None
-    assert next_state.command_palette.cursor_index == 17
+    assert next_state.command_palette.cursor_index == 19
 
 
 def test_set_command_palette_query_resets_cursor() -> None:
@@ -1015,6 +1015,39 @@ def test_submit_command_palette_begins_history_search() -> None:
     assert result.state.ui_mode == "PALETTE"
     assert result.state.command_palette is not None
     assert result.state.command_palette.source == "history"
+
+
+def test_submit_command_palette_goes_back() -> None:
+    state = replace(
+        _reduce_state(build_initial_app_state(), BeginCommandPalette()),
+        history=HistoryState(
+            back=("/home/tadashi/downloads",),
+            forward=(),
+        ),
+    )
+    state = _reduce_state(state, SetCommandPaletteQuery("go back"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.state.command_palette is None
+    assert len(result.effects) == 1
+    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
+    assert result.effects[0].path == "/home/tadashi/downloads"
+
+
+def test_submit_command_palette_go_forward_is_unavailable_without_history() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("go forward"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.notification == NotificationState(
+        level="warning",
+        message="Go forward is not available yet",
+    )
 
 
 def test_submit_command_palette_reloads_directory() -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -17,6 +17,7 @@ from peneo.state import (
     DirectorySizeCacheEntry,
     FileSearchResultState,
     GrepSearchResultState,
+    HistoryState,
     NameConflictState,
     NotificationState,
     PaneState,
@@ -511,13 +512,11 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
 
     assert help_state.lines == (
         "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit",
-        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term",
-        "alt+\u2190 back | alt+\u2192 fwd | ctrl+o history",
+        "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term",
     )
     assert help_state.text == (
         "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit\n"
-        "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename | ctrl+t term\n"
-        "alt+\u2190 back | alt+\u2192 fwd | ctrl+o history"
+        "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term"
     )
 
 
@@ -594,8 +593,38 @@ def test_select_command_palette_state_marks_selected_and_enabled_items() -> None
     ]
     assert palette_state.items[0].selected is True
     assert palette_state.items[0].enabled is True
-    assert any(item.label == "Show attributes" and item.enabled for item in palette_state.items)
-    assert any(item.label == "Rename" and item.enabled for item in palette_state.items)
+    assert any(item.label == "Go back" and not item.enabled for item in palette_state.items)
+    assert any(item.label == "Go forward" and not item.enabled for item in palette_state.items)
+
+
+def test_select_command_palette_state_shows_single_target_commands_when_filtered() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = replace(
+        state,
+        command_palette=replace(state.command_palette, query="rename"),
+    )
+
+    palette_state = select_command_palette_state(state)
+
+    assert palette_state is not None
+    assert [item.label for item in palette_state.items] == ["Rename"]
+    assert palette_state.items[0].enabled is True
+
+
+def test_select_command_palette_state_enables_history_navigation_items() -> None:
+    state = replace(
+        _reduce_state(build_initial_app_state(), BeginCommandPalette()),
+        history=HistoryState(
+            back=("/tmp/a",),
+            forward=("/tmp/b",),
+        ),
+    )
+
+    palette_state = select_command_palette_state(state)
+
+    assert palette_state is not None
+    assert any(item.label == "Go back" and item.enabled for item in palette_state.items)
+    assert any(item.label == "Go forward" and item.enabled for item in palette_state.items)
 
 
 def test_select_command_palette_state_filters_query() -> None:


### PR DESCRIPTION
## Summary
- remove low-frequency rename/history navigation shortcuts from the browsing help bar
- add `Go back` and `Go forward` to the command palette with history-aware enablement
- update README docs and related selector/reducer/app tests

## Testing
- `uv run python -m pytest tests/test_state_selectors.py tests/test_state_reducer.py tests/test_app.py`
- `uv run ruff check .`

## Related
- #232