### PR TITLE
#313 Optimize side pane rendering

### DIFF
--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -8,8 +8,7 @@ from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.css.query import NoMatches
-from textual.widgets import DataTable, Label, ListItem, ListView
+from textual.widgets import DataTable, Label, Static
 
 from peneo.models.shell_data import (
     CurrentPaneRowUpdate,
@@ -128,13 +127,13 @@ class SidePane(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Label(self._title, classes="pane-title")
-        list_view = ListView(
-            *self._build_items(self._entries, 0),
+        content = Static(
+            self._render_entries(self._entries, 0),
             id=self.list_view_id,
             classes="pane-list",
         )
-        list_view.can_focus = False
-        yield list_view
+        content.can_focus = False
+        yield content
 
     def on_mount(self) -> None:
         self.call_after_refresh(self._refresh_rendered_labels)
@@ -149,80 +148,29 @@ class SidePane(Vertical):
         if next_entries == self._entries:
             return
 
-        list_view = self.query_one(ListView)
-        render_width = self._entry_width(list_view)
-        previous_entries = self._entries
-        previous_items = tuple(list_view.children)
-        if any(not self._item_has_label(item) for item in previous_items):
-            await self._rebuild_items(list_view, next_entries, render_width)
-            self._entries = next_entries
-            self._last_render_width = render_width
-            return
-
-        shared_count = min(len(previous_items), len(previous_entries), len(next_entries))
-        for index in range(shared_count):
-            if (
-                previous_entries[index] == next_entries[index]
-                and render_width == self._last_render_width
-            ):
-                continue
-            self._update_item(previous_items[index], next_entries[index], render_width)
-
-        if len(previous_items) > len(next_entries):
-            for item in previous_items[len(next_entries) :]:
-                await item.remove()
-        elif len(previous_items) < len(next_entries):
-            items = self._build_items(next_entries[len(previous_items) :], render_width)
-            if items:
-                await list_view.extend(items)
-
+        content = self._content_widget()
+        render_width = self._entry_width(content)
+        content.update(self._render_entries(next_entries, render_width))
         self._entries = next_entries
         self._last_render_width = render_width
 
     def _refresh_rendered_labels(self) -> None:
-        list_view = self.query_one(ListView)
-        render_width = self._entry_width(list_view)
+        content = self._content_widget()
+        render_width = self._entry_width(content)
         if render_width <= 0 or render_width == self._last_render_width:
             return
-        for item, entry in zip(list_view.children, self._entries, strict=False):
-            self._update_item(item, entry, render_width)
+        content.update(self._render_entries(self._entries, render_width))
         self._last_render_width = render_width
 
-    @classmethod
-    def _update_item(cls, item: ListItem, entry: PaneEntry, render_width: int) -> None:
-        try:
-            item.query_one(Label).update(cls._render_label(entry, render_width))
-        except NoMatches:
-            pass
-
-    @staticmethod
-    def _item_has_label(item: ListItem) -> bool:
-        try:
-            item.query_one(Label)
-        except NoMatches:
-            return False
-        return True
+    def _content_widget(self) -> Static:
+        return self.query_one(f"#{self.list_view_id}", Static)
 
     @classmethod
-    async def _rebuild_items(
-        cls,
-        list_view: ListView,
-        entries: Sequence[PaneEntry],
-        render_width: int,
-    ) -> None:
-        await list_view.clear()
-        items = cls._build_items(entries, render_width)
-        if items:
-            await list_view.extend(items)
-
-    @classmethod
-    def _build_items(cls, entries: Sequence[PaneEntry], render_width: int) -> tuple[ListItem, ...]:
-        return tuple(
-            ListItem(
-                Label(cls._render_label(entry, render_width), classes="pane-entry-label"),
-                classes="pane-entry",
-            )
-            for entry in entries
+    def _render_entries(cls, entries: Sequence[PaneEntry], render_width: int) -> Text:
+        if not entries:
+            return Text()
+        return Text("\n").join(
+            [cls._render_label(entry, render_width) for entry in entries]
         )
 
     @classmethod
@@ -257,8 +205,8 @@ class SidePane(Vertical):
 
         return Text(label)
 
-    def _entry_width(self, list_view: ListView) -> int:
-        return max(0, list_view.size.width - self.ENTRY_HORIZONTAL_PADDING)
+    def _entry_width(self, content: Static) -> int:
+        return max(0, content.size.width - self.ENTRY_HORIZONTAL_PADDING)
 
 
 class MainPane(Vertical):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from rich.text import Text
 from textual.css.query import NoMatches
-from textual.widgets import DataTable, Label, ListView, Static
+from textual.widgets import DataTable, Label, Static
 
 from peneo import create_app
 from peneo.models import (
@@ -279,23 +279,27 @@ async def _wait_for_table_cell(
 async def _wait_for_child_list_label(
     app, expected_substring: str, index: int = 0, timeout: float = 5.0
 ) -> None:
-    from textual.widgets import Label as TextualLabel
-
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
-        child_list = app.query_one("#child-pane-list", ListView)
-        if child_list.children:
-            try:
-                label = child_list.children[index].query_one(TextualLabel)
-                if expected_substring in str(label.renderable):
-                    return
-            except (NoMatches, IndexError):
-                pass
+        child_list = app.query_one("#child-pane-list", Static)
+        child_lines = _side_pane_lines(child_list)
+        try:
+            if expected_substring in child_lines[index]:
+                return
+        except IndexError:
+            pass
         if asyncio.get_running_loop().time() >= deadline:
             raise AssertionError(
                 f"child list label at index {index} did not contain {expected_substring!r}"
             )
         await asyncio.sleep(0.01)
+
+
+def _side_pane_lines(widget: Static) -> list[str]:
+    renderable = widget.renderable
+    if isinstance(renderable, Text):
+        return renderable.plain.splitlines()
+    return str(renderable).splitlines()
 
 
 class FakeConfigSaveService:
@@ -456,17 +460,11 @@ async def _wait_for_list_entries(
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
         try:
-            pane_list = app.query_one(list_selector, ListView)
+            pane_list = app.query_one(list_selector, Static)
         except NoMatches:
             pane_list = None
         if pane_list is not None:
-            actual_names: list[str] = []
-            for item in pane_list.children:
-                try:
-                    actual_names.append(str(item.query_one(Label).renderable))
-                except NoMatches:
-                    actual_names = []
-                    break
+            actual_names = _side_pane_lines(pane_list)
             if actual_names == expected_names:
                 return
         if asyncio.get_running_loop().time() >= deadline:
@@ -801,17 +799,17 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
         await _wait_for_parent_entries(app, ["peneo-app", "sibling"])
         await _wait_for_child_entries(app, ["spec.md"])
 
-        parent_list = app.query_one("#parent-pane-list", ListView)
+        parent_list = app.query_one("#parent-pane-list", Static)
         current_table = app.query_one("#current-pane-table", DataTable)
-        child_list = app.query_one("#child-pane-list", ListView)
+        child_list = app.query_one("#child-pane-list", Static)
         parent_title = app.query_one("#parent-pane .pane-title", Label)
         current_title = app.query_one("#current-pane .pane-title", Label)
         child_title = app.query_one("#child-pane .pane-title", Label)
         current_path_bar = await _wait_for_current_path_bar(app)
         summary_bar = await _wait_for_summary_bar(app)
         status_bar = await _wait_for_status_bar(app)
-        parent_entries = [str(item.query_one(Label).renderable) for item in parent_list.children]
-        child_entries = [str(item.query_one(Label).renderable) for item in child_list.children]
+        parent_entries = _side_pane_lines(parent_list)
+        child_entries = _side_pane_lines(child_list)
         headers = [str(column.label) for column in current_table.ordered_columns]
 
         assert str(parent_title.renderable) == "Parent Directory"
@@ -899,12 +897,12 @@ async def test_app_truncates_long_labels_in_all_panes_when_narrow() -> None:
         await _wait_for_row_count(app, 2)
         await asyncio.sleep(0.05)
 
-        parent_list = app.query_one("#parent-pane-list", ListView)
-        child_list = app.query_one("#child-pane-list", ListView)
+        parent_list = app.query_one("#parent-pane-list", Static)
+        child_list = app.query_one("#child-pane-list", Static)
         current_table = app.query_one("#current-pane-table", DataTable)
 
-        parent_label = str(parent_list.children[0].query_one(Label).renderable)
-        child_label = str(child_list.children[0].query_one(Label).renderable)
+        parent_label = _side_pane_lines(parent_list)[0]
+        child_label = _side_pane_lines(child_list)[0]
         current_name = current_table.get_row_at(0)[1]
 
         assert "~" in parent_label
@@ -940,9 +938,9 @@ async def test_app_tab_keeps_focus_on_current_pane() -> None:
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
 
-        parent_list = app.query_one("#parent-pane-list", ListView)
+        parent_list = app.query_one("#parent-pane-list", Static)
         current_table = app.query_one("#current-pane-table", DataTable)
-        child_list = app.query_one("#child-pane-list", ListView)
+        child_list = app.query_one("#child-pane-list", Static)
 
         assert parent_list.can_focus is False
         assert child_list.can_focus is False
@@ -988,8 +986,8 @@ async def test_app_keyboard_input_updates_selection_and_child_pane() -> None:
         await pilot.press("space")
         await _wait_for_child_entries(app, ["main.py"], timeout=1.0)
 
-        child_list = app.query_one("#child-pane-list", ListView)
-        child_names = [str(item.query_one(Label).renderable) for item in child_list.children]
+        child_list = app.query_one("#child-pane-list", Static)
+        child_names = _side_pane_lines(child_list)
         current_path_bar = await _wait_for_current_path_bar(app)
         summary_bar = await _wait_for_summary_bar(app)
         status_bar = await _wait_for_status_bar(app)
@@ -1049,8 +1047,8 @@ async def test_app_child_pane_debounces_rapid_cursor_moves() -> None:
         await pilot.press("down", "down")
         await _wait_for_cursor_path(app, f"{path}/tests")
 
-        child_list = app.query_one("#child-pane-list", ListView)
-        child_names = [str(item.query_one(Label).renderable) for item in child_list.children]
+        child_list = app.query_one("#child-pane-list", Static)
+        child_names = _side_pane_lines(child_list)
         assert child_names == ["spec.md"]
 
         await _wait_for_child_pane_request_count(loader, 1, timeout=1.0)
@@ -1528,7 +1526,7 @@ async def test_app_refresh_updates_widgets_in_place() -> None:
         summary_bar = app.query_one("#current-pane-summary-bar", SummaryBar)
         status_bar = app.query_one("#status-bar", StatusBar)
         current_table = app.query_one("#current-pane-table", DataTable)
-        child_list = app.query_one("#child-pane-list", ListView)
+        child_list = app.query_one("#child-pane-list", Static)
 
         await pilot.press("down")
         await asyncio.sleep(0.05)
@@ -1538,7 +1536,7 @@ async def test_app_refresh_updates_widgets_in_place() -> None:
         assert app.query_one("#current-pane-summary-bar", SummaryBar) is summary_bar
         assert app.query_one("#status-bar", StatusBar) is status_bar
         assert app.query_one("#current-pane-table", DataTable) is current_table
-        assert app.query_one("#child-pane-list", ListView) is child_list
+        assert app.query_one("#child-pane-list", Static) is child_list
 
 
 @pytest.mark.asyncio
@@ -1628,13 +1626,12 @@ async def test_app_refresh_keeps_parent_pane_items_when_entries_are_unchanged() 
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
 
-        parent_list = app.query_one("#parent-pane-list", ListView)
-        parent_items = tuple(parent_list.children)
+        parent_list = app.query_one("#parent-pane-list", Static)
 
         await pilot.press("down")
         await asyncio.sleep(0.05)
 
-        assert tuple(app.query_one("#parent-pane-list", ListView).children) == parent_items
+        assert app.query_one("#parent-pane-list", Static) is parent_list
 
 
 @pytest.mark.asyncio
@@ -1795,10 +1792,10 @@ async def test_app_file_cursor_clears_child_pane() -> None:
         await pilot.press("down")
         await _wait_for_child_entries(app, [])
 
-        child_list = app.query_one("#child-pane-list", ListView)
+        child_list = app.query_one("#child-pane-list", Static)
 
         assert app.app_state.current_pane.cursor_path == f"{path}/README.md"
-        assert list(child_list.children) == []
+        assert _side_pane_lines(child_list) == []
 
 
 @pytest.mark.asyncio
@@ -1828,12 +1825,12 @@ async def test_app_child_snapshot_failure_shows_error() -> None:
         await _wait_for_child_entries(app, [], timeout=1.0)
         await _wait_for_status_message(app, "error: permission denied", timeout=1.0)
 
-        child_list = app.query_one("#child-pane-list", ListView)
+        child_list = app.query_one("#child-pane-list", Static)
         current_path_bar = await _wait_for_current_path_bar(app)
         summary_bar = await _wait_for_summary_bar(app)
         status_bar = await _wait_for_status_bar(app)
 
-        assert list(child_list.children) == []
+        assert _side_pane_lines(child_list) == []
         assert str(current_path_bar.renderable) == f"Current Path: {path}"
         assert str(summary_bar.renderable) == "2 items | 0 selected | sort: name asc dirs:on"
         assert str(status_bar.renderable) == "error: permission denied"
@@ -3347,19 +3344,19 @@ async def test_app_sort_shortcuts_keep_side_panes_fixed_and_update_status_bar() 
         await pilot.press("s")
         await asyncio.sleep(0.05)
 
-        parent_list = app.query_one("#parent-pane-list", ListView)
-        child_list = app.query_one("#child-pane-list", ListView)
+        parent_list = app.query_one("#parent-pane-list", Static)
+        child_list = app.query_one("#child-pane-list", Static)
         summary_bar = await _wait_for_summary_bar(app)
 
         assert app.app_state.sort.field == "name"
         assert app.app_state.sort.descending is True
         assert app.app_state.sort.directories_first is False
-        assert [str(item.query_one(Label).renderable) for item in parent_list.children] == [
+        assert _side_pane_lines(parent_list) == [
             "alpha",
             "peneo-sort-shortcuts",
             "beta.txt",
         ]
-        assert [str(item.query_one(Label).renderable) for item in child_list.children] == [
+        assert _side_pane_lines(child_list) == [
             "archive",
             "notes.txt",
         ]
@@ -3968,31 +3965,21 @@ async def test_app_cursor_move_updates_large_child_pane_without_clearing(monkeyp
         await _wait_for_row_count(app, 2)
         await _wait_for_child_list_label(app, "child-0999.txt", index=999, timeout=2.0)
 
-        child_list = app.query_one("#child-pane-list", ListView)
-        original_clear = ListView.clear
-        original_extend = ListView.extend
-        clear_calls = 0
-        extend_calls = 0
+        child_list = app.query_one("#child-pane-list", Static)
+        original_update = Static.update
+        update_calls = 0
 
-        async def counting_clear(self, *args, **kwargs):
-            nonlocal clear_calls
+        def counting_update(self, *args, **kwargs):
+            nonlocal update_calls
             if self is child_list:
-                clear_calls += 1
-            return await original_clear(self, *args, **kwargs)
+                update_calls += 1
+            return original_update(self, *args, **kwargs)
 
-        async def counting_extend(self, *args, **kwargs):
-            nonlocal extend_calls
-            if self is child_list:
-                extend_calls += 1
-            return await original_extend(self, *args, **kwargs)
-
-        monkeypatch.setattr(ListView, "clear", counting_clear)
-        monkeypatch.setattr(ListView, "extend", counting_extend)
+        monkeypatch.setattr(Static, "update", counting_update)
 
         await pilot.press("down")
         await _wait_for_child_list_label(app, "module-0999.py", index=999, timeout=2.0)
 
-        assert app.query_one("#child-pane-list", ListView) is child_list
-        assert len(child_list.children) == 1000
-        assert clear_calls == 0
-        assert extend_calls == 0
+        assert app.query_one("#child-pane-list", Static) is child_list
+        assert len(_side_pane_lines(child_list)) == 1000
+        assert update_calls == 1


### PR DESCRIPTION
## Summary
- Replace side pane rendering with a single `Static` update instead of incremental `ListView` item mounts.
- Keep existing truncation and style behavior while avoiding staged entry growth in parent/child panes.

## Testing
- `uv run ruff check .`
- `uv run pytest`

Closes #313
