### PR TITLE
Issue #284 Optimize current pane row updates

### DIFF
--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -19,6 +19,7 @@ class PaneEntry:
     selected: bool = False
     cut: bool = False
     executable: bool = False
+    path: str = ""
 
     @property
     def kind_label(self) -> str:
@@ -168,11 +169,41 @@ def build_dummy_shell_data() -> ThreePaneShellData:
     """Return static data for the initial three-pane shell."""
 
     current_entries = (
-        PaneEntry("docs", "dir", "-", "2026-03-21 09:10"),
-        PaneEntry("src", "dir", "-", "2026-03-20 19:42"),
-        PaneEntry("tests", "dir", "-", "2026-03-20 19:42"),
-        PaneEntry("README.md", "file", "2.1 KB", "2026-03-21 08:55"),
-        PaneEntry("pyproject.toml", "file", "712 B", "2026-03-20 18:11"),
+        PaneEntry(
+            "docs",
+            "dir",
+            "-",
+            "2026-03-21 09:10",
+            path="/home/tadashi/develop/peneo/docs",
+        ),
+        PaneEntry(
+            "src",
+            "dir",
+            "-",
+            "2026-03-20 19:42",
+            path="/home/tadashi/develop/peneo/src",
+        ),
+        PaneEntry(
+            "tests",
+            "dir",
+            "-",
+            "2026-03-20 19:42",
+            path="/home/tadashi/develop/peneo/tests",
+        ),
+        PaneEntry(
+            "README.md",
+            "file",
+            "2.1 KB",
+            "2026-03-21 08:55",
+            path="/home/tadashi/develop/peneo/README.md",
+        ),
+        PaneEntry(
+            "pyproject.toml",
+            "file",
+            "712 B",
+            "2026-03-20 18:11",
+            path="/home/tadashi/develop/peneo/pyproject.toml",
+        ),
     )
 
     return ThreePaneShellData(

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -964,6 +964,7 @@ def _to_pane_entry(
         selected=selected,
         cut=cut,
         executable=_has_execute_permission(entry),
+        path=entry.path,
     )
 
 

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -305,11 +305,15 @@ class MainPane(Vertical):
         if not entries_changed and not cursor_changed:
             return
 
+        previous_entries = self._entries
         self._entries = next_entries
         self._cursor_index = cursor_index
         table = self.query_one(DataTable)
         if entries_changed:
-            self._rebuild_table(table)
+            if self._should_rebuild_rows(table, previous_entries, next_entries):
+                self._rebuild_table(table)
+            else:
+                self._update_changed_rows(table, previous_entries, next_entries)
         if entries_changed or cursor_changed:
             self._apply_cursor_state(table)
 
@@ -371,6 +375,39 @@ class MainPane(Vertical):
             return
         self._rebuild_table(table)
 
+    def _should_rebuild_rows(
+        self,
+        table: DataTable,
+        previous_entries: Sequence[PaneEntry],
+        next_entries: Sequence[PaneEntry],
+    ) -> bool:
+        if table.size.width != self._last_table_width:
+            return True
+        if len(previous_entries) != len(next_entries):
+            return True
+        return self._entry_row_keys(previous_entries) != self._entry_row_keys(next_entries)
+
+    def _update_changed_rows(
+        self,
+        table: DataTable,
+        previous_entries: Sequence[PaneEntry],
+        next_entries: Sequence[PaneEntry],
+    ) -> None:
+        column_widths = self._allocate_column_widths(table)
+        for index, (previous_entry, next_entry) in enumerate(
+            zip(previous_entries, next_entries, strict=False)
+        ):
+            if previous_entry == next_entry:
+                continue
+            next_cells = self._build_row_cells(next_entry, column_widths)
+            row_key = self._row_key(next_entry, index)
+            for column_key, next_cell in zip(
+                self.COLUMN_KEYS,
+                next_cells,
+                strict=False,
+            ):
+                table.update_cell(row_key, column_key, next_cell)
+
     def _rebuild_table(self, table: DataTable) -> None:
         column_widths = self._allocate_column_widths(table)
         table.clear(columns=True)
@@ -388,38 +425,57 @@ class MainPane(Vertical):
             width=column_widths["modified"],
             key=self.COLUMN_KEYS[3],
         )
-        for entry in self._entries:
+        for index, entry in enumerate(self._entries):
             table.add_row(
-                self._render_cell(
-                    entry.selection_marker,
-                    entry.selected,
-                    entry.cut,
-                    entry.executable,
-                    entry.kind,
-                ),
-                self._render_cell(
-                    truncate_middle(build_entry_label(entry), column_widths["name"]),
-                    entry.selected,
-                    entry.cut,
-                    entry.executable,
-                    entry.kind,
-                ),
-                self._render_cell(
-                    entry.size_label,
-                    entry.selected,
-                    entry.cut,
-                    entry.executable,
-                    entry.kind,
-                ),
-                self._render_cell(
-                    entry.modified_label,
-                    entry.selected,
-                    entry.cut,
-                    entry.executable,
-                    entry.kind,
-                ),
+                *self._build_row_cells(entry, column_widths),
+                key=self._row_key(entry, index),
             )
         self._last_table_width = table.size.width
+
+    @classmethod
+    def _entry_row_keys(cls, entries: Sequence[PaneEntry]) -> tuple[str, ...]:
+        return tuple(cls._row_key(entry, index) for index, entry in enumerate(entries))
+
+    @staticmethod
+    def _row_key(entry: PaneEntry, index: int) -> str:
+        return entry.path or f"__row__:{index}"
+
+    @classmethod
+    def _build_row_cells(
+        cls,
+        entry: PaneEntry,
+        column_widths: dict[str, int],
+    ) -> tuple[Text, Text, Text, Text]:
+        return (
+            cls._render_cell(
+                entry.selection_marker,
+                entry.selected,
+                entry.cut,
+                entry.executable,
+                entry.kind,
+            ),
+            cls._render_cell(
+                truncate_middle(build_entry_label(entry), column_widths["name"]),
+                entry.selected,
+                entry.cut,
+                entry.executable,
+                entry.kind,
+            ),
+            cls._render_cell(
+                entry.size_label,
+                entry.selected,
+                entry.cut,
+                entry.executable,
+                entry.kind,
+            ),
+            cls._render_cell(
+                entry.modified_label,
+                entry.selected,
+                entry.cut,
+                entry.executable,
+                entry.kind,
+            ),
+        )
 
     @classmethod
     def _allocate_column_widths(cls, table: DataTable) -> dict[str, int]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -377,6 +377,27 @@ class BlockingGrepSearchService:
         return self.results_by_query.get(key, ())
 
 
+class BlockingDirectorySizeService:
+    def __init__(self) -> None:
+        self.executed_requests: list[tuple[str, ...]] = []
+        self.release_event = threading.Event()
+
+    def calculate_sizes(
+        self,
+        paths: tuple[str, ...],
+        *,
+        is_cancelled=None,
+    ) -> tuple[tuple[tuple[str, int], ...], tuple[tuple[str, str], ...]]:
+        self.executed_requests.append(paths)
+        while not self.release_event.wait(0.01):
+            if is_cancelled is not None and is_cancelled():
+                return (), ()
+        return tuple((path, 1_000 * (index + 1)) for index, path in enumerate(paths)), ()
+
+    def release(self) -> None:
+        self.release_event.set()
+
+
 async def _wait_for_row_count(app, expected_count: int, timeout: float = 0.5) -> None:
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
@@ -1378,6 +1399,118 @@ async def test_app_refresh_keeps_parent_pane_items_when_entries_are_unchanged() 
         await asyncio.sleep(0.05)
 
         assert tuple(app.query_one("#parent-pane-list", ListView).children) == parent_items
+
+
+@pytest.mark.asyncio
+async def test_app_selection_toggle_avoids_rebuilding_large_current_pane(monkeypatch) -> None:
+    path = "/tmp/peneo-large-selection"
+    current_entries = tuple(
+        DirectoryEntryState(f"{path}/file_{index:04d}.txt", f"file_{index:04d}.txt", "file")
+        for index in range(1000)
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 1000, timeout=2.0)
+
+        current_table = app.query_one("#current-pane-table", DataTable)
+        original_clear = DataTable.clear
+        original_add_row = DataTable.add_row
+        clear_calls = 0
+        add_row_calls = 0
+
+        def counting_clear(self, columns: bool = False):
+            nonlocal clear_calls
+            if self is current_table:
+                clear_calls += 1
+            return original_clear(self, columns=columns)
+
+        def counting_add_row(self, *cells, **kwargs):
+            nonlocal add_row_calls
+            if self is current_table:
+                add_row_calls += 1
+            return original_add_row(self, *cells, **kwargs)
+
+        monkeypatch.setattr(DataTable, "clear", counting_clear)
+        monkeypatch.setattr(DataTable, "add_row", counting_add_row)
+
+        await pilot.press("space")
+        await asyncio.sleep(0.05)
+
+        first_row = current_table.get_row_at(0)
+
+        assert clear_calls == 0
+        assert add_row_calls == 0
+        assert app.app_state.current_pane.selected_paths == {f"{path}/file_0000.txt"}
+        assert current_table.cursor_row == 1
+        assert isinstance(first_row[0], Text)
+        assert first_row[0].plain == "*"
+
+
+@pytest.mark.asyncio
+async def test_app_directory_size_update_avoids_rebuilding_large_current_pane(monkeypatch) -> None:
+    path = "/tmp/peneo-large-dir-size"
+    current_entries = tuple(
+        DirectoryEntryState(f"{path}/dir_{index:04d}", f"dir_{index:04d}", "dir")
+        for index in range(1000)
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+                child_path=current_entries[0].path,
+            )
+        }
+    )
+    directory_size_service = BlockingDirectorySizeService()
+    app = create_app(
+        snapshot_loader=loader,
+        directory_size_service=directory_size_service,
+        app_config=AppConfig(display=DisplayConfig(show_directory_sizes=True)),
+        initial_path=path,
+    )
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 1000, timeout=2.0)
+
+        current_table = app.query_one("#current-pane-table", DataTable)
+        original_clear = DataTable.clear
+        original_add_row = DataTable.add_row
+        clear_calls = 0
+        add_row_calls = 0
+
+        def counting_clear(self, columns: bool = False):
+            nonlocal clear_calls
+            if self is current_table:
+                clear_calls += 1
+            return original_clear(self, columns=columns)
+
+        def counting_add_row(self, *cells, **kwargs):
+            nonlocal add_row_calls
+            if self is current_table:
+                add_row_calls += 1
+            return original_add_row(self, *cells, **kwargs)
+
+        monkeypatch.setattr(DataTable, "clear", counting_clear)
+        monkeypatch.setattr(DataTable, "add_row", counting_add_row)
+
+        directory_size_service.release()
+        await _wait_for_directory_sizes(app, timeout=2.0)
+        await _wait_for_table_cell(app, "3.0 KB", 0, 2, timeout=2.0)
+
+        assert clear_calls == 0
+        assert add_row_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -4,15 +4,18 @@
 主要な操作のパフォーマンスを測定するベンチマークテストを提供します。
 """
 
+from dataclasses import replace
+
 import pytest
 
 from peneo.adapters.filesystem import LocalFilesystemAdapter
-from peneo.services.directory_size import DirectorySizeService
+from peneo.services.directory_size import LiveDirectorySizeService
 from peneo.state import (
     AppState,
     CommandPaletteSource,
     CommandPaletteState,
-    build_initial_app_state,
+    PaneState,
+    build_placeholder_app_state,
 )
 from peneo.state.command_palette import get_command_palette_items
 from peneo.state.reducer_common import list_matching_directory_paths
@@ -23,6 +26,22 @@ from tests.benchmark_fixtures import (
     create_large_directory,
 )
 from tests.benchmark_utils import benchmark, measure_import_time, measure_startup_time
+
+
+def _build_benchmark_state(path: str) -> AppState:
+    adapter = LocalFilesystemAdapter()
+    entries = adapter.list_directory(path)
+    cursor_path = entries[0].path if entries else None
+    state = build_placeholder_app_state(path)
+    return replace(
+        state,
+        current_path=path,
+        current_pane=PaneState(
+            directory_path=path,
+            entries=entries,
+            cursor_path=cursor_path,
+        ),
+    )
 
 
 class TestStartupBenchmarks:
@@ -92,15 +111,15 @@ class TestDirectoryBenchmarks:
         create_large_directory(tmp_path / "test_dir", num_dirs=100, num_files=400)
 
         adapter = LocalFilesystemAdapter()
-        service = DirectorySizeService(adapter)
+        service = LiveDirectorySizeService(filesystem=adapter)
 
         @benchmark(iterations=5, warmup=1)
         def _calculate_sizes():
-            # ディレクトリ内のファイルのサイズを計算
+            # ディレクトリ内のサブディレクトリサイズをまとめて計算
             entries = adapter.list_directory(str(tmp_path / "test_dir"))
-            file_entries = [e for e in entries if e.kind == "file"]
-            service.calculate_directory_sizes(
-                tuple(e.path for e in file_entries[:10]),  # 最初の10ファイル
+            dir_entries = [e for e in entries if e.kind == "dir"]
+            return service.calculate_sizes(
+                tuple(e.path for e in dir_entries[:10]),
             )
 
         result = _calculate_sizes()
@@ -121,7 +140,7 @@ class TestSelectorBenchmarks:
         create_flat_directory(tmp_path / "test_dir", num_entries=num_entries)
 
         # 初期状態を構築
-        state = build_initial_app_state(str(tmp_path / "test_dir"))
+        state = _build_benchmark_state(str(tmp_path / "test_dir"))
 
         @benchmark(iterations=100, warmup=10)
         def _select_shell_data():
@@ -168,22 +187,13 @@ class TestSelectorBenchmarks:
         create_flat_directory(tmp_path / "test_dir", num_entries=num_candidates)
 
         # go-to-path ソースのコマンドパレット状態を作成
-        state = build_initial_app_state(str(tmp_path / "test_dir"))
+        state = _build_benchmark_state(str(tmp_path / "test_dir"))
 
         # go_to_path_candidates を設定
         candidates = tuple(
             str(tmp_path / "test_dir" / f"dir_{i:05d}")
             for i in range(min(num_candidates, 100))
         )
-
-        # ディレクトリを作成
-        for candidate in candidates:
-            candidate_path = candidate
-            if "dir_" in candidate_path:
-                try:
-                    candidate_path.mkdir(exist_ok=True)
-                except (OSError, FileNotFoundError):
-                    pass
 
         state = AppState(
             **{
@@ -302,7 +312,7 @@ class TestQuickBenchmarks:
     def test_quick_selector_performance(self, tmp_path):
         """セレクタの簡易測定"""
         create_flat_directory(tmp_path / "test_dir", num_entries=1000)
-        state = build_initial_app_state(str(tmp_path / "test_dir"))
+        state = _build_benchmark_state(str(tmp_path / "test_dir"))
 
         @benchmark(iterations=50, warmup=5)
         def _select_shell_data():


### PR DESCRIPTION
## Summary
- switch Current Directory row refreshes to path-keyed diff updates instead of full table rebuilds when only row content changes
- add regression coverage for large-pane selection toggles and directory size updates so they no longer trigger full `clear()` / `add_row()` cycles
- align benchmark tests with the current directory-size and app-state APIs

## Testing
- `uv run ruff check .`
- `uv run pytest -q --ignore=tests/test_benchmarks.py --basetemp=/home/tadashi/.tmp/peneo-issue284-main`
- `TMPDIR=/home/tadashi/.tmp uv run pytest tests/test_benchmarks.py::TestSelectorBenchmarks::test_select_shell_data_performance[10000] tests/test_benchmarks.py::TestQuickBenchmarks::test_quick_selector_performance -q --basetemp=/home/tadashi/.tmp/peneo-issue284-bench`

Closes #284
