### PR TITLE
Add command palette shortcut to help bar (issue #236)

### DIFF
--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -190,8 +190,8 @@ def build_dummy_shell_data() -> ThreePaneShellData:
         ),
         help=HelpBarState(
             (
-                "Enter open | e edit | / filter | : palette | q quit",
-                "Space select | y copy | x cut | p paste | s sort | d dirs | F2 rename",
+                "Enter open | e edit | / filter | : palette | ctrl+f find | ctrl+g grep | q quit",
+                "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term",
             )
         ),
         command_palette=None,

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -180,7 +180,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         return HelpBarState(("processing...",))
     return HelpBarState(
         (
-            "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit",
+            "Enter open | e edit | / filter | : palette | ctrl+f find | ctrl+g grep | q quit",
             "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term",
         )
     )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1320,7 +1320,7 @@ async def test_app_displays_browsing_help_bar() -> None:
         help_bar = app.query_one("#help-bar", HelpBar)
 
         assert str(help_bar.renderable) == (
-            "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit\n"
+            "Enter open | e edit | / filter | : palette | ctrl+f find | ctrl+g grep | q quit\n"
             "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term"
         )
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -511,11 +511,11 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     help_state = select_help_bar_state(state)
 
     assert help_state.lines == (
-        "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit",
+        "Enter open | e edit | / filter | : palette | ctrl+f find | ctrl+g grep | q quit",
         "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term",
     )
     assert help_state.text == (
-        "Enter open | e edit | / filter | ctrl+f find | ctrl+g grep | q quit\n"
+        "Enter open | e edit | / filter | : palette | ctrl+f find | ctrl+g grep | q quit\n"
         "Space select | y copy | x cut | p paste | s sort | d dirs | ctrl+t term"
     )
 


### PR DESCRIPTION
## Summary

- Add missing ": palette" shortcut to the default help bar in `select_help_bar_state()`
- Update `build_dummy_shell_data()` to match the actual help bar content
- Adjust test expectations accordingly

## Test plan

- [x] All existing tests pass (461 tests)
- [x] Help bar now correctly shows ": palette" shortcut in browse mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)