### PR TITLE
[#245] Align input dispatcher responsibilities

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -411,21 +411,7 @@ class PeneoApp(App[None]):
     async def action_dispatch_bound_key(self, key: str) -> None:
         """Handle priority key bindings through the central dispatcher."""
 
-        character = None
-        if self._app_state.ui_mode in {"FILTER", "RENAME", "CREATE", "PALETTE"} or (
-            self._app_state.ui_mode == "BROWSING"
-            and self._app_state.split_terminal.visible
-            and self._app_state.split_terminal.focus_target == "terminal"
-        ):
-            if key == "space":
-                if self._app_state.ui_mode in {"RENAME", "CREATE", "PALETTE"} or (
-                    self._app_state.ui_mode == "BROWSING"
-                    and self._app_state.split_terminal.focus_target == "terminal"
-                ):
-                    character = " "
-            elif len(key) == 1 and key.isprintable():
-                character = key
-        await self._dispatch_key_press(key, character=character)
+        await self._dispatch_key_press(key)
 
     def _build_body(self, shell: ThreePaneShellData) -> Vertical:
         return build_body(shell)

--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -152,6 +152,8 @@ def dispatch_key_input(
 ) -> DispatchedActions:
     """Return reducer actions for the current mode and key press."""
 
+    character = _normalize_input_character(state, key=key, character=character)
+
     if _terminal_has_focus(state):
         return _dispatch_split_terminal_input(key=key, character=character)
 
@@ -177,6 +179,41 @@ def dispatch_key_input(
         return _dispatch_pending_input(state, key=key, character=character)
 
     return _dispatch_browsing_input(state, key)
+
+
+def _normalize_input_character(
+    state: AppState,
+    *,
+    key: str,
+    character: str | None,
+) -> str | None:
+    resolved_character = _resolve_printable_character(key=key, character=character)
+    if resolved_character is None:
+        return None
+
+    if _terminal_has_focus(state):
+        return resolved_character
+
+    if state.ui_mode in {"PALETTE", "RENAME", "CREATE"}:
+        return resolved_character
+
+    if state.ui_mode == "FILTER" and not resolved_character.isspace():
+        return resolved_character
+
+    return None
+
+
+def _resolve_printable_character(*, key: str, character: str | None) -> str | None:
+    if character is not None and character.isprintable():
+        return character
+
+    if key == "space":
+        return " "
+
+    if len(key) == 1 and key.isprintable():
+        return key
+
+    return None
 
 
 def _dispatch_browsing_input(state: AppState, key: str) -> DispatchedActions:
@@ -381,9 +418,6 @@ def _terminal_control_character(key: str) -> str | None:
 
     letter = suffix.lower()
     return chr(ord(letter) - ord("a") + 1)
-
-
-
 
 def _dispatch_command_palette_input(
     state: AppState,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2734,6 +2734,35 @@ async def test_app_filter_mode_accepts_printable_bound_keys() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_action_dispatch_bound_key_uses_dispatcher_character_rules() -> None:
+    path = "/tmp/peneo-palette-bound-space"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (DirectoryEntryState(f"{path}/docs", "docs", "dir"),),
+                child_path=f"{path}/docs",
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press(":")
+        await app.action_dispatch_bound_key("space")
+        await app.action_dispatch_bound_key("y")
+        await asyncio.sleep(0.05)
+
+        palette = await _wait_for_command_palette(app)
+
+        assert app.app_state.ui_mode == "PALETTE"
+        assert app.app_state.command_palette is not None
+        assert app.app_state.command_palette.query == " y"
+        assert palette.display is True
+
+
+@pytest.mark.asyncio
 async def test_app_confirmed_filter_stays_visible_in_current_pane() -> None:
     path = "/tmp/peneo-filter-confirm"
     loader = FakeBrowserSnapshotLoader(

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -229,6 +229,21 @@ def test_filter_q_updates_query_instead_of_exiting() -> None:
     assert actions == (SetNotification(None), SetFilterQuery("q", active=True))
 
 
+def test_filter_bound_space_without_character_is_rejected() -> None:
+    state = replace(build_initial_app_state(), ui_mode="FILTER")
+
+    actions = dispatch_key_input(state, key="space")
+
+    assert actions == (
+        SetNotification(
+            NotificationState(
+                level="warning",
+                message="This key is unavailable while editing the filter",
+            )
+        ),
+    )
+
+
 def test_browsing_y_dispatches_copy_targets() -> None:
     state = build_initial_app_state()
 
@@ -461,6 +476,14 @@ def test_palette_space_updates_query() -> None:
     assert actions == (SetNotification(None), SetCommandPaletteQuery(" "))
 
 
+def test_palette_bound_space_without_character_updates_query() -> None:
+    state = replace(build_initial_app_state(), ui_mode="PALETTE")
+
+    actions = dispatch_key_input(state, key="space")
+
+    assert actions == (SetNotification(None), SetCommandPaletteQuery(" "))
+
+
 def test_palette_pageup_moves_cursor_by_page() -> None:
     state = replace(build_initial_app_state(), ui_mode="PALETTE")
 
@@ -498,6 +521,14 @@ def test_split_terminal_focus_sends_printable_input() -> None:
     actions = dispatch_key_input(state, key="a", character="a")
 
     assert actions == (SetNotification(None), SendSplitTerminalInput("a"))
+
+
+def test_split_terminal_focus_sends_bound_space_without_character() -> None:
+    state = _focused_split_terminal_state()
+
+    actions = dispatch_key_input(state, key="space")
+
+    assert actions == (SetNotification(None), SendSplitTerminalInput(" "))
 
 
 def test_split_terminal_focus_sends_tab_for_completion() -> None:


### PR DESCRIPTION
## Summary
- centralize printable character normalization in `dispatch_key_input()`
- simplify `PeneoApp.action_dispatch_bound_key()` so app-level input rules are no longer duplicated
- add dispatcher and app regression tests for bound-key character handling across filter, palette, and split terminal paths

## Testing
- `uv run pytest tests/test_input_dispatch.py tests/test_app.py`
- `uv run ruff check src/peneo/state/input.py src/peneo/app.py tests/test_input_dispatch.py tests/test_app.py`

## Follow-up
- none

Refs #245
