### PR TITLE
Issue #318: ヘルプバー見直し

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -276,10 +276,9 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         return HelpBarState(state.config.help_bar.browsing)
     return HelpBarState(
         (
-            "Enter open | e edit | i info | / filter | : palette | ctrl+f find | "
-            "ctrl+g grep | ! shell | q quit",
-            "Space select | y copy | x cut | p paste | c path | . hidden | "
-            "b bookmark | ctrl+t term",
+            "enter open | e edit | i info | space select | y copy | x cut | p paste | c path",
+            "/ filter | s sort | . hidden | b bookmark | ctrl+f find | ctrl+g grep",
+            ": palette | ! shell | ctrl+t term | q quit",
         )
     )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1851,9 +1851,9 @@ async def test_app_displays_browsing_help_bar() -> None:
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
-        "Enter open | e edit | i info | / filter | : palette | ctrl+f find | "
-        "ctrl+g grep | ! shell | q quit\n"
-        "Space select | y copy | x cut | p paste | c path | . hidden | b bookmark | ctrl+t term"
+        "enter open | e edit | i info | space select | y copy | x cut | p paste | c path\n"
+        "/ filter | s sort | . hidden | b bookmark | ctrl+f find | ctrl+g grep\n"
+        ": palette | ! shell | ctrl+t term | q quit"
     )
 
     async with app.run_test():

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -766,14 +766,14 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     help_state = select_help_bar_state(state)
 
     assert help_state.lines == (
-        "Enter open | e edit | i info | / filter | : palette | ctrl+f find | "
-        "ctrl+g grep | ! shell | q quit",
-        "Space select | y copy | x cut | p paste | c path | . hidden | b bookmark | ctrl+t term",
+        "enter open | e edit | i info | space select | y copy | x cut | p paste | c path",
+        "/ filter | s sort | . hidden | b bookmark | ctrl+f find | ctrl+g grep",
+        ": palette | ! shell | ctrl+t term | q quit",
     )
     assert help_state.text == (
-        "Enter open | e edit | i info | / filter | : palette | ctrl+f find | "
-        "ctrl+g grep | ! shell | q quit\n"
-        "Space select | y copy | x cut | p paste | c path | . hidden | b bookmark | ctrl+t term"
+        "enter open | e edit | i info | space select | y copy | x cut | p paste | c path\n"
+        "/ filter | s sort | . hidden | b bookmark | ctrl+f find | ctrl+g grep\n"
+        ": palette | ! shell | ctrl+t term | q quit"
     )
 
 


### PR DESCRIPTION
## 概要
Issue #318「ヘルプバー見直し」の対応を実施しました。

## 変更内容
- ヘルプバーのキーバインド表示を統一（"Enter" → "enter", "Space" → "space"）
- ヘルプバーのレイアウトを2行から3行に再編成
- "s sort" キーバインドをヘルプバーに追加

## 新しいヘルプバー形式
```
enter open | e edit | i info | space select | y copy | x cut | p paste | c path
/ filter | s sort | . hidden | b bookmark | ctrl+f find | ctrl+g grep
: palette | ! shell | ctrl+t term | q quit
```

## 変更対象ファイル
- `src/peneo/state/selectors.py` - デフォルトヘルプバーテキストの変更
- `tests/test_state_selectors.py` - テストケースの更新
- `tests/test_app.py` - 統合テストの更新

## テスト結果
- 単体テスト: PASSED (test_select_help_bar_defaults_to_browsing_shortcuts)
- 統合テスト: PASSED (test_app_displays_browsing_help_bar, test_app_rename_mode_shows_context_input_and_updates_help)
- 全体テスト: 672 passed in 45.20s

## 影響範囲
- カスタムヘルプバーテキストを使用しているユーザーには影響しません
- デフォルトのヘルプバーテキストのみ変更されます

Closes #318