### PR TITLE
[#287] Add directory snapshot cache

### DIFF
--- a/src/peneo/app_runtime.py
+++ b/src/peneo/app_runtime.py
@@ -248,6 +248,8 @@ def _clear_tracking_for_request(app: Any, tracking: _TrackingConfig, request_id:
 
 
 def schedule_browser_snapshot(app: Any, effect: LoadBrowserSnapshotEffect) -> None:
+    if effect.invalidate_paths:
+        app._snapshot_loader.invalidate_directory_listing_cache(effect.invalidate_paths)
     _run_worker(
         app,
         effect,

--- a/src/peneo/services/browser_snapshot.py
+++ b/src/peneo/services/browser_snapshot.py
@@ -1,5 +1,7 @@
 """Snapshot loading services for three-pane browser state."""
 
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from time import sleep
@@ -11,9 +13,12 @@ from peneo.services import ArchiveListService, LiveArchiveListService
 from peneo.state.models import (
     AppState,
     BrowserSnapshot,
+    DirectoryEntryState,
     PaneState,
     build_initial_app_state,
 )
+
+DEFAULT_DIRECTORY_CACHE_CAPACITY = 64
 
 
 class BrowserSnapshotLoader(Protocol):
@@ -31,6 +36,11 @@ class BrowserSnapshotLoader(Protocol):
         cursor_path: str | None,
     ) -> PaneState: ...
 
+    def invalidate_directory_listing_cache(
+        self,
+        paths: tuple[str, ...] = (),
+    ) -> None: ...
+
 
 @dataclass(frozen=True)
 class LiveBrowserSnapshotLoader:
@@ -38,6 +48,19 @@ class LiveBrowserSnapshotLoader:
 
     filesystem: DirectoryReader = field(default_factory=LocalFilesystemAdapter)
     archive_list: ArchiveListService = field(default_factory=LiveArchiveListService)
+    directory_cache_capacity: int = DEFAULT_DIRECTORY_CACHE_CAPACITY
+    _directory_entries_cache: OrderedDict[str, tuple[DirectoryEntryState, ...]] = field(
+        default_factory=OrderedDict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _directory_entries_cache_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def load_browser_snapshot(
         self,
@@ -91,7 +114,54 @@ class LiveBrowserSnapshotLoader:
 
         return PaneState(directory_path=current_path, entries=())
 
+    def invalidate_directory_listing_cache(
+        self,
+        paths: tuple[str, ...] = (),
+    ) -> None:
+        normalized_paths = tuple(
+            dict.fromkeys(_normalize_directory_cache_path(path) for path in paths)
+        )
+        with self._directory_entries_cache_lock:
+            if not normalized_paths:
+                self._directory_entries_cache.clear()
+                return
+            for path in normalized_paths:
+                self._directory_entries_cache.pop(path, None)
+
     def _list_directory(self, path: str):
+        resolved_path = _normalize_directory_cache_path(path)
+        cached_entries = self._get_cached_directory_entries(resolved_path)
+        if cached_entries is not None:
+            return cached_entries
+        entries = self._read_directory(resolved_path)
+        self._store_cached_directory_entries(resolved_path, entries)
+        return entries
+
+    def _get_cached_directory_entries(
+        self,
+        path: str,
+    ) -> tuple[DirectoryEntryState, ...] | None:
+        with self._directory_entries_cache_lock:
+            entries = self._directory_entries_cache.get(path)
+            if entries is None:
+                return None
+            self._directory_entries_cache.move_to_end(path)
+            return entries
+
+    def _store_cached_directory_entries(
+        self,
+        path: str,
+        entries: tuple[DirectoryEntryState, ...],
+    ) -> None:
+        if self.directory_cache_capacity <= 0:
+            return
+        with self._directory_entries_cache_lock:
+            self._directory_entries_cache[path] = entries
+            self._directory_entries_cache.move_to_end(path)
+            while len(self._directory_entries_cache) > self.directory_cache_capacity:
+                self._directory_entries_cache.popitem(last=False)
+
+    def _read_directory(self, path: str):
         try:
             return self.filesystem.list_directory(path)
         except PermissionError as error:
@@ -117,6 +187,7 @@ class FakeBrowserSnapshotLoader:
     child_delay_seconds: Mapping[tuple[str, str | None], float] = field(default_factory=dict)
     archive_list: ArchiveListService = field(default_factory=LiveArchiveListService)
     executed_child_pane_requests: list[tuple[str, str | None]] = field(default_factory=list)
+    invalidated_directory_listing_paths: list[tuple[str, ...]] = field(default_factory=list)
 
     def load_browser_snapshot(
         self,
@@ -155,6 +226,15 @@ class FakeBrowserSnapshotLoader:
             return pane
 
         return PaneState(directory_path=current_path, entries=())
+
+    def invalidate_directory_listing_cache(
+        self,
+        paths: tuple[str, ...] = (),
+    ) -> None:
+        normalized_paths = tuple(
+            dict.fromkeys(_normalize_directory_cache_path(path) for path in paths)
+        )
+        self.invalidated_directory_listing_paths.append(normalized_paths)
 
     def _resolve_snapshot(
         self,
@@ -222,3 +302,7 @@ def _resolve_cursor_path(entries, cursor_path: str | None) -> str | None:
 
 def _contains_path(entries, path: str) -> bool:
     return any(entry.path == path for entry in entries)
+
+
+def _normalize_directory_cache_path(path: str) -> str:
+    return str(Path(path).expanduser().resolve())

--- a/src/peneo/state/actions.py
+++ b/src/peneo/state/actions.py
@@ -522,6 +522,7 @@ class RequestBrowserSnapshot:
     path: str
     cursor_path: str | None = None
     blocking: bool = False
+    invalidate_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/peneo/state/effects.py
+++ b/src/peneo/state/effects.py
@@ -24,6 +24,7 @@ class LoadBrowserSnapshotEffect:
     path: str
     cursor_path: str | None = None
     blocking: bool = False
+    invalidate_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -386,6 +386,17 @@ def restore_ui_mode_after_pending_input(state: AppState) -> str:
     return "RENAME"
 
 
+def browser_snapshot_invalidation_paths(
+    path: str,
+    cursor_path: str | None = None,
+) -> tuple[str, ...]:
+    resolved_path = str(Path(path).expanduser().resolve())
+    paths = [resolved_path, str(Path(resolved_path).parent)]
+    if cursor_path is not None:
+        paths.append(str(Path(cursor_path).expanduser().resolve()))
+    return tuple(dict.fromkeys(paths))
+
+
 def request_snapshot_refresh(
     state: AppState,
     *,
@@ -393,6 +404,11 @@ def request_snapshot_refresh(
     keep_current_cursor: bool = True,
 ) -> ReduceResult:
     request_id = state.next_request_id
+    resolved_cursor_path = (
+        state.current_pane.cursor_path
+        if keep_current_cursor and cursor_path is None
+        else cursor_path
+    )
     next_state = replace(
         state,
         pending_browser_snapshot_request_id=request_id,
@@ -405,12 +421,12 @@ def request_snapshot_refresh(
             LoadBrowserSnapshotEffect(
                 request_id=request_id,
                 path=state.current_path,
-                cursor_path=(
-                    state.current_pane.cursor_path
-                    if keep_current_cursor and cursor_path is None
-                    else cursor_path
-                ),
+                cursor_path=resolved_cursor_path,
                 blocking=False,
+                invalidate_paths=browser_snapshot_invalidation_paths(
+                    state.current_path,
+                    resolved_cursor_path,
+                ),
             ),
         ),
     )

--- a/src/peneo/state/reducer_mutations.py
+++ b/src/peneo/state/reducer_mutations.py
@@ -66,6 +66,7 @@ from .models import (
 from .reducer_common import (
     ReducerFn,
     active_current_entries,
+    browser_snapshot_invalidation_paths,
     build_extract_archive_request,
     build_file_mutation_request,
     build_zip_compress_request,
@@ -734,6 +735,10 @@ def handle_mutation_action(
                 path=str(Path(action.result.destination_path).parent),
                 cursor_path=action.result.destination_path,
                 blocking=True,
+                invalidate_paths=browser_snapshot_invalidation_paths(
+                    str(Path(action.result.destination_path).parent),
+                    action.result.destination_path,
+                ),
             ),
         )
 
@@ -840,6 +845,10 @@ def handle_mutation_action(
                 path=str(Path(action.result.destination_path).parent),
                 cursor_path=action.result.destination_path,
                 blocking=True,
+                invalidate_paths=browser_snapshot_invalidation_paths(
+                    str(Path(action.result.destination_path).parent),
+                    action.result.destination_path,
+                ),
             ),
         )
 

--- a/src/peneo/state/reducer_navigation.py
+++ b/src/peneo/state/reducer_navigation.py
@@ -34,6 +34,7 @@ from .effects import LoadBrowserSnapshotEffect, ReduceResult, RunDirectorySizeEf
 from .models import AppState, DirectorySizeCacheEntry, FilterState, NotificationState, PaneState
 from .reducer_common import (
     ReducerFn,
+    browser_snapshot_invalidation_paths,
     build_history_after_snapshot_load,
     current_entry_for_path,
     current_entry_paths,
@@ -286,6 +287,10 @@ def handle_navigation_action(
                 state.current_path,
                 cursor_path=state.current_pane.cursor_path,
                 blocking=True,
+                invalidate_paths=browser_snapshot_invalidation_paths(
+                    state.current_path,
+                    state.current_pane.cursor_path,
+                ),
             ),
         )
 
@@ -393,6 +398,7 @@ def handle_navigation_action(
                 path=action.path,
                 cursor_path=action.cursor_path,
                 blocking=action.blocking,
+                invalidate_paths=action.invalidate_paths,
             ),
         )
 

--- a/tests/test_app_runtime.py
+++ b/tests/test_app_runtime.py
@@ -18,6 +18,7 @@ from peneo.app_runtime import (
     failed_worker_actions,
     handle_worker_state_changed,
     run_foreground_external_launch,
+    schedule_browser_snapshot,
     schedule_child_pane_snapshot,
     schedule_file_search,
     start_child_pane_snapshot,
@@ -65,8 +66,26 @@ class _RecordingTimer:
 
 
 @dataclass
+class _RecordingSnapshotLoader:
+    invalidated_paths: list[tuple[str, ...]] = field(default_factory=list)
+    load_browser_snapshot_calls: list[tuple[str, str | None]] = field(default_factory=list)
+
+    def invalidate_directory_listing_cache(self, paths: tuple[str, ...] = ()) -> None:
+        self.invalidated_paths.append(paths)
+
+    def load_browser_snapshot(
+        self,
+        path: str,
+        cursor_path: str | None = None,
+    ) -> None:
+        self.load_browser_snapshot_calls.append((path, cursor_path))
+        return None
+
+
+@dataclass
 class _RecordingApp:
     _app_state: Any = field(default_factory=build_initial_app_state)
+    _snapshot_loader: Any = field(default_factory=_RecordingSnapshotLoader)
     _pending_workers: dict[str, object] = field(default_factory=dict)
     _child_pane_timer: Any = None
     _file_search_timer: Any = None
@@ -186,6 +205,25 @@ def test_complete_worker_actions_maps_browser_snapshot_load() -> None:
             blocking=True,
         ),
     )
+
+
+def test_schedule_browser_snapshot_invalidates_requested_paths_before_worker() -> None:
+    loader = _RecordingSnapshotLoader()
+    app = _RecordingApp(_snapshot_loader=loader)
+    effect = LoadBrowserSnapshotEffect(
+        request_id=7,
+        path="/tmp/project",
+        cursor_path="/tmp/project/docs",
+        blocking=True,
+        invalidate_paths=("/tmp/project", "/tmp", "/tmp/project/docs"),
+    )
+
+    schedule_browser_snapshot(app, effect)
+    worker_fn = app.run_worker_calls[0]["worker_fn"]
+    worker_fn()
+
+    assert loader.invalidated_paths == [("/tmp/project", "/tmp", "/tmp/project/docs")]
+    assert loader.load_browser_snapshot_calls == [("/tmp/project", "/tmp/project/docs")]
 
 
 def test_complete_worker_actions_maps_directory_size_result() -> None:

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 import pytest
 
+from peneo.adapters import LocalFilesystemAdapter
 from peneo.services import FakeBrowserSnapshotLoader, LiveBrowserSnapshotLoader
 from peneo.state import BrowserSnapshot, DirectoryEntryState, PaneState
 
@@ -10,11 +11,21 @@ from peneo.state import BrowserSnapshot, DirectoryEntryState, PaneState
 class StubFilesystemAdapter:
     entries_by_path: dict[str, tuple[DirectoryEntryState, ...]] = field(default_factory=dict)
     errors_by_path: dict[str, Exception] = field(default_factory=dict)
+    list_directory_calls: list[str] = field(default_factory=list)
 
     def list_directory(self, path: str) -> tuple[DirectoryEntryState, ...]:
+        self.list_directory_calls.append(path)
         if path in self.errors_by_path:
             raise self.errors_by_path[path]
         return self.entries_by_path[path]
+
+
+def _build_stub_filesystem(*paths: str) -> StubFilesystemAdapter:
+    live_filesystem = LocalFilesystemAdapter()
+    filesystem = StubFilesystemAdapter()
+    for path in paths:
+        filesystem.entries_by_path[path] = live_filesystem.list_directory(path)
+    return filesystem
 
 
 def test_live_browser_snapshot_loader_builds_three_pane_snapshot(tmp_path) -> None:
@@ -89,6 +100,63 @@ def test_live_browser_snapshot_loader_normalizes_permission_error() -> None:
         loader.load_browser_snapshot("/secret")
 
 
+def test_live_browser_snapshot_loader_reuses_directory_listings_across_snapshot_requests(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    docs = project / "docs"
+    docs.mkdir()
+    (docs / "spec.md").write_text("spec\n", encoding="utf-8")
+
+    filesystem = _build_stub_filesystem(str(project), str(tmp_path), str(docs))
+    loader = LiveBrowserSnapshotLoader(filesystem=filesystem)
+
+    first = loader.load_browser_snapshot(str(project), cursor_path=str(docs))
+    second = loader.load_browser_snapshot(str(project), cursor_path=str(docs))
+
+    assert first == second
+    assert filesystem.list_directory_calls == [str(project), str(tmp_path), str(docs)]
+
+
+def test_live_browser_snapshot_loader_reuses_cached_child_directory_snapshot(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    docs = project / "docs"
+    docs.mkdir()
+    (docs / "spec.md").write_text("spec\n", encoding="utf-8")
+
+    filesystem = _build_stub_filesystem(str(project), str(tmp_path), str(docs))
+    loader = LiveBrowserSnapshotLoader(filesystem=filesystem)
+
+    loader.load_browser_snapshot(str(project), cursor_path=str(docs))
+    loader.load_child_pane_snapshot(str(project), str(docs))
+
+    assert filesystem.list_directory_calls == [str(project), str(tmp_path), str(docs)]
+
+
+def test_live_browser_snapshot_loader_invalidates_selected_directory_cache_entry(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    docs = project / "docs"
+    docs.mkdir()
+    (docs / "spec.md").write_text("spec\n", encoding="utf-8")
+
+    filesystem = _build_stub_filesystem(str(project), str(tmp_path), str(docs))
+    loader = LiveBrowserSnapshotLoader(filesystem=filesystem)
+
+    loader.load_browser_snapshot(str(project), cursor_path=str(docs))
+    loader.invalidate_directory_listing_cache((str(project),))
+    loader.load_browser_snapshot(str(project), cursor_path=str(docs))
+
+    assert filesystem.list_directory_calls == [
+        str(project),
+        str(tmp_path),
+        str(docs),
+        str(project),
+    ]
+
+
 def test_fake_browser_snapshot_loader_prefers_requested_cursor_path() -> None:
     path = "/tmp/peneo"
     docs = f"{path}/docs"
@@ -115,3 +183,13 @@ def test_fake_browser_snapshot_loader_prefers_requested_cursor_path() -> None:
 
     assert resolved.current_pane.cursor_path == src
     assert resolved.child_pane.directory_path == src
+
+
+def test_fake_browser_snapshot_loader_records_invalidated_directory_listing_paths() -> None:
+    loader = FakeBrowserSnapshotLoader()
+
+    loader.invalidate_directory_listing_cache(("/tmp/project", "/tmp/project/docs"))
+
+    assert loader.invalidated_directory_listing_paths == [
+        ("/tmp/project", "/tmp/project/docs"),
+    ]

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -590,6 +590,11 @@ def test_reload_directory_requests_snapshot_with_current_cursor() -> None:
     assert result.effects[0].path == "/home/tadashi/develop/peneo"
     assert result.effects[0].cursor_path == "/home/tadashi/develop/peneo/src"
     assert result.effects[0].blocking is True
+    assert result.effects[0].invalidate_paths == (
+        "/home/tadashi/develop/peneo",
+        "/home/tadashi/develop",
+        "/home/tadashi/develop/peneo/src",
+    )
 
 
 def test_open_path_with_default_app_emits_external_launch_effect() -> None:
@@ -2939,6 +2944,7 @@ def test_archive_extract_completed_requests_snapshot_for_destination_parent() ->
             path="/tmp/output",
             cursor_path="/tmp/output/archive",
             blocking=True,
+            invalidate_paths=("/tmp/output", "/tmp", "/tmp/output/archive"),
         ),
     )
 
@@ -2978,6 +2984,7 @@ def test_zip_compress_completed_requests_snapshot_for_destination_parent() -> No
             path="/tmp",
             cursor_path="/tmp/output.zip",
             blocking=True,
+            invalidate_paths=("/tmp", "/", "/tmp/output.zip"),
         ),
     )
 
@@ -3445,6 +3452,19 @@ def test_clipboard_paste_completed_for_cut_clears_clipboard_and_requests_reload(
 
     assert result.state.clipboard.mode == "none"
     assert result.state.pending_browser_snapshot_request_id == 1
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path="/home/tadashi/develop/peneo",
+            cursor_path="/home/tadashi/develop/peneo/docs",
+            blocking=False,
+            invalidate_paths=(
+                "/home/tadashi/develop/peneo",
+                "/home/tadashi/develop",
+                "/home/tadashi/develop/peneo/docs",
+            ),
+        ),
+    )
 
 
 def test_file_mutation_completed_requests_reload_with_result_cursor() -> None:
@@ -3479,6 +3499,11 @@ def test_file_mutation_completed_requests_reload_with_result_cursor() -> None:
             path="/home/tadashi/develop/peneo",
             cursor_path="/home/tadashi/develop/peneo/notes.txt",
             blocking=False,
+            invalidate_paths=(
+                "/home/tadashi/develop/peneo",
+                "/home/tadashi/develop",
+                "/home/tadashi/develop/peneo/notes.txt",
+            ),
         ),
     )
 
@@ -3513,6 +3538,11 @@ def test_delete_file_mutation_completed_requests_reload_without_deleted_cursor()
             path="/home/tadashi/develop/peneo",
             cursor_path="/home/tadashi/develop/peneo/src",
             blocking=False,
+            invalidate_paths=(
+                "/home/tadashi/develop/peneo",
+                "/home/tadashi/develop",
+                "/home/tadashi/develop/peneo/src",
+            ),
         ),
     )
 


### PR DESCRIPTION
## Summary
- add an LRU cache for directory listings inside `LiveBrowserSnapshotLoader`
- invalidate cached listings before reload and post-mutation snapshot refreshes
- add regression tests for cache reuse, targeted invalidation, and runtime wiring

## Testing
- `uv run ruff check .`
- `uv run pytest -q`

Fixes #287
