### PR TITLE
[#242] Add runtime and input dispatcher regression tests

### DIFF
--- a/tests/test_app_runtime.py
+++ b/tests/test_app_runtime.py
@@ -1,5 +1,25 @@
-from peneo.app_runtime import complete_worker_actions, failed_worker_actions
-from peneo.models import AppConfig
+import threading
+from contextlib import nullcontext
+from dataclasses import dataclass, field, replace
+from types import SimpleNamespace
+from typing import Any
+
+from textual.app import SuspendNotSupported
+
+from peneo.app_runtime import (
+    cancel_pending_directory_size,
+    cancel_pending_file_search,
+    cancel_pending_grep_search,
+    clear_effect_tracking,
+    complete_worker_actions,
+    failed_worker_actions,
+    run_foreground_external_launch,
+    start_file_search_worker,
+    start_grep_search_worker,
+    start_split_terminal,
+    write_split_terminal_input,
+)
+from peneo.models import AppConfig, ExternalLaunchRequest
 from peneo.services import InvalidFileSearchQueryError
 from peneo.state import (
     BrowserSnapshot,
@@ -7,13 +27,93 @@ from peneo.state import (
     ConfigSaveCompleted,
     DirectoryEntryState,
     DirectorySizesLoaded,
+    ExternalLaunchFailed,
     FileSearchFailed,
     LoadBrowserSnapshotEffect,
     PaneState,
     RunConfigSaveEffect,
     RunDirectorySizeEffect,
+    RunExternalLaunchEffect,
     RunFileSearchEffect,
+    RunGrepSearchEffect,
+    SplitTerminalStartFailed,
+    StartSplitTerminalEffect,
+    WriteSplitTerminalInputEffect,
+    build_initial_app_state,
 )
+
+
+@dataclass
+class _RecordingApp:
+    _app_state: Any = field(default_factory=build_initial_app_state)
+    _pending_workers: dict[str, object] = field(default_factory=dict)
+    _file_search_timer: Any = None
+    _grep_search_timer: Any = None
+    _active_file_search_cancel_event: threading.Event | None = None
+    _active_file_search_request_id: int | None = None
+    _active_grep_search_cancel_event: threading.Event | None = None
+    _active_grep_search_request_id: int | None = None
+    _active_directory_size_cancel_event: threading.Event | None = None
+    _active_directory_size_request_id: int | None = None
+    _external_launch_service: Any = field(
+        default_factory=lambda: SimpleNamespace(execute=lambda request: None)
+    )
+    _split_terminal_service: Any = field(
+        default_factory=lambda: SimpleNamespace(start=lambda cwd, **kwargs: None)
+    )
+    _split_terminal_session: Any = None
+    suspend_error: BaseException | None = None
+    run_worker_calls: list[dict[str, Any]] = field(default_factory=list)
+    call_next_calls: list[tuple[Any, tuple[Any, ...]]] = field(default_factory=list)
+    refresh_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def run_worker(self, worker_fn: Any, **kwargs: Any) -> Any:
+        self.run_worker_calls.append(kwargs)
+        return SimpleNamespace(name=kwargs["name"])
+
+    def call_next(self, callback: Any, *args: Any) -> None:
+        self.call_next_calls.append((callback, args))
+
+    def dispatch_actions(self, actions: tuple[Any, ...]) -> None:
+        return None
+
+    def refresh(self, **kwargs: Any) -> None:
+        self.refresh_calls.append(kwargs)
+
+    def suspend(self) -> Any:
+        if self.suspend_error is not None:
+            raise self.suspend_error
+        return nullcontext()
+
+
+@dataclass(frozen=True)
+class _FailingExternalLaunchService:
+    message: str
+
+    def execute(self, request: ExternalLaunchRequest) -> None:
+        raise OSError(self.message)
+
+
+@dataclass(frozen=True)
+class _FailingSplitTerminalService:
+    message: str
+
+    def start(self, cwd: str, **kwargs: Any) -> None:
+        raise OSError(self.message)
+
+
+@dataclass(frozen=True)
+class _FailingSplitTerminalSession:
+    message: str
+
+    def write(self, data: str) -> None:
+        raise OSError(self.message)
+
+
+def _scheduled_actions(app: _RecordingApp) -> tuple[Any, ...]:
+    callback, args = app.call_next_calls[-1]
+    assert callback == app.dispatch_actions
+    return args[0]
 
 
 def test_complete_worker_actions_maps_browser_snapshot_load() -> None:
@@ -106,5 +206,195 @@ def test_failed_worker_actions_marks_invalid_file_search_queries() -> None:
             query="re:[",
             message="unterminated character set",
             invalid_query=True,
+        ),
+    )
+
+
+def test_start_file_search_worker_ignores_stale_request() -> None:
+    app = _RecordingApp(
+        _app_state=replace(build_initial_app_state(), pending_file_search_request_id=99),
+    )
+
+    start_file_search_worker(
+        app,
+        RunFileSearchEffect(
+            request_id=7,
+            root_path="/tmp/project",
+            query="docs",
+            show_hidden=False,
+        ),
+    )
+
+    assert app.run_worker_calls == []
+    assert app._pending_workers == {}
+    assert app._active_file_search_cancel_event is None
+    assert app._active_file_search_request_id is None
+
+
+def test_start_grep_search_worker_ignores_stale_request() -> None:
+    app = _RecordingApp(
+        _app_state=replace(build_initial_app_state(), pending_grep_search_request_id=99),
+    )
+
+    start_grep_search_worker(
+        app,
+        RunGrepSearchEffect(
+            request_id=7,
+            root_path="/tmp/project",
+            query="TODO",
+            show_hidden=False,
+        ),
+    )
+
+    assert app.run_worker_calls == []
+    assert app._pending_workers == {}
+    assert app._active_grep_search_cancel_event is None
+    assert app._active_grep_search_request_id is None
+
+
+def test_cancel_pending_runtime_helpers_clear_active_tracking() -> None:
+    app = _RecordingApp()
+    file_search_cancel = threading.Event()
+    grep_search_cancel = threading.Event()
+    directory_size_cancel = threading.Event()
+    app._active_file_search_cancel_event = file_search_cancel
+    app._active_file_search_request_id = 3
+    app._active_grep_search_cancel_event = grep_search_cancel
+    app._active_grep_search_request_id = 4
+    app._active_directory_size_cancel_event = directory_size_cancel
+    app._active_directory_size_request_id = 5
+
+    cancel_pending_file_search(app)
+    cancel_pending_grep_search(app)
+    cancel_pending_directory_size(app)
+
+    assert file_search_cancel.is_set()
+    assert app._active_file_search_cancel_event is None
+    assert app._active_file_search_request_id is None
+    assert grep_search_cancel.is_set()
+    assert app._active_grep_search_cancel_event is None
+    assert app._active_grep_search_request_id is None
+    assert directory_size_cancel.is_set()
+    assert app._active_directory_size_cancel_event is None
+    assert app._active_directory_size_request_id is None
+
+
+def test_clear_effect_tracking_only_clears_matching_request() -> None:
+    app = _RecordingApp()
+    file_search_cancel = threading.Event()
+    grep_search_cancel = threading.Event()
+    directory_size_cancel = threading.Event()
+    app._active_file_search_cancel_event = file_search_cancel
+    app._active_file_search_request_id = 3
+    app._active_grep_search_cancel_event = grep_search_cancel
+    app._active_grep_search_request_id = 4
+    app._active_directory_size_cancel_event = directory_size_cancel
+    app._active_directory_size_request_id = 5
+
+    clear_effect_tracking(
+        app,
+        RunFileSearchEffect(
+            request_id=99,
+            root_path="/tmp/project",
+            query="docs",
+            show_hidden=False,
+        ),
+    )
+    clear_effect_tracking(
+        app,
+        RunFileSearchEffect(
+            request_id=3,
+            root_path="/tmp/project",
+            query="docs",
+            show_hidden=False,
+        ),
+    )
+
+    assert app._active_file_search_cancel_event is None
+    assert app._active_file_search_request_id is None
+    assert app._active_grep_search_cancel_event is grep_search_cancel
+    assert app._active_grep_search_request_id == 4
+    assert app._active_directory_size_cancel_event is directory_size_cancel
+    assert app._active_directory_size_request_id == 5
+
+
+def test_run_foreground_external_launch_maps_suspend_failures() -> None:
+    request = ExternalLaunchRequest(kind="open_editor", path="/tmp/project/README.md")
+    app = _RecordingApp(suspend_error=SuspendNotSupported("suspend unavailable"))
+
+    run_foreground_external_launch(
+        app,
+        RunExternalLaunchEffect(request_id=8, request=request),
+    )
+
+    assert app.refresh_calls == []
+    assert _scheduled_actions(app) == (
+        ExternalLaunchFailed(
+            request_id=8,
+            request=request,
+            message="suspend unavailable",
+        ),
+    )
+
+
+def test_run_foreground_external_launch_maps_os_errors_to_failure_actions() -> None:
+    request = ExternalLaunchRequest(kind="open_editor", path="/tmp/project/README.md")
+    app = _RecordingApp(
+        _external_launch_service=_FailingExternalLaunchService("editor failed"),
+    )
+
+    run_foreground_external_launch(
+        app,
+        RunExternalLaunchEffect(request_id=8, request=request),
+    )
+
+    assert app.refresh_calls == [{"repaint": True, "layout": True}]
+    assert _scheduled_actions(app) == (
+        ExternalLaunchFailed(
+            request_id=8,
+            request=request,
+            message="editor failed",
+        ),
+    )
+
+
+def test_start_split_terminal_maps_start_failures() -> None:
+    app = _RecordingApp(
+        _split_terminal_service=_FailingSplitTerminalService("pty unavailable"),
+    )
+
+    start_split_terminal(
+        app,
+        StartSplitTerminalEffect(session_id=4, cwd="/tmp/project"),
+    )
+
+    assert app._split_terminal_session is None
+    assert _scheduled_actions(app) == (
+        SplitTerminalStartFailed(
+            session_id=4,
+            message="pty unavailable",
+        ),
+    )
+
+
+def test_write_split_terminal_input_maps_write_failures() -> None:
+    state = build_initial_app_state()
+    app = _RecordingApp(
+        _app_state=replace(
+            state,
+            split_terminal=replace(state.split_terminal, session_id=4),
+        ),
+        _split_terminal_session=_FailingSplitTerminalSession("write failed"),
+    )
+
+    write_split_terminal_input(
+        app,
+        WriteSplitTerminalInputEffect(session_id=4, data="ls"),
+    )
+
+    assert _scheduled_actions(app) == (
+        SplitTerminalStartFailed(
+            session_id=4,
+            message="write failed",
         ),
     )

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -58,6 +58,19 @@ from peneo.state import (
 )
 
 
+def _focused_split_terminal_state():
+    state = build_initial_app_state()
+    return replace(
+        state,
+        split_terminal=replace(
+            state.split_terminal,
+            visible=True,
+            status="running",
+            focus_target="terminal",
+        ),
+    )
+
+
 def test_browsing_down_dispatches_move_cursor() -> None:
     state = build_initial_app_state()
 
@@ -176,6 +189,14 @@ def test_browsing_q_dispatches_exit_current_path() -> None:
     actions = dispatch_key_input(state, key="q", character="q")
 
     assert actions == (SetNotification(None), ExitCurrentPath())
+
+
+def test_browsing_uppercase_printable_key_is_ignored() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="T", character="T")
+
+    assert actions == ()
 
 
 def test_browsing_ctrl_f_begins_file_search() -> None:
@@ -432,6 +453,14 @@ def test_palette_printable_key_updates_query() -> None:
     assert actions == (SetNotification(None), SetCommandPaletteQuery("f"))
 
 
+def test_palette_space_updates_query() -> None:
+    state = replace(build_initial_app_state(), ui_mode="PALETTE")
+
+    actions = dispatch_key_input(state, key="space", character=" ")
+
+    assert actions == (SetNotification(None), SetCommandPaletteQuery(" "))
+
+
 def test_palette_pageup_moves_cursor_by_page() -> None:
     state = replace(build_initial_app_state(), ui_mode="PALETTE")
 
@@ -448,16 +477,23 @@ def test_palette_pagedown_moves_cursor_by_page() -> None:
     assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=7))
 
 
-def test_split_terminal_focus_sends_printable_input() -> None:
-    state = replace(
-        build_initial_app_state(),
-        split_terminal=replace(
-            build_initial_app_state().split_terminal,
-            visible=True,
-            status="running",
-            focus_target="terminal",
+def test_palette_unbound_key_shows_guidance() -> None:
+    state = replace(build_initial_app_state(), ui_mode="PALETTE")
+
+    actions = dispatch_key_input(state, key="delete")
+
+    assert actions == (
+        SetNotification(
+            NotificationState(
+                level="warning",
+                message="Use arrows, type to filter, Enter to run, or Esc to cancel",
+            )
         ),
     )
+
+
+def test_split_terminal_focus_sends_printable_input() -> None:
+    state = _focused_split_terminal_state()
 
     actions = dispatch_key_input(state, key="a", character="a")
 
@@ -465,15 +501,7 @@ def test_split_terminal_focus_sends_printable_input() -> None:
 
 
 def test_split_terminal_focus_sends_tab_for_completion() -> None:
-    state = replace(
-        build_initial_app_state(),
-        split_terminal=replace(
-            build_initial_app_state().split_terminal,
-            visible=True,
-            status="running",
-            focus_target="terminal",
-        ),
-    )
+    state = _focused_split_terminal_state()
 
     actions = dispatch_key_input(state, key="tab")
 
@@ -481,15 +509,7 @@ def test_split_terminal_focus_sends_tab_for_completion() -> None:
 
 
 def test_split_terminal_focus_sends_delete_sequence() -> None:
-    state = replace(
-        build_initial_app_state(),
-        split_terminal=replace(
-            build_initial_app_state().split_terminal,
-            visible=True,
-            status="running",
-            focus_target="terminal",
-        ),
-    )
+    state = _focused_split_terminal_state()
 
     actions = dispatch_key_input(state, key="delete")
 
@@ -497,15 +517,7 @@ def test_split_terminal_focus_sends_delete_sequence() -> None:
 
 
 def test_split_terminal_focus_sends_navigation_sequences() -> None:
-    state = replace(
-        build_initial_app_state(),
-        split_terminal=replace(
-            build_initial_app_state().split_terminal,
-            visible=True,
-            status="running",
-            focus_target="terminal",
-        ),
-    )
+    state = _focused_split_terminal_state()
 
     assert dispatch_key_input(state, key="home") == (
         SetNotification(None),
@@ -525,16 +537,16 @@ def test_split_terminal_focus_sends_navigation_sequences() -> None:
     )
 
 
+def test_split_terminal_focus_takes_priority_over_browsing_navigation() -> None:
+    state = _focused_split_terminal_state()
+
+    actions = dispatch_key_input(state, key="left")
+
+    assert actions == (SetNotification(None), SendSplitTerminalInput("\x1b[D"))
+
+
 def test_split_terminal_focus_sends_ctrl_shortcuts_except_ctrl_t() -> None:
-    state = replace(
-        build_initial_app_state(),
-        split_terminal=replace(
-            build_initial_app_state().split_terminal,
-            visible=True,
-            status="running",
-            focus_target="terminal",
-        ),
-    )
+    state = _focused_split_terminal_state()
 
     assert dispatch_key_input(state, key="ctrl+d") == (
         SetNotification(None),
@@ -788,6 +800,31 @@ def test_config_escape_closes_editor() -> None:
     assert actions == (SetNotification(None), DismissConfigEditor())
 
 
+def test_config_unbound_key_shows_guidance() -> None:
+    state = replace(
+        build_initial_app_state(config_path="/tmp/peneo/config.toml"),
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/peneo/config.toml",
+            draft=build_initial_app_state().config,
+        ),
+    )
+
+    actions = dispatch_key_input(state, key="x", character="x")
+
+    assert actions == (
+        SetNotification(
+            NotificationState(
+                level="warning",
+                message=(
+                    "Use arrows to change values, s to save, "
+                    "e to edit the file, or Esc to close"
+                ),
+            )
+        ),
+    )
+
+
 def test_confirm_o_selects_overwrite_resolution() -> None:
     state = replace(build_initial_app_state(), ui_mode="CONFIRM")
 
@@ -880,6 +917,23 @@ def test_pending_input_escape_cancels() -> None:
     actions = dispatch_key_input(state, key="escape")
 
     assert actions == (SetNotification(None), CancelPendingInput())
+
+
+def test_pending_input_unbound_key_shows_guidance() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        ui_mode="RENAME",
+        pending_input=PendingInputState(prompt="Rename: ", value="docs"),
+    )
+
+    actions = dispatch_key_input(state, key="left")
+
+    assert actions == (
+        SetNotification(
+            NotificationState(level="warning", message="Use Enter to apply or Esc to cancel")
+        ),
+    )
 
 
 def test_busy_key_shows_warning_message() -> None:


### PR DESCRIPTION
## Summary
- add runtime regression tests for stale request handling, cancel tracking cleanup, external launch failures, and split terminal failures
- add input dispatcher regression tests for mode-specific printable input handling and guidance boundaries
- keep production behavior unchanged while reducing duplication in split terminal dispatcher tests

## Why
- strengthen the test safety net requested in #242 before follow-up refactoring under #241
- make runtime and dispatcher edge cases fail loudly in tests instead of being inferred from reducer behavior alone

## Validation
- `uv run ruff check tests/test_app_runtime.py tests/test_input_dispatch.py`
- `uv run pytest tests/test_input_dispatch.py tests/test_app_runtime.py tests/test_state_reducer.py -q`

Refs #242
