### PR TITLE
#248 Refresh architecture markdown

### DIFF
--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1,45 +1,63 @@
 # Peneo Architecture Overview
 
-This document gives a high-level view of the current implementation structure of `Peneo`.
-It describes the actual responsibilities and data flow that exist in the codebase as of `2026-03-26`, not the full MVP vision.
+This document gives a high-level view of the current implementation structure of `Peneo`.  
+It describes the actual responsibilities and data flow that exist in the codebase as of `2026-04-02`, not the full MVP vision.
 
 ## 1. Principles
 
 The current implementation is built around these responsibilities:
 
-- `UI`: Textual rendering and event entry points
+- `UI`: Textual widgets for rendering and event entry points
+- `app runtime`: bridges reducer effects to workers and services, then maps async results back into actions
 - `input dispatcher`: normalizes key input into reducer-facing `Action` values
 - `reducer`: updates `AppState` as a pure function and returns required side effects as `Effect`
 - `selectors`: builds render-only models from `AppState`
 - `services`: use-case boundaries that execute effects outside the reducer
 - `adapters`: implementations for external dependencies such as the OS, filesystem, and clipboard
 
-The design keeps branching logic out of widgets and centralizes state transitions under `state/`.
+The design keeps branching logic out of widgets and centralizes state transitions under `state/`.  
+Actual UI refresh stays confined to selector-produced view models plus `app_shell.py`, while async orchestration is split into `app_runtime.py`.
 
 ## 2. Overall Structure
 
 ```mermaid
 flowchart LR
-    subgraph UI["UI (`src/peneo/app.py`, `src/peneo/ui`)"]
+    subgraph UI["UI (`src/peneo/app.py`, `src/peneo/app_shell.py`, `src/peneo/ui`)"]
         App["PeneoApp"]
-        Widgets["CurrentPathBar / MainPane / SidePane / CommandPalette / ConflictDialog / AttributeDialog / HelpBar / StatusBar"]
+        Shell["app_shell.py\nwidget mount / refresh / focus"]
+        Widgets["CurrentPathBar / MainPane / SidePane / CommandPalette / ConflictDialog / AttributeDialog / ConfigDialog / SplitTerminalPane / HelpBar / StatusBar"]
     end
 
     subgraph State["State (`src/peneo/state`)"]
         Input["input.py\nkey input dispatcher"]
         Actions["actions.py\nAction definitions"]
-        Reducer["reducer.py\nreduce_app_state"]
+        Reducer["reducer.py\ndispatch entrypoint"]
+        NavReducer["reducer_navigation.py\nnavigation / snapshots / directory size"]
+        MutationReducer["reducer_mutations.py\ncopy / cut / paste / rename / create / delete / extract"]
+        PaletteReducer["reducer_palette.py\npalette / history / bookmarks / go-to-path"]
+        TerminalReducer["reducer_terminal_config.py\nterminal / config / external launch"]
         Effects["effects.py\nEffect definitions"]
         Selectors["selectors.py\nselect_shell_data"]
         Models["models.py\nAppState / PaneState / UiMode"]
-        Palette["command_palette.py\npalette candidate builder"]
+        Palette["command_palette.py\npalette item builder"]
+    end
+
+    subgraph Runtime["Runtime (`src/peneo/app_runtime.py`)"]
+        RuntimeMain["effect scheduling / worker tracking"]
+        Debounce["debounce and cancel for file search / grep / directory size"]
     end
 
     subgraph Services["Services (`src/peneo/services`)"]
         Snapshot["browser_snapshot.py"]
+        Search["file_search.py / grep_search.py"]
+        DirSize["directory_size.py"]
         Clipboard["clipboard_operations.py"]
         Mutations["file_mutations.py"]
+        Archive["archive_extract.py"]
+        Config["config.py"]
         Launch["external_launcher.py"]
+        Split["split_terminal.py"]
+        ArchiveUtils["archive_utils.py\narchive detection / destination resolution"]
     end
 
     subgraph Adapters["Adapters (`src/peneo/adapters`)"]
@@ -48,32 +66,48 @@ flowchart LR
         External["external_launcher.py"]
     end
 
-    subgraph Display["Display models (`src/peneo/models`)"]
-        Shell["shell_data.py\nThreePaneShellData"]
-        Domain["file_operations.py / external_launch.py"]
+    subgraph Display["Display / Domain models (`src/peneo/models`)"]
+        ShellModel["shell_data.py\nThreePaneShellData"]
+        Domain["config.py / file_operations.py / external_launch.py"]
     end
 
     App --> Input
-    Input --> Actions
     App --> Reducer
-    Reducer --> Models
-    Reducer --> Effects
+    App --> RuntimeMain
     App --> Selectors
-    Selectors --> Models
-    Selectors --> Palette
     Selectors --> Shell
-    App --> Widgets
-    Effects --> Services
+    Shell --> Widgets
+    Input --> Actions
+    Reducer --> NavReducer
+    Reducer --> MutationReducer
+    Reducer --> PaletteReducer
+    Reducer --> TerminalReducer
+    NavReducer --> Models
+    MutationReducer --> Models
+    PaletteReducer --> Models
+    TerminalReducer --> Models
+    Reducer --> Effects
+    Selectors --> Palette
+    Selectors --> ShellModel
+    RuntimeMain --> Debounce
+    RuntimeMain --> Services
     Snapshot --> FS
+    Search --> FS
+    DirSize --> FS
     Clipboard --> FileOps
     Mutations --> FileOps
+    Archive --> ArchiveUtils
+    Archive --> FileOps
+    Config --> Domain
     Launch --> External
+    Split --> External
     Services --> Domain
 ```
 
 ## 3. Flow From Key Input To Rendering
 
-The core flow is: input -> Action -> state update -> effect execution -> selector -> rerender.
+The core flow is: input -> Action -> state update -> effect execution -> selector -> rerender.  
+Search work and directory-size calculation use `app_runtime.py` for debounce and cancellation, and stale request ids are discarded by the reducer.
 
 ```mermaid
 sequenceDiagram
@@ -81,10 +115,11 @@ sequenceDiagram
     participant App as PeneoApp
     participant Input as dispatch_key_input
     participant Reducer as reduce_app_state
+    participant Runtime as app_runtime
     participant Worker as Textual worker
     participant Service as services
     participant Selector as select_shell_data
-    participant UI as Widgets
+    participant Shell as app_shell / Widgets
 
     User->>App: Key input
     App->>Input: AppState, key, character
@@ -94,14 +129,15 @@ sequenceDiagram
         Reducer-->>App: ReduceResult(state, effects)
     end
     opt Effects exist
-        App->>Worker: Run effect asynchronously
-        Worker->>Service: snapshot / paste / mutation / launch
+        App->>Runtime: schedule_effects(effects)
+        Runtime->>Worker: start worker / manage debounce / cancel
+        Worker->>Service: snapshot / search / directory size / mutation / extract / launch
         Service-->>App: success / failure action
         App->>Reducer: success / failure action
     end
     App->>Selector: Latest AppState
     Selector-->>App: ThreePaneShellData
-    App->>UI: Rerender path / panes / dialogs / help / status
+    App->>Shell: Rerender path / panes / dialogs / help / status / terminal
 ```
 
 ## 4. Responsibilities Of Major Modules
@@ -110,70 +146,121 @@ sequenceDiagram
 
 - `PeneoApp` assembles the whole application
 - Sends Textual `Key` events into the central dispatcher
-- Bridges reducer effects to workers and services
-- Updates UI widgets using selector output
+- Passes reducer effects into `app_runtime.py`
+- Updates the UI shell from selector output
+
+### `src/peneo/app_runtime.py`
+
+- Chooses how each effect is scheduled as a worker
+- Manages debounce, request ids, and cancellation for file search, grep search, and directory-size work
+- Normalizes service results and exceptions into reducer-facing actions
+- Tracks longer-lived work such as snapshots and split-terminal sessions
+
+### `src/peneo/app_shell.py`
+
+- Mounts and refreshes the widget tree for the three-pane browser, dialogs, and split terminal
+- Applies selector-generated view models to widgets
+- Handles split-terminal focus and terminal-size synchronization
 
 ### `src/peneo/state/input.py`
 
 - Normalizes key input into `Action` values by mode
-- The main currently supported modes are `BROWSING`, `FILTER`, `RENAME`, `CREATE`, `PALETTE`, `CONFIRM`, and `BUSY`
-- Absorbs context-dependent keys such as `Esc`
+- The main supported modes are `BROWSING`, `FILTER`, `RENAME`, `CREATE`, `EXTRACT`, `PALETTE`, `DETAIL`, `CONFIRM`, `CONFIG`, and `BUSY`
+- When the split terminal owns input, browser shortcuts are bypassed in favor of terminal input
+- Also absorbs compound shortcuts such as `Ctrl+F`, `Ctrl+G`, `Ctrl+O`, `Ctrl+B`, `Ctrl+J`, `Alt+Left`, `Alt+Right`, and `Alt+Home`
 
 ### `src/peneo/state/reducer.py`
 
-- The single update point for `AppState`
-- Manages screen transitions, cursor movement, selection, filter, sort, clipboard, rename/create/delete, palette execution, file search, config editor, split terminal, and dialog state
-- Does not perform external I/O directly; instead returns effects for snapshot loads, child-pane loads, paste, rename/create/delete, external launch, file search, split-terminal lifecycle, and config save
-- Matches async results by request id and discards stale snapshot results
+- The single public update point for `AppState`
+- Acts as a thin entrypoint that delegates work to responsibility-specific reducer handlers
+
+### `src/peneo/state/reducer_navigation.py`
+
+- Handles directory movement, history back / forward, home navigation, reload, filter, sort, and hidden-files toggling
+- Also applies browser snapshots, child-pane snapshots, directory-size requests, and directory-size results
+
+### `src/peneo/state/reducer_mutations.py`
+
+- Handles selection, copy / cut / paste, rename, create, trash delete, and archive-extract transitions
+- Owns paste-conflict, name-conflict, archive-confirmation, and extraction-progress state
+
+### `src/peneo/state/reducer_palette.py`
+
+- Handles command-palette open / close, query updates, cursor movement, and execution
+- Starts derived flows such as `Find files`, `Grep search`, `History search`, `Show bookmarks`, `Go to path`, bookmark add/remove, `Show attributes`, and `Extract archive`
+- Also owns attribute-dialog dismissal and file-search / grep-search result application
+
+### `src/peneo/state/reducer_terminal_config.py`
+
+- Handles split-terminal start / stop / I/O
+- Handles config-editor edits and saves, bookmark persistence, external-app launch, and terminal-editor launch
 
 ### `src/peneo/state/selectors.py`
 
 - Builds `ThreePaneShellData` from `AppState`
-- Applies filter and sort only to the main pane, while parent and child panes stay fixed to name order plus directories-first
-- Formats the display text for the help bar, status bar, input bar, command palette, conflict dialog, attribute dialog, config dialog, and split terminal
-- Also assembles cut-item dimming and the summary line fields such as `item_count`, `selected_count`, and `sort_label`
+- Applies filter, sort, and directory-size display only to the main pane, while parent and child panes remain fixed-order
+- Formats display text for the help bar, status bar, input bar, command palette, conflict dialog, attribute dialog, config dialog, and split terminal
+- Summarizes busy state, extraction progress, search errors, and notifications for the UI
 
 ### `src/peneo/state/command_palette.py`
 
-- Builds command palette candidates and filters them by query
-- The current palette includes `Find file`, `Grep`, `Show attributes`, `Rename`, `Extract archive`, `Copy path`, `Open in file manager`, `Open terminal here`, `Open/Close split terminal`, `Show/Hide hidden files`, `Edit config`, `Create file`, and `Create directory`
-- `Show attributes` appears only for a single target and opens a read-only attribute dialog with `Name`, `Type`, `Path`, `Size`, `Modified`, `Hidden`, and `Permissions`
-- `Extract archive` appears only for a single supported archive (`.zip` / `.tar` / `.tar.gz` / `.tar.bz2`) and reuses the pending input bar to edit the destination path
-  - The input accepts both absolute and relative paths, and relative paths are resolved from the archive file's parent directory
-  - The default value is the absolute path to a same-name directory next to the archive
-  - The reducer performs a preflight scan for destination conflicts and uses the confirm dialog before continuing when conflicts are found
-  - Extraction runs in `BUSY` mode and reports entry-count progress through the status bar
-- `Find file` switches the palette into file-search mode and reuses the same UI to show recursive matches under the current directory
-  - Plain input runs a case-insensitive partial basename match
-  - `re:`-prefixed input is treated as a Python regex against basenames, and invalid regex patterns are surfaced inline in the palette
-- `Grep` switches the palette into content-search mode and renders matches as `relative/path:line:content`
-  - Plain input runs a case-insensitive fixed-string search
-  - `re:`-prefixed input is treated as regex, and invalid patterns are surfaced inline in the palette
-- The split-terminal and hidden-files entries change their labels to reflect the current state
+- Builds palette items and filters them by query
+- The default command palette includes:
+  - `Find files`
+  - `Grep search`
+  - `History search`
+  - `Show bookmarks`
+  - `Go back`
+  - `Go forward`
+  - `Go to path`
+  - `Go to home directory`
+  - `Reload directory`
+  - `Toggle split terminal`
+  - `Show attributes`
+  - `Rename`
+  - `Extract archive`
+  - `Open in editor`
+  - `Copy path`
+  - `Move to trash`
+  - `Open in file manager`
+  - `Open terminal here`
+  - `Bookmark this directory` / `Remove bookmark`
+  - `Show hidden files` / `Hide hidden files`
+  - `Edit config`
+  - `Create file`
+  - `Create directory`
+- Palette sources are `commands`, `file_search`, `grep_search`, `history`, `bookmarks`, and `go_to_path`
+- `go_to_path` shows a single preview candidate while the user types
 
 ### `src/peneo/services/`
 
 - `browser_snapshot.py`: builds the three-pane snapshot from the real filesystem
-- `clipboard_operations.py`: handles copy / cut / paste execution and conflict detection
-- `config.py`: loads, validates, saves, and renders `config.toml`, including normalized startup editor settings such as `editor.command`
-- `file_search.py`: handles recursive file search under the current directory, interpreting both plain input and `re:` regex input before filtering results according to hidden-file visibility
-- `grep_search.py`: handles recursive content search through `rg`, treating plain input as fixed-string search and `re:` input as regex before applying hidden-file visibility rules
+- `file_search.py`: handles recursive file search under the current directory
+- `grep_search.py`: handles recursive content search through `rg`
+- `directory_size.py`: calculates recursive sizes for visible directories
+- `clipboard_operations.py`: executes copy / cut / paste and detects conflicts
 - `file_mutations.py`: handles rename / create / trash delete
-- `archive_extract.py`: handles preflight archive scans, destination conflict detection, safe extraction with the standard-library `zipfile` / `tarfile` modules, and progress notifications
-- `external_launcher.py`: handles default-app open, editor-in-current-terminal launch, terminal launch, and copying a path to the system clipboard, resolving editors in config -> `$EDITOR` -> built-in order
-- `split_terminal.py`: starts PTY-backed embedded terminal sessions, forwards I/O, and reports exit events
+- `archive_extract.py`: handles archive preflight scanning, conflict detection, safe extraction, and progress reporting
+- `config.py`: loads, validates, saves, and renders `config.toml`
+- `external_launcher.py`: handles default-app launch, terminal-editor launch, external-terminal launch, and path copy
+- `split_terminal.py`: starts PTY-backed split-terminal sessions, forwards I/O, and reports exit events
+
+### `src/peneo/archive_utils.py`
+
+- Detects supported archive formats
+- Resolves default extraction destinations and user-entered relative or absolute destination paths
 
 ### `src/peneo/adapters/`
 
-- `filesystem.py`: enumerates directory entries and reads metadata
-- `file_operations.py`: performs copy / move / rename / create / trash and related file operations
-- `external_launcher.py`: hides OS-specific command differences and launches external processes
+- `filesystem.py`: enumerates entries, reads metadata, and calculates directory sizes
+- `file_operations.py`: performs copy / move / rename / create / trash and archive-related file operations
+- `external_launcher.py`: hides OS-specific launch command differences
 
-### `src/peneo/models/`
+### `src/peneo/models/` and `src/peneo/state/models.py`
 
-- `shell_data.py`: render-only models
-- `external_launch.py` and `file_operations.py`: request / result models exchanged between services and the reducer
-- `state/models.py`: state models managed by the reducer
+- `models/` stores request / result / view-model types shared across services and UI
+- `state/models.py` stores reducer-owned persistent state
+- Cross-cutting UI state such as `HistoryState`, `CommandPaletteState`, `SplitTerminalState`, and `DirectorySizeCacheEntry` lives under `state/models.py`
 
 ## 5. Modes And Input Boundaries
 
@@ -181,73 +268,77 @@ sequenceDiagram
 stateDiagram-v2
     [*] --> BROWSING
     BROWSING --> FILTER: /
-    BROWSING --> RENAME: F2
-    BROWSING --> PALETTE: :
-    PALETTE --> CREATE: Enter on create command
-    PALETTE --> CONFIG: Enter on Edit config
-    PALETTE --> PALETTE: Enter on Find file / type file-search query
-    PALETTE --> BROWSING: Enter on other command / Esc
-    CONFIG --> BUSY: s save
-    CONFIG --> BROWSING: Esc
+    BROWSING --> PALETTE: : / Ctrl+F / Ctrl+G / Ctrl+O / Ctrl+B / Ctrl+J
+    BROWSING --> RENAME: F2 / Rename
+    BROWSING --> EXTRACT: Extract archive
+    BROWSING --> DETAIL: Show attributes
+    BROWSING --> CONFIG: Edit config
+    BROWSING --> CONFIRM: delete / paste conflict / archive conflict
+    BROWSING --> BUSY: snapshot / mutation / launch / config save
+    BROWSING --> BROWSING: Alt+Left / Alt+Right / Alt+Home / reload / sort / hidden toggle
+    PALETTE --> BROWSING: Enter on command / Esc
+    PALETTE --> PALETTE: query updates / search mode
     FILTER --> BROWSING: Enter / Down / Esc
     RENAME --> BUSY: Enter
     CREATE --> BUSY: Enter
-    RENAME --> BROWSING: Esc
-    CREATE --> BROWSING: Esc
-    CONFIRM --> BROWSING: delete confirm/cancel
-    CONFIRM --> BROWSING: paste conflict resolved/cancelled
-    CONFIRM --> RENAME: rename conflict dismissed
-    CONFIRM --> CREATE: create conflict dismissed
+    EXTRACT --> CONFIRM: Enter with conflicts
+    EXTRACT --> BUSY: Enter without conflicts
+    EXTRACT --> BROWSING: Esc
+    DETAIL --> BROWSING: Enter / Esc
+    CONFIG --> BUSY: s save
+    CONFIG --> BROWSING: Esc
+    CONFIRM --> BROWSING: confirm / cancel
     BUSY --> BROWSING: effect completes
-
-    BUSY --> BUSY: arbitrary keys are suppressed
 ```
 
 Notes:
 
 - `BROWSING`
-  - Handles navigation, selection, starting filter input, paste, delete, rename, palette, and sort switching
-  - If an active filter exists, `Esc` clears the filter before clearing the selection
-- `FILTER`
-  - Handles text input, `Backspace`, `Enter`, `Down`, and `Esc`
+  - Handles navigation, selection, history movement, bookmark / history / go-to-path entry, filter, palette, sort, and terminal toggling
+  - If an active filter exists, `Esc` clears the filter before clearing selection
 - `PALETTE`
-  - Handles query updates, candidate cursor movement, command execution, and cancel
+  - Reuses one UI surface for normal commands plus file search, grep search, history, bookmarks, and go-to-path preview
+- `DETAIL`
+  - Read-only mode for the attribute dialog
+- `EXTRACT`
+  - Shows the extraction-destination input and moves into preflight checking or extraction on `Enter`
 - `CONFIG`
-  - Edits startup defaults in the config overlay, including terminal-editor presets, saves with `s`, and opens the raw `config.toml` in a terminal editor with `e`
-- `RENAME` / `CREATE`
-  - Edits names in the input bar and issues a mutation effect on `Enter`
-- `CONFIRM`
-  - Handles delete confirmation, paste conflicts, and duplicate-name warnings for rename/create
-- `BUSY`
-  - Wait state while loading snapshots or executing file mutations
+  - Edits startup settings in the config overlay, saves with `s`, and opens raw `config.toml` in a terminal editor with `e`
 - While the split terminal is visible
-  - Terminal input takes precedence over browser shortcuts, and `Ctrl+T` closes the embedded terminal
+  - Terminal input takes precedence over browser shortcuts, and `Ctrl+T` or `Esc` closes it
 
 ## 6. What Works Today
 
-- Launches the three-pane UI by loading the real filesystem from `CWD`
-- Shows parent / current / child panes and supports cursor movement
-- Moves into directories, back to parent, and reloads the current directory
-- Supports filter input and continued list interaction after applying the filter
+- Launches the three-pane UI from the real filesystem rooted at `CWD`
+- Shows parent / current / child directories and supports cursor movement
+- Moves into directories, back to the parent directory, to the home directory, and reloads the current directory
+- Supports back / forward history navigation and jumping from the history list
+- Supports jumping from saved bookmarks plus adding or removing the current directory as a bookmark
+- Supports go-to-path input for direct navigation to a typed path
+- Supports filter input and continued list interaction after filtering
 - Switches sort by name / modified time / size and toggles directories-first ordering
+- Shows recursive directory sizes for visible directories when needed
 - Supports selection toggle, clear selection, copy / cut / paste
 - Detects paste conflicts and resolves them with overwrite / skip / rename
 - Renames a single target
 - Creates files and directories
-- Moves items to trash and shows a confirmation dialog for multi-target deletion
+- Moves items to trash with confirmation
 - Opens files with the OS default app
-- Opens files in a terminal editor with `e`
-- Provides recursive file search, attribute inspection, path copy, file-manager launch, terminal launch, and hidden-files toggle from the command palette
-- Edits startup defaults in the config overlay and saves them back to `config.toml`
-- Starts the embedded split terminal, forwards input to it, and reports when the session exits
-- Keeps status bar / help bar / input bar / conflict dialog / attribute dialog / config dialog / split terminal synchronized with application state
+- Opens files in the current terminal editor with `e`
+- Provides recursive file search, recursive grep search, attribute inspection, path copy, file-manager launch, external-terminal launch, and hidden-files toggling from the command palette
+- Extracts supported archives (`.zip`, `.tar`, `.tar.gz`, `.tar.bz2`) with conflict confirmation and progress reporting
+- Saves startup settings and bookmarks through the config overlay
+- Starts the embedded split terminal, forwards input, supports clipboard paste, and reports exit events
+- Keeps status bar, help bar, input bar, conflict dialog, attribute dialog, config dialog, and split terminal synchronized with application state
 
-## 7. Areas Still Unwired Or Unimplemented
+## 7. Areas Still Unimplemented Or Constrained
 
-- `HistoryState` exists in state, but back / forward is not wired into the UI yet
 - File preview, in-app editing, Git integration, tabs, and keybinding customization are not implemented
+- Native Windows runtime remains unsupported, even though the config accepts a `windows` terminal key for future compatibility
+- Directory-size calculation and archive extraction grow in cost with visible directory count or archive contents, so runtime cancellation and progress tracking are part of the design
 
-Filesystem mutations treat the entry path selected in the UI as the trust boundary. When the selected item is a symlink, the final path component is not canonicalized, so delete / rename / move / copy / overwrite / trash operate on the symlink entry itself rather than silently following the target.
+Filesystem mutations treat the entry path selected in the UI as the trust boundary.  
+When the selected item is a symlink, the final path component is not canonicalized, so delete / rename / move / copy / overwrite / trash operate on the symlink entry itself rather than silently following the target.
 
 ## 8. How To Extend It
 
@@ -257,12 +348,13 @@ When adding a new action, the intended insertion order is:
 flowchart TD
     Key["New action"] --> Input["Add dispatch in input.py"]
     Input --> Action["Add Action in actions.py"]
-    Action --> Reducer["Add state transition in reducer.py"]
-    Reducer --> Effect["Add Effect if needed"]
-    Effect --> Service["Add execution in services/"]
+    Action --> Reducer["Add state transition in reducer_*"]
+    Reducer --> Effect["Add Effect in effects.py if needed"]
+    Effect --> Runtime["Add scheduler / completion mapping in app_runtime.py"]
+    Runtime --> Service["Add execution in services/"]
     Service --> Adapter["Delegate OS / FS differences to adapters"]
     Reducer --> Selector["Update selectors if rendering changes"]
-    Selector --> UI["Keep UI display-only"]
+    Selector --> Shell["Keep app_shell.py / ui display-only"]
 ```
 
 Following this path keeps feature changes localized without pushing branching logic into widgets.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,45 +1,63 @@
 # Peneo アーキテクチャ概要
 
 このドキュメントは、`Peneo` の現在の実装構造を俯瞰するためのものです。  
-対象は `2026-03-26` 時点でコード上に存在する責務分割とデータフローであり、MVP 構想全体ではなく現実装を説明します。
+対象は `2026-04-02` 時点でコード上に存在する責務分割とデータフローであり、MVP 構想全体ではなく現実装を説明します。
 
 ## 1. 方針
 
 現在の実装は、次の責務分離を前提にしています。
 
-- `UI`: Textual の表示とイベント入口
+- `UI`: Textual widget の描画とイベント入口
+- `app runtime`: reducer が返した effect を worker と service に橋渡しし、非同期結果を action へ戻す
 - `input dispatcher`: キー入力を reducer 向け `Action` に正規化
 - `reducer`: `AppState` を純粋関数で更新し、必要な副作用を `Effect` として返す
 - `selectors`: `AppState` から描画専用モデルを組み立てる
 - `services`: reducer 外で effect を実行するユースケース境界
 - `adapters`: OS / filesystem / clipboard など外部依存の実装
 
-widget 側に操作分岐を持たせず、状態遷移は `state/` に寄せる構成です。
+widget 側に操作分岐を持たせず、状態遷移は `state/` に寄せる構成です。  
+実際の UI 更新は `selectors` が作る view model と `app_shell.py` の組み立て処理に限定し、非同期処理の制御は `app_runtime.py` に分離しています。
 
 ## 2. 全体構成
 
 ```mermaid
 flowchart LR
-    subgraph UI["UI (`src/peneo/app.py`, `src/peneo/ui`)"]
+    subgraph UI["UI (`src/peneo/app.py`, `src/peneo/app_shell.py`, `src/peneo/ui`)"]
         App["PeneoApp"]
-        Widgets["CurrentPathBar / MainPane / SidePane / CommandPalette / ConflictDialog / AttributeDialog / HelpBar / StatusBar"]
+        Shell["app_shell.py\nwidget mount / refresh / focus"]
+        Widgets["CurrentPathBar / MainPane / SidePane / CommandPalette / ConflictDialog / AttributeDialog / ConfigDialog / SplitTerminalPane / HelpBar / StatusBar"]
     end
 
     subgraph State["State (`src/peneo/state`)"]
         Input["input.py\nキー入力 dispatcher"]
         Actions["actions.py\nAction 定義"]
-        Reducer["reducer.py\nreduce_app_state"]
+        Reducer["reducer.py\nハンドラ振り分け"]
+        NavReducer["reducer_navigation.py\n移動 / snapshot / directory size"]
+        MutationReducer["reducer_mutations.py\ncopy / cut / paste / rename / create / delete / extract"]
+        PaletteReducer["reducer_palette.py\npalette / history / bookmarks / go-to-path"]
+        TerminalReducer["reducer_terminal_config.py\nterminal / config / external launch"]
         Effects["effects.py\nEffect 定義"]
         Selectors["selectors.py\nselect_shell_data"]
         Models["models.py\nAppState / PaneState / UiMode"]
         Palette["command_palette.py\npalette 候補構築"]
     end
 
+    subgraph Runtime["Runtime (`src/peneo/app_runtime.py`)"]
+        RuntimeMain["effect scheduling / worker tracking"]
+        Debounce["file search / grep / directory size の debounce と cancel"]
+    end
+
     subgraph Services["Services (`src/peneo/services`)"]
         Snapshot["browser_snapshot.py"]
+        Search["file_search.py / grep_search.py"]
+        DirSize["directory_size.py"]
         Clipboard["clipboard_operations.py"]
         Mutations["file_mutations.py"]
+        Archive["archive_extract.py"]
+        Config["config.py"]
         Launch["external_launcher.py"]
+        Split["split_terminal.py"]
+        ArchiveUtils["archive_utils.py\narchive 判定 / 展開先解決"]
     end
 
     subgraph Adapters["Adapters (`src/peneo/adapters`)"]
@@ -48,32 +66,48 @@ flowchart LR
         External["external_launcher.py"]
     end
 
-    subgraph Display["Display models (`src/peneo/models`)"]
-        Shell["shell_data.py\nThreePaneShellData"]
-        Domain["file_operations.py / external_launch.py"]
+    subgraph Display["Display / Domain models (`src/peneo/models`)"]
+        ShellModel["shell_data.py\nThreePaneShellData"]
+        Domain["config.py / file_operations.py / external_launch.py"]
     end
 
     App --> Input
-    Input --> Actions
     App --> Reducer
-    Reducer --> Models
-    Reducer --> Effects
+    App --> RuntimeMain
     App --> Selectors
-    Selectors --> Models
-    Selectors --> Palette
     Selectors --> Shell
-    App --> Widgets
-    Effects --> Services
+    Shell --> Widgets
+    Input --> Actions
+    Reducer --> NavReducer
+    Reducer --> MutationReducer
+    Reducer --> PaletteReducer
+    Reducer --> TerminalReducer
+    NavReducer --> Models
+    MutationReducer --> Models
+    PaletteReducer --> Models
+    TerminalReducer --> Models
+    Reducer --> Effects
+    Selectors --> Palette
+    Selectors --> ShellModel
+    RuntimeMain --> Debounce
+    RuntimeMain --> Services
     Snapshot --> FS
+    Search --> FS
+    DirSize --> FS
     Clipboard --> FileOps
     Mutations --> FileOps
+    Archive --> ArchiveUtils
+    Archive --> FileOps
+    Config --> Domain
     Launch --> External
+    Split --> External
     Services --> Domain
 ```
 
 ## 3. キー入力から描画までの流れ
 
-中核フローは「入力 -> Action -> 状態更新 -> Effect 実行 -> Selector -> 再描画」です。
+中核フローは「入力 -> Action -> 状態更新 -> Effect 実行 -> Selector -> 再描画」です。  
+検索系と directory size 計算は `app_runtime.py` 側で debounce と cancel を扱い、古い request id の結果は reducer で破棄します。
 
 ```mermaid
 sequenceDiagram
@@ -81,10 +115,11 @@ sequenceDiagram
     participant App as PeneoApp
     participant Input as dispatch_key_input
     participant Reducer as reduce_app_state
+    participant Runtime as app_runtime
     participant Worker as Textual worker
     participant Service as services
     participant Selector as select_shell_data
-    participant UI as Widgets
+    participant Shell as app_shell / Widgets
 
     User->>App: キー入力
     App->>Input: AppState, key, character
@@ -94,14 +129,15 @@ sequenceDiagram
         Reducer-->>App: ReduceResult(state, effects)
     end
     opt Effect がある
-        App->>Worker: effect を非同期実行
-        Worker->>Service: snapshot / paste / mutation / launch
+        App->>Runtime: schedule_effects(effects)
+        Runtime->>Worker: worker 起動 / debounce / cancel 管理
+        Worker->>Service: snapshot / search / directory size / mutation / extract / launch
         Service-->>App: success / failure action
         App->>Reducer: success / failure action
     end
     App->>Selector: 最新 AppState
     Selector-->>App: ThreePaneShellData
-    App->>UI: path / panes / dialogs / help / status を再描画
+    App->>Shell: path / panes / dialogs / help / status / terminal を再描画
 ```
 
 ## 4. 主要モジュールの責務
@@ -110,70 +146,121 @@ sequenceDiagram
 
 - `PeneoApp` がアプリ全体の組み立て役
 - Textual の `Key` イベントを中央 dispatcher に流す
-- reducer が返した effect を worker と各 service に橋渡しする
-- selector の結果を使って UI widget を更新する
+- reducer が返した effect を `app_runtime.py` に橋渡しする
+- selector の結果を使って UI shell を更新する
+
+### `src/peneo/app_runtime.py`
+
+- effect ごとに worker 起動方法を切り替える
+- file search / grep search / directory size の debounce、request id 管理、cancel 制御を担当する
+- service の結果や例外を reducer 向け action に正規化する
+- snapshot や split terminal など長寿命処理の tracking を行う
+
+### `src/peneo/app_shell.py`
+
+- 3 ペイン本体、dialog、split terminal を含む widget ツリーの mount / refresh を担当する
+- selector が返した view model を各 widget へ反映する
+- split terminal の focus 制御と terminal サイズ同期を行う
 
 ### `src/peneo/state/input.py`
 
 - モード別にキー入力を `Action` へ正規化する
-- 現在サポートしている主なモードは `BROWSING` / `FILTER` / `RENAME` / `CREATE` / `PALETTE` / `CONFIRM` / `BUSY`
-- `Esc` のように文脈で意味が変わるキーもここで吸収する
+- 現在サポートしている主なモードは `BROWSING` / `FILTER` / `RENAME` / `CREATE` / `EXTRACT` / `PALETTE` / `DETAIL` / `CONFIRM` / `CONFIG` / `BUSY`
+- split terminal が入力を持つ間は browser 用キーバインドではなく terminal 入力を優先する
+- `Ctrl+F` / `Ctrl+G` / `Ctrl+O` / `Ctrl+B` / `Ctrl+J` / `Alt+←` / `Alt+→` / `Alt+Home` などの複合キーもここで吸収する
 
 ### `src/peneo/state/reducer.py`
 
-- `AppState` の唯一の更新点
-- 画面遷移、カーソル移動、選択、filter、sort、clipboard、rename/create/delete、palette 実行、file search、config editor、split terminal、dialog 状態を管理する
-- 外部 I/O は直接行わず、snapshot、child-pane load、paste、rename/create/delete、外部起動、file search、split terminal 起動/入力/終了、config 保存の各 effect を返す
-- 非同期結果は request id で突き合わせ、古い snapshot 結果を破棄する
+- `AppState` の唯一の公開更新点
+- 実処理は責務別ハンドラへ振り分ける薄いエントリポイントとして振る舞う
+
+### `src/peneo/state/reducer_navigation.py`
+
+- ディレクトリ移動、history 戻る / 進む、home 移動、reload、filter、sort、hidden files 切り替えを担当する
+- browser snapshot と child pane snapshot の反映、directory size request の発行と結果反映もここで扱う
+
+### `src/peneo/state/reducer_mutations.py`
+
+- 選択、copy / cut / paste、rename、create、trash delete、archive extract の state 遷移を担当する
+- paste conflict、name conflict、archive extract confirm、進捗表示の各状態を管理する
+
+### `src/peneo/state/reducer_palette.py`
+
+- コマンドパレットの開閉、query 更新、候補カーソル移動、実行を担当する
+- `Find files`、`Grep search`、`History search`、`Show bookmarks`、`Go to path`、bookmark add/remove、`Show attributes`、`Extract archive` などの派生フローを起動する
+- 属性ダイアログの開閉や file search / grep search の結果反映もここで扱う
+
+### `src/peneo/state/reducer_terminal_config.py`
+
+- split terminal の起動 / 終了 / 入出力を担当する
+- config editor の編集と保存、bookmark 保存、外部アプリ起動、terminal editor 起動を担当する
 
 ### `src/peneo/state/selectors.py`
 
 - `AppState` から `ThreePaneShellData` を組み立てる
-- 中央ペインにだけ filter / sort を適用し、親・子ペインは名前順 + ディレクトリ優先で固定表示する
-- help bar、status bar、input bar、command palette、conflict dialog、attribute dialog、config dialog、split terminal の表示文言もここで整形する
-- cut 対象の dim 表示や summary 行の `item_count / selected_count / sort_label` も selector 側で組み立てる
+- 中央ペインにだけ filter / sort / directory size 表示を適用し、親・子ペインは固定順で表示する
+- help bar、status bar、input bar、command palette、conflict dialog、attribute dialog、config dialog、split terminal の表示文言を整形する
+- busy 状態、extract 進捗、検索エラー、通知メッセージを UI 向けに要約する
 
 ### `src/peneo/state/command_palette.py`
 
-- コマンドパレット候補の構築と query フィルタリングを担当する
-- 現在の palette には `Find file`、`Grep`、`Show attributes`、`Rename`、`Extract archive`、`Copy path`、`Open in file manager`、`Open terminal here`、`Open/Close split terminal`、`Show/Hide hidden files`、`Edit config`、`Create file`、`Create directory` がある
-- `Show attributes` は単一対象がある場合にだけ表示し、`Name` / `Type` / `Path` / `Size` / `Modified` / `Hidden` / `Permissions` を持つ read-only の属性ダイアログを開く
-- `Extract archive` は単一の対応アーカイブ (`.zip` / `.tar` / `.tar.gz` / `.tar.bz2`) にだけ表示し、既存の pending input bar を使って展開先パスを編集する
-  - 入力値は絶対パスと相対パスの両方を受け付け、相対パスはアーカイブ親ディレクトリ基準で解決する
-  - 初期値はアーカイブと同じ階層にある同名ディレクトリの絶対パス
-  - 実行前に展開先の競合を走査し、必要なら confirm dialog で続行可否を確認する
-  - 展開中は `BUSY` モードで entry-count ベースの進捗を status bar に反映する
-- `Find file` 選択後は palette をファイル検索モードに切り替え、現在ディレクトリ以下を再帰検索した結果を同じ UI で表示する
-  - 通常入力は basename 対象の大文字小文字を無視した部分一致
-  - `re:` 接頭辞付き入力は basename 対象の Python regex として扱い、無効な regex は palette 内メッセージで表示する
-- `Grep` は palette を内容検索モードに切り替え、現在ディレクトリ以下のヒットを `相対パス:行番号:ヒット行` 形式で表示する
-  - 通常入力は固定文字列の大文字小文字を無視した検索
-  - `re:` 接頭辞付き入力は regex として扱い、無効な regex は palette 内メッセージで表示する
-- split terminal と hidden files のトグルは状態に応じてラベルを切り替える
+- palette 候補の構築と query フィルタリングを担当する
+- 通常 palette には次の候補がある
+  - `Find files`
+  - `Grep search`
+  - `History search`
+  - `Show bookmarks`
+  - `Go back`
+  - `Go forward`
+  - `Go to path`
+  - `Go to home directory`
+  - `Reload directory`
+  - `Toggle split terminal`
+  - `Show attributes`
+  - `Rename`
+  - `Extract archive`
+  - `Open in editor`
+  - `Copy path`
+  - `Move to trash`
+  - `Open in file manager`
+  - `Open terminal here`
+  - `Bookmark this directory` / `Remove bookmark`
+  - `Show hidden files` / `Hide hidden files`
+  - `Edit config`
+  - `Create file`
+  - `Create directory`
+- palette source は `commands` / `file_search` / `grep_search` / `history` / `bookmarks` / `go_to_path` を持つ
+- `go_to_path` は入力中に preview path を 1 件だけ候補表示する
 
 ### `src/peneo/services/`
 
-- `browser_snapshot.py`: 実 filesystem から 3 ペイン用 snapshot を構築
-- `clipboard_operations.py`: copy / cut / paste の実処理と競合検出を担当
-- `config.py`: `config.toml` の読み込み、検証、保存、既定値レンダリングを担当し、`editor.command` を含む起動設定を正規化する
-- `file_search.py`: 現在ディレクトリ以下の再帰ファイル検索を担当し、通常入力と `re:` regex 入力を解釈したうえで hidden 設定に応じて結果を絞る
-- `grep_search.py`: `rg` を使った再帰内容検索を担当し、通常入力は固定文字列、`re:` 入力は regex として hidden 設定に応じて結果を返す
-- `file_mutations.py`: rename / create / trash delete を担当
-- `archive_extract.py`: 対応アーカイブの事前走査、競合検出、標準ライブラリ (`zipfile` / `tarfile`) を使った安全な展開、進捗通知を担当
-- `external_launcher.py`: 既定アプリ起動、現在のターミナル内エディタ起動、ターミナル起動、システムクリップボードへのパスコピーを担当し、editor config -> `$EDITOR` -> 既定値の順でエディタ候補を解決する
-- `split_terminal.py`: 埋め込み split terminal の PTY セッション起動、入出力、終了通知を担当
+- `browser_snapshot.py`: 実 filesystem から 3 ペイン用 snapshot を構築する
+- `file_search.py`: 現在ディレクトリ以下の再帰ファイル検索を担当する
+- `grep_search.py`: `rg` を使った再帰内容検索を担当する
+- `directory_size.py`: 可視ディレクトリの再帰サイズ計算を担当する
+- `clipboard_operations.py`: copy / cut / paste 実処理と競合検出を担当する
+- `file_mutations.py`: rename / create / trash delete を担当する
+- `archive_extract.py`: archive 事前走査、競合検出、安全な展開、進捗通知を担当する
+- `config.py`: `config.toml` の読み込み、検証、保存、既定値レンダリングを担当する
+- `external_launcher.py`: 既定アプリ起動、terminal editor 起動、外部 terminal 起動、パスコピーを担当する
+- `split_terminal.py`: 埋め込み split terminal の PTY セッション起動、入出力、終了通知を担当する
+
+### `src/peneo/archive_utils.py`
+
+- 対応 archive 形式の判定を行う
+- 展開先の既定値生成と、ユーザー入力された相対 / 絶対パスの解決を担当する
 
 ### `src/peneo/adapters/`
 
-- `filesystem.py`: ディレクトリエントリの列挙とメタデータ取得
-- `file_operations.py`: copy / move / rename / create / trash などのファイル操作
-- `external_launcher.py`: OS ごとのコマンド差異を吸収して外部プロセスを起動
+- `filesystem.py`: ディレクトリエントリ列挙、メタデータ取得、directory size 計算を担当する
+- `file_operations.py`: copy / move / rename / create / trash / archive 展開補助などのファイル操作を担当する
+- `external_launcher.py`: OS ごとの起動コマンド差異を吸収する
 
-### `src/peneo/models/`
+### `src/peneo/models/` と `src/peneo/state/models.py`
 
-- `shell_data.py`: 描画専用モデル
-- `external_launch.py` と `file_operations.py`: service と reducer が受け渡す request / result モデル
-- `state/models.py`: reducer 管理対象の状態モデル
+- `models/` には service と UI が共有する request / result / view model を置く
+- `state/models.py` には reducer 管理下の永続 state を置く
+- `HistoryState`、`CommandPaletteState`、`SplitTerminalState`、`DirectorySizeCacheEntry` などの UI 横断状態は `state/models.py` 側に集約する
 
 ## 5. モードと入力境界
 
@@ -181,73 +268,77 @@ sequenceDiagram
 stateDiagram-v2
     [*] --> BROWSING
     BROWSING --> FILTER: /
-    BROWSING --> RENAME: F2
-    BROWSING --> PALETTE: :
-    PALETTE --> CREATE: Enter on create command
-    PALETTE --> CONFIG: Enter on Edit config
-    PALETTE --> PALETTE: Enter on Find file / type file-search query
-    PALETTE --> BROWSING: Enter on other command / Esc
-    CONFIG --> BUSY: s save
-    CONFIG --> BROWSING: Esc
+    BROWSING --> PALETTE: : / Ctrl+F / Ctrl+G / Ctrl+O / Ctrl+B / Ctrl+J
+    BROWSING --> RENAME: F2 / Rename
+    BROWSING --> EXTRACT: Extract archive
+    BROWSING --> DETAIL: Show attributes
+    BROWSING --> CONFIG: Edit config
+    BROWSING --> CONFIRM: delete / paste conflict / archive conflict
+    BROWSING --> BUSY: snapshot / mutation / launch / config save
+    BROWSING --> BROWSING: Alt+← / Alt+→ / Alt+Home / reload / sort / hidden toggle
+    PALETTE --> BROWSING: Enter on command / Esc
+    PALETTE --> PALETTE: query 更新 / search mode 継続
     FILTER --> BROWSING: Enter / Down / Esc
     RENAME --> BUSY: Enter
     CREATE --> BUSY: Enter
-    RENAME --> BROWSING: Esc
-    CREATE --> BROWSING: Esc
-    CONFIRM --> BROWSING: delete confirm/cancel
-    CONFIRM --> BROWSING: paste conflict resolved/cancelled
-    CONFIRM --> RENAME: rename conflict dismissed
-    CONFIRM --> CREATE: create conflict dismissed
+    EXTRACT --> CONFIRM: Enter with conflicts
+    EXTRACT --> BUSY: Enter without conflicts
+    EXTRACT --> BROWSING: Esc
+    DETAIL --> BROWSING: Enter / Esc
+    CONFIG --> BUSY: s save
+    CONFIG --> BROWSING: Esc
+    CONFIRM --> BROWSING: confirm / cancel
     BUSY --> BROWSING: effect 完了
-
-    BUSY --> BUSY: 任意キーは抑止
 ```
 
 補足:
 
 - `BROWSING`
-  - 移動、選択、filter 開始、paste、delete、rename、palette、sort 切り替えを処理する
+  - 移動、選択、履歴移動、bookmark / history / go-to-path 起動、filter、palette、sort、terminal 切り替えを処理する
   - `Esc` は active filter が残っている場合、選択解除より先に filter 解除を優先する
-- `FILTER`
-  - 文字入力、`Backspace`、`Enter`、`Down`、`Esc` を処理する
 - `PALETTE`
-  - query 更新、候補カーソル移動、コマンド実行、キャンセルを処理する
+  - 通常コマンドだけでなく、file search / grep search / history / bookmarks / go-to-path preview の各 source を同一 UI で扱う
+- `DETAIL`
+  - read-only 属性ダイアログを閉じるだけのモード
+- `EXTRACT`
+  - archive 展開先の入力バーを表示し、`Enter` で事前チェックまたは展開開始へ進む
 - `CONFIG`
-  - config overlay 上で起動時設定を編集し、terminal editor のプリセット選択を含めて `s` で保存し、`e` で生の `config.toml` をターミナル内エディタで開く
-- `RENAME` / `CREATE`
-  - 入力バーで名前を編集し、`Enter` で mutation effect を発行する
-- `CONFIRM`
-  - delete 確認、paste conflict、rename/create の重複名警告を扱う
-- `BUSY`
-  - snapshot 読み込みや file mutation 実行中の待機状態
+  - config overlay 上で起動時設定を編集し、`s` で保存し、`e` で生の `config.toml` を terminal editor で開く
 - split terminal 可視時
-  - 通常の browse 用キーバインドではなく terminal 入力が優先され、`Ctrl+T` で閉じる
+  - 通常の browse 用キーバインドではなく terminal 入力が優先され、`Ctrl+T` または `Esc` で閉じる
 
 ## 6. 現在できること
 
-- `CWD` から実ファイルシステムを読み込んで 3 ペイン UI を起動
+- `CWD` から実 filesystem を読み込んで 3 ペイン UI を起動
 - 親 / 現在 / 子ディレクトリ表示とカーソル移動
-- ディレクトリへの移動、親ディレクトリへの復帰、再読み込み
+- ディレクトリ移動、親ディレクトリ復帰、home 移動、再読み込み
+- back / forward 履歴移動と履歴一覧からのジャンプ
+- bookmark 一覧からのジャンプと、現在ディレクトリの bookmark 追加 / 削除
+- go-to-path 入力による任意パスへの移動
 - filter 入力と filter 適用後の一覧継続操作
-- 名前 / 更新日時 / サイズソートとディレクトリ優先表示切り替え
+- 名前 / 更新日時 / サイズソートと directory-first 切り替え
+- 必要に応じた可視ディレクトリの再帰サイズ表示
 - 選択トグル、選択解除、copy / cut / paste
 - 貼り付け時の競合検出と overwrite / skip / rename の解決
 - 単一対象の rename
 - 新規ファイル / 新規ディレクトリ作成
-- ゴミ箱への削除と複数対象削除時の確認ダイアログ
+- ゴミ箱への削除と確認ダイアログ
 - ファイルの既定アプリ起動
-- `e` による現在のターミナル内エディタ起動
-- コマンドパレットからの再帰ファイル検索（通常部分一致と `re:` regex、invalid regex の inline 表示を含む）、属性表示、path copy、既定ファイラー起動、terminal 起動、hidden files 切り替え
-- config overlay による起動時設定の編集と `config.toml` 保存
-- 埋め込み split terminal の起動、入力、終了通知
+- `e` による現在の terminal 内 editor 起動
+- コマンドパレットからの再帰 file search、再帰 grep search、属性表示、path copy、既定 file manager 起動、外部 terminal 起動、hidden files 切り替え
+- 対応 archive (`.zip` / `.tar` / `.tar.gz` / `.tar.bz2`) の展開、競合確認、進捗表示
+- config overlay による起動時設定と bookmark の保存
+- 埋め込み split terminal の起動、入力、clipboard paste、終了通知
 - status bar / help bar / input bar / conflict dialog / attribute dialog / config dialog / split terminal の状態連動表示
 
-## 7. 現時点で未接続または未実装の範囲
+## 7. 現時点で未実装または限定的な範囲
 
-- `HistoryState` は state にあるが、戻る / 進む操作としてはまだ UI に接続していない
 - ファイル内容プレビュー、アプリ内編集、Git 連携、タブ機能、キーバインドカスタマイズは未実装
+- Windows ネイティブ実行は依然として非対応で、設定上の `windows` キーは将来互換用
+- directory size 計算や archive 展開は可視対象数やアーカイブ内容に応じてコストが増えるため、runtime 側で cancel と進捗管理を前提にしている
 
-filesystem mutation は、UI が選択している entry path をそのまま trust boundary として扱う。選択対象が symlink の場合でも最終パス要素を canonicalize せず、delete / rename / move / copy / overwrite / trash は symlink 自体に作用させる。
+filesystem mutation は、UI が選択している entry path をそのまま trust boundary として扱います。  
+選択対象が symlink の場合でも最終パス要素を canonicalize せず、delete / rename / move / copy / overwrite / trash は symlink 自体に作用させます。
 
 ## 8. 拡張時の差し込み方
 
@@ -257,12 +348,13 @@ filesystem mutation は、UI が選択している entry path をそのまま tr
 flowchart TD
     Key["新しい操作"] --> Input["input.py に dispatch 追加"]
     Input --> Action["actions.py に Action 追加"]
-    Action --> Reducer["reducer.py に状態遷移追加"]
-    Reducer --> Effect["必要なら Effect 追加"]
-    Effect --> Service["services/ に実行追加"]
+    Action --> Reducer["reducer_* に状態遷移追加"]
+    Reducer --> Effect["必要なら effects.py に Effect 追加"]
+    Effect --> Runtime["app_runtime.py に scheduler / 完了ハンドラ追加"]
+    Runtime --> Service["services/ に実行追加"]
     Service --> Adapter["OS / FS 差異は adapters へ委譲"]
-    Reducer --> Selector["表示変更が必要なら selector 更新"]
-    Selector --> UI["UI は表示更新のみ"]
+    Reducer --> Selector["表示変更が必要なら selectors 更新"]
+    Selector --> Shell["app_shell.py / ui は表示更新のみ"]
 ```
 
 この流れを守ることで、widget ごとの分岐を増やさずに機能追加を局所化できます。


### PR DESCRIPTION
## Summary
- refresh `docs/architecture.md` to match the current reducer/runtime/service split
- refresh `docs/architecture.en.md` with the same structure and current feature set
- document current history, bookmarks, go-to-path, directory size, archive extraction, and split terminal flows

## Testing
- `uv run pytest`
- `uv run ruff check .`

Closes #248
