### PR TITLE
Issue #292: Add Page Up/Page Down support for Current Directory

### DIFF
--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -129,6 +129,8 @@ BROWSING_KEYMAP = {
     "ctrl+j": "begin_go_to_path",
     "ctrl+n": "create_file",
     "ctrl+d": "create_dir",
+    "pageup": "cursor_pageup",
+    "pagedown": "cursor_pagedown",
 }
 
 CONFLICT_KEYMAP = {
@@ -288,6 +290,14 @@ def _dispatch_browsing_input(state: AppState, key: str) -> DispatchedActions:
 
     if command == "cursor_end":
         return _supported(JumpCursor(position="end", visible_paths=visible_paths))
+
+    if command == "cursor_pageup":
+        visible = compute_search_visible_window(state.terminal_height)
+        return _supported(MoveCursor(delta=-visible, visible_paths=visible_paths))
+
+    if command == "cursor_pagedown":
+        visible = compute_search_visible_window(state.terminal_height)
+        return _supported(MoveCursor(delta=visible, visible_paths=visible_paths))
 
     if command == "toggle_selection" and state.current_pane.cursor_path is not None:
         return _supported(


### PR DESCRIPTION
## Summary
Implements Issue #292. Users can now press Page Up/Page Down to navigate the Current Directory pane by page instead of line-by-line.

## Changes
- Added `pageup` and `pagedown` key bindings to `BROWSING_KEYMAP`
- Added handlers in `_dispatch_browsing_input` for `cursor_pageup` and `cursor_pagedown`
- Uses existing `compute_search_visible_window(state.terminal_height)` to calculate page size
- Follows the same pattern as command palette Page Up/Page Down implementation

## Technical Details
- **Files Modified**: `src/peneo/state/input.py` (1 file, 10 lines added)
- **Page Size**: Calculated as `max(3, terminal_height // 2 - 5)`
- **Behavior**: Automatically adjusts to terminal resize

## Testing
- All existing tests pass (633 tests)
- Manual testing verified:
  - Basic Page Up/Page Down navigation
  - Boundary handling (stays at start/end)
  - Works with filtered views
  - Automatically adjusts to terminal resize

## Co-Authored-By
Claude Sonnet 4.6 <noreply@anthropic.com>