### PR TITLE
#305 Optimize side pane updates

### DIFF
--- a/src/peneo/app_shell.py
+++ b/src/peneo/app_shell.py
@@ -104,7 +104,6 @@ async def refresh_shell(
         return
 
     current_path_bar.set_path(shell.current_path)
-    await parent_pane.set_entries(shell.parent_entries)
     current_pane.set_entries(shell.current_entries, shell.current_cursor_index)
     current_pane.set_cursor_state(
         shell.current_cursor_index,
@@ -113,6 +112,7 @@ async def refresh_shell(
     )
     current_pane.set_summary(shell.current_summary)
     current_pane.set_context_input(shell.current_context_input)
+    await parent_pane.set_entries(shell.parent_entries)
     await child_pane.set_entries(shell.child_entries)
     split_terminal.set_state(shell.split_terminal)
     resize_split_terminal_session(app, app_state, split_terminal_session)

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -142,13 +142,35 @@ class SidePane(Vertical):
         if next_entries == self._entries:
             return
 
-        self._entries = next_entries
         list_view = self.query_one(ListView)
-        await list_view.clear()
-        items = self._build_items(self._entries, self._entry_width(list_view))
-        if items:
-            await list_view.extend(items)
-        self._last_render_width = self._entry_width(list_view)
+        render_width = self._entry_width(list_view)
+        previous_entries = self._entries
+        previous_items = tuple(list_view.children)
+        if any(not self._item_has_label(item) for item in previous_items):
+            await self._rebuild_items(list_view, next_entries, render_width)
+            self._entries = next_entries
+            self._last_render_width = render_width
+            return
+
+        shared_count = min(len(previous_items), len(previous_entries), len(next_entries))
+        for index in range(shared_count):
+            if (
+                previous_entries[index] == next_entries[index]
+                and render_width == self._last_render_width
+            ):
+                continue
+            self._update_item(previous_items[index], next_entries[index], render_width)
+
+        if len(previous_items) > len(next_entries):
+            for item in previous_items[len(next_entries) :]:
+                await item.remove()
+        elif len(previous_items) < len(next_entries):
+            items = self._build_items(next_entries[len(previous_items) :], render_width)
+            if items:
+                await list_view.extend(items)
+
+        self._entries = next_entries
+        self._last_render_width = render_width
 
     def _refresh_rendered_labels(self) -> None:
         list_view = self.query_one(ListView)
@@ -156,11 +178,35 @@ class SidePane(Vertical):
         if render_width <= 0 or render_width == self._last_render_width:
             return
         for item, entry in zip(list_view.children, self._entries, strict=False):
-            try:
-                item.query_one(Label).update(self._render_label(entry, render_width))
-            except NoMatches:
-                continue
+            self._update_item(item, entry, render_width)
         self._last_render_width = render_width
+
+    @classmethod
+    def _update_item(cls, item: ListItem, entry: PaneEntry, render_width: int) -> None:
+        try:
+            item.query_one(Label).update(cls._render_label(entry, render_width))
+        except NoMatches:
+            pass
+
+    @staticmethod
+    def _item_has_label(item: ListItem) -> bool:
+        try:
+            item.query_one(Label)
+        except NoMatches:
+            return False
+        return True
+
+    @classmethod
+    async def _rebuild_items(
+        cls,
+        list_view: ListView,
+        entries: Sequence[PaneEntry],
+        render_width: int,
+    ) -> None:
+        await list_view.clear()
+        items = cls._build_items(entries, render_width)
+        if items:
+            await list_view.extend(items)
 
     @classmethod
     def _build_items(cls, entries: Sequence[PaneEntry], render_width: int) -> tuple[ListItem, ...]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -446,30 +446,47 @@ async def _wait_for_cursor_path(app, expected_path: str, timeout: float = 0.5) -
         await asyncio.sleep(0.01)
 
 
-async def _wait_for_child_entries(
+async def _wait_for_list_entries(
     app,
+    list_selector: str,
     expected_names: list[str],
     timeout: float = 0.5,
 ) -> None:
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
         try:
-            child_list = app.query_one("#child-pane-list", ListView)
+            pane_list = app.query_one(list_selector, ListView)
         except NoMatches:
-            child_list = None
-        if child_list is not None:
-            child_names: list[str] = []
-            for item in child_list.children:
+            pane_list = None
+        if pane_list is not None:
+            actual_names: list[str] = []
+            for item in pane_list.children:
                 try:
-                    child_names.append(str(item.query_one(Label).renderable))
+                    actual_names.append(str(item.query_one(Label).renderable))
                 except NoMatches:
-                    child_names = []
+                    actual_names = []
                     break
-            if child_names == expected_names:
+            if actual_names == expected_names:
                 return
         if asyncio.get_running_loop().time() >= deadline:
-            raise AssertionError(f"child entries did not become {expected_names}")
+            raise AssertionError(f"{list_selector} entries did not become {expected_names}")
         await asyncio.sleep(0.01)
+
+
+async def _wait_for_child_entries(
+    app,
+    expected_names: list[str],
+    timeout: float = 0.5,
+) -> None:
+    await _wait_for_list_entries(app, "#child-pane-list", expected_names, timeout=timeout)
+
+
+async def _wait_for_parent_entries(
+    app,
+    expected_names: list[str],
+    timeout: float = 0.5,
+) -> None:
+    await _wait_for_list_entries(app, "#parent-pane-list", expected_names, timeout=timeout)
 
 
 async def _wait_for_external_launch_count(app, expected_count: int, timeout: float = 0.5) -> None:
@@ -711,6 +728,8 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
     async with app.run_test():
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
+        await _wait_for_parent_entries(app, ["peneo-app", "sibling"])
+        await _wait_for_child_entries(app, ["spec.md"])
 
         parent_list = app.query_one("#parent-pane-list", ListView)
         current_table = app.query_one("#current-pane-table", DataTable)
@@ -3763,3 +3782,79 @@ async def test_app_large_directory_smoke_with_1000_entries(tmp_path) -> None:
         current_table = app.query_one("#current-pane-table", DataTable)
         assert current_table.row_count == 1000
         assert current_table.cursor_row == 150
+
+
+@pytest.mark.asyncio
+async def test_app_cursor_move_updates_large_child_pane_without_clearing(monkeypatch) -> None:
+    path = "/tmp/peneo-large-child-pane"
+    current_entries = (
+        DirectoryEntryState(f"{path}/docs", "docs", "dir"),
+        DirectoryEntryState(f"{path}/src", "src", "dir"),
+    )
+    docs_child_entries = tuple(
+        DirectoryEntryState(
+            f"{path}/docs/child-{index:04d}.txt",
+            f"child-{index:04d}.txt",
+            "file",
+        )
+        for index in range(1000)
+    )
+    src_child_entries = tuple(
+        DirectoryEntryState(
+            f"{path}/src/module-{index:04d}.py",
+            f"module-{index:04d}.py",
+            "file",
+        )
+        for index in range(1000)
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+                child_path=f"{path}/docs",
+                child_entries=docs_child_entries,
+            )
+        },
+        child_panes={
+            (path, f"{path}/src"): PaneState(
+                directory_path=f"{path}/src",
+                entries=src_child_entries,
+            )
+        },
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 2)
+        await _wait_for_child_list_label(app, "child-0999.txt", index=999, timeout=2.0)
+
+        child_list = app.query_one("#child-pane-list", ListView)
+        original_clear = ListView.clear
+        original_extend = ListView.extend
+        clear_calls = 0
+        extend_calls = 0
+
+        async def counting_clear(self, *args, **kwargs):
+            nonlocal clear_calls
+            if self is child_list:
+                clear_calls += 1
+            return await original_clear(self, *args, **kwargs)
+
+        async def counting_extend(self, *args, **kwargs):
+            nonlocal extend_calls
+            if self is child_list:
+                extend_calls += 1
+            return await original_extend(self, *args, **kwargs)
+
+        monkeypatch.setattr(ListView, "clear", counting_clear)
+        monkeypatch.setattr(ListView, "extend", counting_extend)
+
+        await pilot.press("down")
+        await _wait_for_child_list_label(app, "module-0999.py", index=999, timeout=2.0)
+
+        assert app.query_one("#child-pane-list", ListView) is child_list
+        assert len(child_list.children) == 1000
+        assert clear_calls == 0
+        assert extend_calls == 0


### PR DESCRIPTION
## Summary
- update `SidePane` to reuse existing rows and avoid full `clear()/extend()` on same-length child pane refreshes
- refresh the current pane before parent/child panes so central interactions are reflected first
- add headless regression coverage for large child panes and explicit waits for side-pane rendering

## Testing
- `uv run ruff check .`
- `uv run pytest`

Closes #305
