### PR TITLE
Issue #197: Parent Directoryの表示幅を少し縮める

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -118,18 +118,18 @@ class PeneoApp(App[None]):
 
     .pane {
         height: 1fr;
-        min-width: 24;
+        min-width: 20;
         border: round $surface;
         background: $boost;
     }
 
     .side-pane {
-        width: 1fr;
+        width: 0.9fr;
     }
 
     .main-pane {
-        width: 2fr;
-        min-width: 40;
+        width: 2.2fr;
+        min-width: 44;
     }
 
     .pane-title {

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -2,7 +2,9 @@
 
 from collections.abc import Sequence
 
+from rich.cells import cell_len
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import DataTable, Label, ListItem, ListView
@@ -12,11 +14,85 @@ from peneo.models.shell_data import CurrentSummaryState, InputBarState, PaneEntr
 from .input_bar import InputBar
 from .summary_bar import SummaryBar
 
+ELLIPSIS = "~"
+
+
+def build_entry_label(entry: PaneEntry) -> str:
+    """Return the complete entry label before width-based truncation."""
+
+    if entry.name_detail is None:
+        return entry.name
+    return f"{entry.name}  ({entry.name_detail})"
+
+
+def truncate_middle(text: str, max_width: int) -> str:
+    """Shorten text with a middle marker while preserving a useful suffix."""
+
+    if max_width <= 0:
+        return ""
+    if cell_len(text) <= max_width:
+        return text
+    if max_width == 1:
+        return ELLIPSIS
+    if max_width == 2:
+        return f"{ELLIPSIS}{_take_suffix_cells(text, 1)}"
+
+    remaining_width = max_width - cell_len(ELLIPSIS)
+    preferred_suffix = _preferred_suffix(text)
+    if preferred_suffix and cell_len(preferred_suffix) <= remaining_width - 1:
+        suffix_width = cell_len(preferred_suffix)
+    else:
+        suffix_width = max(1, remaining_width // 2)
+    prefix_width = remaining_width - suffix_width
+    if prefix_width <= 0:
+        prefix_width = 1
+        suffix_width = remaining_width - prefix_width
+
+    prefix = _take_prefix_cells(text, prefix_width)
+    suffix = _take_suffix_cells(text, suffix_width)
+    return f"{prefix}{ELLIPSIS}{suffix}"
+
+
+def _preferred_suffix(text: str) -> str:
+    dot_index = text.rfind(".")
+    if dot_index <= 0 or dot_index == len(text) - 1:
+        return ""
+    return text[dot_index:]
+
+
+def _take_prefix_cells(text: str, width: int) -> str:
+    if width <= 0:
+        return ""
+    collected: list[str] = []
+    used_width = 0
+    for character in text:
+        character_width = cell_len(character)
+        if used_width + character_width > width:
+            break
+        collected.append(character)
+        used_width += character_width
+    return "".join(collected)
+
+
+def _take_suffix_cells(text: str, width: int) -> str:
+    if width <= 0:
+        return ""
+    collected: list[str] = []
+    used_width = 0
+    for character in reversed(text):
+        character_width = cell_len(character)
+        if used_width + character_width > width:
+            break
+        collected.append(character)
+        used_width += character_width
+    return "".join(reversed(collected))
+
 
 class SidePane(Vertical):
     """Lightweight pane used for parent and child directory listings."""
 
     CUT_STYLE = "bright_black dim"
+    ENTRY_HORIZONTAL_PADDING = 2
 
     def __init__(
         self,
@@ -29,6 +105,7 @@ class SidePane(Vertical):
         super().__init__(id=id, classes=classes)
         self._title = title
         self._entries = tuple(entries)
+        self._last_render_width = 0
 
     @property
     def list_view_id(self) -> str | None:
@@ -38,12 +115,18 @@ class SidePane(Vertical):
     def compose(self) -> ComposeResult:
         yield Label(self._title, classes="pane-title")
         list_view = ListView(
-            *self._build_items(self._entries),
+            *self._build_items(self._entries, 0),
             id=self.list_view_id,
             classes="pane-list",
         )
         list_view.can_focus = False
         yield list_view
+
+    def on_mount(self) -> None:
+        self.call_after_refresh(self._refresh_rendered_labels)
+
+    def on_resize(self, _event: events.Resize) -> None:
+        self._refresh_rendered_labels()
 
     async def set_entries(self, entries: Sequence[PaneEntry]) -> None:
         """Replace the rendered entries without remounting the pane."""
@@ -55,35 +138,65 @@ class SidePane(Vertical):
         self._entries = next_entries
         list_view = self.query_one(ListView)
         await list_view.clear()
-        items = self._build_items(self._entries)
+        items = self._build_items(self._entries, self._entry_width(list_view))
         if items:
             await list_view.extend(items)
+        self._last_render_width = self._entry_width(list_view)
 
-    @staticmethod
-    def _build_items(entries: Sequence[PaneEntry]) -> tuple[ListItem, ...]:
+    def _refresh_rendered_labels(self) -> None:
+        list_view = self.query_one(ListView)
+        render_width = self._entry_width(list_view)
+        if render_width <= 0 or render_width == self._last_render_width:
+            return
+        for item, entry in zip(list_view.children, self._entries, strict=False):
+            item.query_one(Label).update(self._render_label(entry, render_width))
+        self._last_render_width = render_width
+
+    @classmethod
+    def _build_items(cls, entries: Sequence[PaneEntry], render_width: int) -> tuple[ListItem, ...]:
         return tuple(
             ListItem(
-                Label(SidePane._render_label(entry), classes="pane-entry-label"),
+                Label(cls._render_label(entry, render_width), classes="pane-entry-label"),
                 classes="pane-entry",
             )
             for entry in entries
         )
 
     @classmethod
-    def _render_label(cls, entry: PaneEntry) -> Text:
-        label = entry.name if entry.name_detail is None else f"{entry.name}  ({entry.name_detail})"
+    def _render_label(cls, entry: PaneEntry, render_width: int = 0) -> Text:
+        label = build_entry_label(entry)
+        if render_width > 0:
+            label = truncate_middle(label, render_width)
         if not entry.cut:
             return Text(label)
         return Text(label, style=cls.CUT_STYLE)
+
+    def _entry_width(self, list_view: ListView) -> int:
+        return max(0, list_view.size.width - self.ENTRY_HORIZONTAL_PADDING)
 
 
 class MainPane(Vertical):
     """Center pane with detailed columns for the current directory."""
 
     COLUMN_LABELS = ("Sel", "Type", "Name", "Size", "Modified")
+    COLUMN_KEYS = ("sel", "type", "name", "size", "modified")
     SELECTED_STYLE = "bold green"
     CUT_STYLE = "bright_black dim"
     SELECTED_CUT_STYLE = "bold bright_black"
+    NAME_MIN_WIDTH = 3
+    FIXED_COLUMN_PREFERRED_WIDTHS = {
+        "sel": 1,
+        "type": 4,
+        "size": 13,
+        "modified": 16,
+    }
+    FIXED_COLUMN_MIN_WIDTHS = {
+        "sel": 1,
+        "type": 3,
+        "size": 4,
+        "modified": 5,
+    }
+    FIXED_COLUMN_SHRINK_ORDER = ("modified", "size", "type", "sel")
 
     def __init__(
         self,
@@ -102,6 +215,7 @@ class MainPane(Vertical):
         self._summary = summary
         self._cursor_index = cursor_index
         self._context_input = context_input
+        self._last_table_width = 0
 
     @property
     def table_id(self) -> str | None:
@@ -132,8 +246,11 @@ class MainPane(Vertical):
         table.cursor_type = "row"
         table.show_cursor = True
         table.zebra_stripes = True
-        table.add_columns(*self.COLUMN_LABELS)
-        self.set_entries(self._entries, self._cursor_index)
+        self._rebuild_table(table)
+        self.call_after_refresh(self._refresh_table_width)
+
+    def on_resize(self, _event: events.Resize) -> None:
+        self._refresh_table_width()
 
     def set_entries(
         self,
@@ -152,15 +269,7 @@ class MainPane(Vertical):
         self._cursor_index = cursor_index
         table = self.query_one(DataTable)
         if entries_changed:
-            table.clear()
-            for entry in self._entries:
-                table.add_row(
-                    self._render_cell(entry.selection_marker, entry.selected, entry.cut),
-                    self._render_cell(entry.kind_label, entry.selected, entry.cut),
-                    self._render_cell(self._render_name(entry), entry.selected, entry.cut),
-                    self._render_cell(entry.size_label, entry.selected, entry.cut),
-                    self._render_cell(entry.modified_label, entry.selected, entry.cut),
-                )
+            self._rebuild_table(table)
         if entries_changed or cursor_changed:
             self._sync_cursor(table)
 
@@ -188,6 +297,78 @@ class MainPane(Vertical):
         clamped_index = max(0, min(len(self._entries) - 1, self._cursor_index))
         table.move_cursor(row=clamped_index, animate=False, scroll=True)
 
+    def _refresh_table_width(self) -> None:
+        table = self.query_one(DataTable)
+        table_width = table.size.width
+        if table_width <= 0 or table_width == self._last_table_width:
+            return
+        self._rebuild_table(table)
+
+    def _rebuild_table(self, table: DataTable) -> None:
+        column_widths = self._allocate_column_widths(table)
+        table.clear(columns=True)
+        table.add_column(
+            self.COLUMN_LABELS[0], width=column_widths["sel"], key=self.COLUMN_KEYS[0]
+        )
+        table.add_column(
+            self.COLUMN_LABELS[1], width=column_widths["type"], key=self.COLUMN_KEYS[1]
+        )
+        table.add_column(
+            self.COLUMN_LABELS[2], width=column_widths["name"], key=self.COLUMN_KEYS[2]
+        )
+        table.add_column(
+            self.COLUMN_LABELS[3], width=column_widths["size"], key=self.COLUMN_KEYS[3]
+        )
+        table.add_column(
+            self.COLUMN_LABELS[4],
+            width=column_widths["modified"],
+            key=self.COLUMN_KEYS[4],
+        )
+        for entry in self._entries:
+            table.add_row(
+                self._render_cell(entry.selection_marker, entry.selected, entry.cut),
+                self._render_cell(entry.kind_label, entry.selected, entry.cut),
+                self._render_cell(
+                    truncate_middle(build_entry_label(entry), column_widths["name"]),
+                    entry.selected,
+                    entry.cut,
+                ),
+                self._render_cell(entry.size_label, entry.selected, entry.cut),
+                self._render_cell(entry.modified_label, entry.selected, entry.cut),
+            )
+        self._last_table_width = table.size.width
+
+    @classmethod
+    def _allocate_column_widths(cls, table: DataTable) -> dict[str, int]:
+        column_count = len(cls.COLUMN_LABELS)
+        padding_width = column_count * table.cell_padding * 2
+        available_content_width = max(1, table.size.width - padding_width)
+
+        fixed_widths = dict(cls.FIXED_COLUMN_PREFERRED_WIDTHS)
+        fixed_budget = max(0, available_content_width - cls.NAME_MIN_WIDTH)
+        overflow = sum(fixed_widths.values()) - fixed_budget
+        for column_key in cls.FIXED_COLUMN_SHRINK_ORDER:
+            if overflow <= 0:
+                break
+            reducible = fixed_widths[column_key] - cls.FIXED_COLUMN_MIN_WIDTHS[column_key]
+            if reducible <= 0:
+                continue
+            shrink_by = min(reducible, overflow)
+            fixed_widths[column_key] -= shrink_by
+            overflow -= shrink_by
+
+        if sum(fixed_widths.values()) + cls.NAME_MIN_WIDTH > available_content_width:
+            fixed_widths = dict(cls.FIXED_COLUMN_MIN_WIDTHS)
+
+        name_width = max(1, available_content_width - sum(fixed_widths.values()))
+        return {
+            "sel": fixed_widths["sel"],
+            "type": fixed_widths["type"],
+            "name": name_width,
+            "size": fixed_widths["size"],
+            "modified": fixed_widths["modified"],
+        }
+
     @classmethod
     def _render_cell(cls, value: str, selected: bool, cut: bool) -> Text:
         if cut and selected:
@@ -197,9 +378,3 @@ class MainPane(Vertical):
         if not selected:
             return Text(value)
         return Text(value, style=cls.SELECTED_STYLE)
-
-    @staticmethod
-    def _render_name(entry: PaneEntry) -> str:
-        if entry.name_detail is None:
-            return entry.name
-        return f"{entry.name}  ({entry.name_detail})"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -656,6 +656,73 @@ async def test_app_can_start_in_narrow_headless_mode() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_truncates_long_labels_in_all_panes_when_narrow() -> None:
+    path = "/tmp/peneo-narrow-truncate"
+    current_entries = (
+        DirectoryEntryState(
+            f"{path}/reducer_common_directory",
+            "reducer_common_directory",
+            "dir",
+        ),
+        DirectoryEntryState(f"{path}/reducer_common.py", "reducer_common.py", "file"),
+    )
+    child_entries = (
+        DirectoryEntryState(
+            f"{path}/reducer_common_directory/child_reducer_entry.py",
+            "child_reducer_entry.py",
+            "file",
+        ),
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                    parent_pane=PaneState(
+                        directory_path="/tmp",
+                        entries=(
+                            DirectoryEntryState(
+                                path,
+                                "parent_directory_with_long_name_that_keeps_going.py",
+                                "dir",
+                            ),
+                            DirectoryEntryState("/tmp/sibling", "another_parent_entry.py", "file"),
+                        ),
+                        cursor_path=path,
+                    ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=current_entries,
+                    cursor_path=current_entries[0].path,
+                ),
+                child_pane=PaneState(
+                    directory_path=current_entries[0].path,
+                    entries=child_entries,
+                ),
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test(size=(100, 20)):
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 2)
+        await asyncio.sleep(0.05)
+
+        parent_list = app.query_one("#parent-pane-list", ListView)
+        child_list = app.query_one("#child-pane-list", ListView)
+        current_table = app.query_one("#current-pane-table", DataTable)
+
+        parent_label = str(parent_list.children[0].query_one(Label).renderable)
+        child_label = str(child_list.children[0].query_one(Label).renderable)
+        current_name = current_table.get_row_at(0)[2]
+
+        assert "~" in parent_label
+        assert "~" in child_label
+        assert isinstance(current_name, Text)
+        assert "~" in current_name.plain
+
+
+@pytest.mark.asyncio
 async def test_app_tab_keeps_focus_on_current_pane() -> None:
     path = "/tmp/peneo-tab-focus"
     loader = FakeBrowserSnapshotLoader(

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -1,0 +1,31 @@
+from peneo.models import PaneEntry
+from peneo.ui.panes import build_entry_label, truncate_middle
+
+
+def test_truncate_middle_keeps_text_when_width_is_sufficient() -> None:
+    assert truncate_middle("README.md", 9) == "README.md"
+
+
+def test_truncate_middle_uses_middle_marker_for_long_name() -> None:
+    rendered = truncate_middle("very-long-directory-name", 10)
+
+    assert rendered == "very-~name"
+    assert "~" in rendered
+
+
+def test_truncate_middle_preserves_file_extension_when_possible() -> None:
+    assert truncate_middle("reducer_common.py", 11) == "reducer~.py"
+
+
+def test_truncate_middle_handles_extremely_narrow_widths() -> None:
+    assert truncate_middle("README.md", 1) == "~"
+    assert truncate_middle("README.md", 2) == "~d"
+
+
+def test_build_entry_label_truncates_full_name_detail_string() -> None:
+    entry = PaneEntry("archive.tar.gz", "file", name_detail="2.1 KB")
+
+    rendered = truncate_middle(build_entry_label(entry), 15)
+
+    assert "~" in rendered
+    assert rendered.endswith("1 KB)")


### PR DESCRIPTION
## Summary
- Parent / Child pane を少し狭めて Current pane の表示領域を優先するように調整
- Parent / Current / Child すべてのペインで長い名前を `~` を使った中間省略表示に統一
- リサイズ時にも省略表示が追従するようにし、UI テストと純粋関数テストを追加

## Testing
- `uv run pytest tests/test_app.py tests/test_ui_panes.py`
- `uv run ruff check src/peneo/app.py src/peneo/ui/panes.py tests/test_app.py tests/test_ui_panes.py`

Closes #197