### PR TITLE
Fix #260: ディレクトリを移動したらフィルターは解除

### DIFF
--- a/src/peneo/state/reducer_navigation.py
+++ b/src/peneo/state/reducer_navigation.py
@@ -31,7 +31,7 @@ from .actions import (
     ToggleHiddenFiles,
 )
 from .effects import LoadBrowserSnapshotEffect, ReduceResult, RunDirectorySizeEffect
-from .models import AppState, DirectorySizeCacheEntry, NotificationState, PaneState
+from .models import AppState, DirectorySizeCacheEntry, FilterState, NotificationState, PaneState
 from .reducer_common import (
     ReducerFn,
     build_history_after_snapshot_load,
@@ -386,6 +386,11 @@ def handle_navigation_action(
                 state.current_pane.selection_anchor_path,
                 tuple(entry.path for entry in action.snapshot.current_pane.entries),
             )
+        filter_state = (
+            FilterState()
+            if action.snapshot.current_path != state.current_path
+            else state.filter
+        )
         next_state = replace(
             state,
             current_path=action.snapshot.current_path,
@@ -396,6 +401,7 @@ def handle_navigation_action(
                 selection_anchor_path=selection_anchor_path,
             ),
             child_pane=action.snapshot.child_pane,
+            filter=filter_state,
             notification=state.post_reload_notification,
             post_reload_notification=None,
             pending_browser_snapshot_request_id=None,

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -4097,3 +4097,75 @@ def test_go_forward_then_snapshot_loaded_updates_history_correctly() -> None:
     assert loaded_result.current_path == forward_path
     assert loaded_result.history.back == (initial_path,)
     assert loaded_result.history.forward == ()
+
+
+def test_browser_snapshot_loaded_clears_filter_when_directory_changes() -> None:
+    state = build_initial_app_state()
+    state = _reduce_state(state, SetFilterQuery("readme"))
+
+    requested = reduce_app_state(
+        state,
+        RequestBrowserSnapshot("/tmp/example", blocking=True),
+    ).state
+    snapshot = BrowserSnapshot(
+        current_path="/tmp/example",
+        parent_pane=requested.parent_pane,
+        current_pane=requested.current_pane,
+        child_pane=requested.child_pane,
+    )
+    next_state = _reduce_state(
+        requested,
+        BrowserSnapshotLoaded(request_id=1, snapshot=snapshot, blocking=True),
+    )
+
+    assert next_state.filter.query == ""
+    assert next_state.filter.active is False
+
+
+def test_browser_snapshot_loaded_preserves_filter_on_reload() -> None:
+    state = build_initial_app_state()
+    state = _reduce_state(state, SetFilterQuery("readme"))
+    initial_path = state.current_path
+
+    requested = reduce_app_state(
+        state,
+        RequestBrowserSnapshot(initial_path, blocking=True),
+    ).state
+    snapshot = BrowserSnapshot(
+        current_path=initial_path,
+        parent_pane=requested.parent_pane,
+        current_pane=requested.current_pane,
+        child_pane=requested.child_pane,
+    )
+    next_state = _reduce_state(
+        requested,
+        BrowserSnapshotLoaded(request_id=1, snapshot=snapshot, blocking=True),
+    )
+
+    assert next_state.filter.query == "readme"
+    assert next_state.filter.active is True
+
+
+def test_browser_snapshot_loaded_exits_filter_mode_on_directory_change() -> None:
+    state = build_initial_app_state()
+    state = _reduce_state(state, BeginFilterInput())
+    state = _reduce_state(state, SetFilterQuery("test"))
+
+    requested = reduce_app_state(
+        state,
+        RequestBrowserSnapshot("/tmp/example", blocking=True),
+    ).state
+    snapshot = BrowserSnapshot(
+        current_path="/tmp/example",
+        parent_pane=requested.parent_pane,
+        current_pane=requested.current_pane,
+        child_pane=requested.child_pane,
+    )
+    next_state = _reduce_state(
+        requested,
+        BrowserSnapshotLoaded(request_id=1, snapshot=snapshot, blocking=True),
+    )
+
+    assert next_state.ui_mode == "BROWSING"
+    assert next_state.filter.query == ""
+    assert next_state.filter.active is False


### PR DESCRIPTION
## Summary
- ディレクトリ移動時にフィルター状態を自動的に解除するように変更
- リロード（同じディレクトリ）時はフィルターを保持

## Changes
- `BrowserSnapshotLoaded` ハンドラーにフィルター解除ロジックを追加
- ディレクトリ変更時: フィルターをクリア
- リロード時: フィルターを保持

## Test plan
- [x] 単体テスト追加（3件）
  - `test_browser_snapshot_loaded_clears_filter_when_directory_changes`
  - `test_browser_snapshot_loaded_preserves_filter_on_reload`
  - `test_browser_snapshot_loaded_exits_filter_mode_on_directory_change`
- [x] 既存テスト全件パス（574件）
- [ ] 手動テスト

## 手動テスト手順
1. アプリケーションを起動: `uv run peneo`
2. `/` キーでフィルター入力モードを開始
3. フィルタクエリを入力（例: "readme"）
4. フィルターが適用されていることを確認
5. 別のディレクトリに移動（Enter、Backspace、矢印キーなど）
6. フィルターが解除されていることを確認
7. フィルターを再度適用
8. F5 でリロード
9. フィルターが保持されていることを確認

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)