### PR TITLE
Add badges to README (#264)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,11 @@
 # Peneo
 
+![CI](https://github.com/devgamesan/peneo/workflows/Python%20CI/badge.svg)
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
+![Release](https://img.shields.io/github/v/release/devgamesan/peneo)
+![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)
+
 [English README](README.md)
 
 Peneo は、ターミナルで作業しながら GUI アプリとも自然に行き来したい環境向けの、Textual ベースの TUI ファイルマネージャです。親 / 現在 / 子ディレクトリを並べた 3 ペイン構成で、GUI のファイラーに近い感覚で主要操作へたどり着けることを重視しています。よく使う操作は画面上のヘルプに常時表示され、Peneo 上の操作から各種ファイルを OS の既定アプリで開けます。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Peneo
 
+![CI](https://github.com/devgamesan/peneo/workflows/Python%20CI/badge.svg)
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
+![Release](https://img.shields.io/github/v/release/devgamesan/peneo)
+![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)
+
 [日本語版 README](README.ja.md)
 
 Peneo is a Textual-based TUI file manager for environments where you want to keep working in the terminal while still moving smoothly into GUI applications. Its three-pane layout shows the parent, current, and child directories side by side, aiming to feel closer to a GUI file explorer than to a keyboard-heavy power-user tool. Common actions stay visible in the on-screen help, and files can be opened in the OS default app directly from Peneo.


### PR DESCRIPTION
## Summary
- Add CI, license, Python version, release, and Ruff badges to README.md
- Add the same badges to README.ja.md for consistency
- Badges are displayed prominently below the project title

## Test plan
- [x] Verify badges display correctly in Markdown preview
- [ ] Verify badges render correctly on GitHub after merge
- [ ] Verify CI badge links to GitHub Actions
- [ ] Run existing tests to ensure no regressions: `uv run pytest`

## Related Issue
Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)