### PR TITLE
Issue #304: Add viewport projection spike benchmark

### DIFF
--- a/docs/performance.en.md
+++ b/docs/performance.en.md
@@ -50,3 +50,67 @@ uv run pytest tests/test_app.py -k main_flow_round_trip_on_live_filesystem -q
 uv run python -m pytest tests/test_state_selectors.py -q
 uv run python -m pytest tests/test_app.py -k 'refresh or large_directory_smoke_with_1000_entries' -q
 ```
+
+## Issue #304 Viewport-Aware Projection Spike
+
+### Date
+
+- 2026-04-05
+
+### Added for the spike
+
+- `scripts/benchmark_current_pane_projection.py`
+  - manual benchmark script comparing current-pane `cursor move`, `page scroll`, `selection toggle`, and `directory size` reflection under `full` vs `viewport`
+- `create_app(..., current_pane_projection_mode="viewport")`
+  - comparison-only spike that keeps `DataTable` and limits current-pane rendering to a terminal-height-derived window
+
+### Measurement setup
+
+- Python: `uv run python`
+- terminal height: 24
+- viewport window: 16 rows
+- the benchmark focuses on the `select_shell_data()` projection/update-hint path
+- this is a local manual benchmark for Issue #304, not a CI benchmark
+
+### Re-run commands
+
+```bash
+uv run python scripts/benchmark_current_pane_projection.py --entries 10000 --iterations 200
+uv run python scripts/benchmark_current_pane_projection.py --entries 50000 --iterations 100
+```
+
+### Observations
+
+#### 10,000 entries
+
+| mode | operation | rendered rows | mean |
+| --- | --- | ---: | ---: |
+| full | cursor move | 10000 | 5.26 ms |
+| full | page scroll | 10000 | 4.77 ms |
+| full | selection toggle | 10000 | 5.27 ms |
+| full | directory size reflect | 10000 | 8.55 ms |
+| viewport | cursor move | 16 | 2.48 ms |
+| viewport | page scroll | 16 | 2.48 ms |
+| viewport | selection toggle | 16 | 2.42 ms |
+| viewport | directory size reflect | 16 | 2.45 ms |
+
+#### 50,000 entries
+
+| mode | operation | rendered rows | mean |
+| --- | --- | ---: | ---: |
+| full | cursor move | 50000 | 26.59 ms |
+| full | page scroll | 50000 | 24.39 ms |
+| full | selection toggle | 50000 | 26.50 ms |
+| full | directory size reflect | 50000 | 42.46 ms |
+| viewport | cursor move | 16 | 12.25 ms |
+| viewport | page scroll | 16 | 12.10 ms |
+| viewport | selection toggle | 16 | 12.11 ms |
+| viewport | directory size reflect | 16 | 12.27 ms |
+
+### Decision notes
+
+- Keeping `DataTable` and windowing only the current-pane projection already lowers the cost consistently
+- The improvement is about 2x at 10,000 entries and up to about 3.5x for `directory size` reflection at 50,000 entries
+- Even after windowing, the 50,000-entry case still spends about 12 ms per call, so fixed costs outside projection remain
+- That means we cannot conclude that virtualization is unnecessary; at minimum, excluding offscreen rows from current-pane projection is worth pursuing
+- This spike is for comparison only. Scroll-offset persistence and page-scroll UX still need follow-up design work

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,7 +5,8 @@
 ## 目次
 
 1. [スモークテスト（既存）](#スモークテスト既存)
-2. [現在の方針](#現在の方針)
+2. [Issue #304 viewport-aware projection スパイク](#issue-304-viewport-aware-projection-スパイク)
+3. [現在の方針](#現在の方針)
 
 ---
 
@@ -62,6 +63,72 @@ uv run python -m pytest tests/test_app.py -k 'refresh or large_directory_smoke_w
 
 ---
 
+## Issue #304 viewport-aware projection スパイク
+
+### 実施日
+
+- 2026-04-05
+
+### 追加したもの
+
+- `scripts/benchmark_current_pane_projection.py`
+  - current pane の `cursor move` / `page scroll` / `selection toggle` / `directory size` 反映を、`full` と `viewport` で同条件比較する手動計測スクリプト
+- `create_app(..., current_pane_projection_mode="viewport")`
+  - `DataTable` は維持したまま、current pane の表示を terminal 高さ由来の window に絞る比較用スパイク
+
+### 計測条件
+
+- Python: `uv run python`
+- terminal height: 24
+- viewport window: 16 rows
+- 測定対象は `select_shell_data()` を中心にした projection/update hint 生成コスト
+- CI benchmark ではなく、Issue #304 の判断材料を残すためのローカル手動計測
+
+### 再実行コマンド
+
+```bash
+uv run python scripts/benchmark_current_pane_projection.py --entries 10000 --iterations 200
+uv run python scripts/benchmark_current_pane_projection.py --entries 50000 --iterations 100
+```
+
+### 観察結果
+
+#### 10,000 entries
+
+| mode | operation | rendered rows | mean |
+| --- | --- | ---: | ---: |
+| full | cursor move | 10000 | 5.26 ms |
+| full | page scroll | 10000 | 4.77 ms |
+| full | selection toggle | 10000 | 5.27 ms |
+| full | directory size reflect | 10000 | 8.55 ms |
+| viewport | cursor move | 16 | 2.48 ms |
+| viewport | page scroll | 16 | 2.48 ms |
+| viewport | selection toggle | 16 | 2.42 ms |
+| viewport | directory size reflect | 16 | 2.45 ms |
+
+#### 50,000 entries
+
+| mode | operation | rendered rows | mean |
+| --- | --- | ---: | ---: |
+| full | cursor move | 50000 | 26.59 ms |
+| full | page scroll | 50000 | 24.39 ms |
+| full | selection toggle | 50000 | 26.50 ms |
+| full | directory size reflect | 50000 | 42.46 ms |
+| viewport | cursor move | 16 | 12.25 ms |
+| viewport | page scroll | 16 | 12.10 ms |
+| viewport | selection toggle | 16 | 12.11 ms |
+| viewport | directory size reflect | 16 | 12.27 ms |
+
+### 判断メモ
+
+- `DataTable` 自体を置き換えなくても、current pane の projection を window 化するだけで処理時間は一貫して下がった
+- 改善幅は 10,000 entries で約 2 倍、50,000 entries では `directory size` 反映で約 3.5 倍
+- 50,000 entries では viewport 化後も 12 ms 前後かかるため、selector 以外の比較的固定コストは残る
+- つまり「仮想化は不要」とは言えず、少なくとも current pane 側で offscreen row を projection 対象から外す価値はある
+- このスパイクは比較用であり、scroll offset の保持方法や page 移動時の UX 調整は follow-up で詰める
+
+---
+
 ## 現在の方針
 
 - 自動ベンチマークは削除した
@@ -75,4 +142,5 @@ uv run python -m pytest tests/test_app.py -k 'refresh or large_directory_smoke_w
 uv run pytest tests/test_app.py -k large_directory_smoke_with_1000_entries --durations=1 -q
 uv run pytest tests/test_app.py -k main_flow_round_trip_on_live_filesystem -q
 uv run pytest tests/test_state_selectors.py -q
+uv run python scripts/benchmark_current_pane_projection.py --entries 10000 --iterations 200
 ```

--- a/scripts/benchmark_current_pane_projection.py
+++ b/scripts/benchmark_current_pane_projection.py
@@ -1,0 +1,256 @@
+"""Manual benchmark for current-pane projection strategies."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import replace
+from datetime import datetime, timedelta
+from statistics import mean
+
+from peneo.state import (
+    AppState,
+    CurrentPaneDeltaState,
+    DirectoryEntryState,
+    DirectorySizeCacheEntry,
+    DirectorySizeDeltaState,
+    PaneState,
+    build_placeholder_app_state,
+    select_shell_data,
+)
+from peneo.state.selectors import compute_current_pane_visible_window
+
+CURRENT_PATH = "/tmp/peneo-benchmark"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark full vs viewport current-pane projection.",
+    )
+    parser.add_argument(
+        "--entries",
+        type=int,
+        default=10_000,
+        help="Number of current-pane entries",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=200,
+        help="Timed iterations per operation and projection mode",
+    )
+    parser.add_argument(
+        "--terminal-height",
+        type=int,
+        default=24,
+        help="Terminal height used to derive the viewport window",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    entries = build_entries(args.entries)
+
+    print(
+        "current pane projection benchmark "
+        f"(entries={args.entries}, iterations={args.iterations}, "
+        f"terminal_height={args.terminal_height})"
+    )
+    print("")
+    print("mode      op                rendered_rows  mean_ms  p95_ms")
+    print("--------  ----------------  -------------  -------  ------")
+
+    for mode in ("full", "viewport"):
+        base_state = build_benchmark_state(
+            entries=entries,
+            terminal_height=args.terminal_height,
+            projection_mode=mode,
+        )
+        for operation in (
+            "cursor_move",
+            "page_scroll",
+            "selection_toggle",
+            "directory_size_reflect",
+        ):
+            result = benchmark_operation(
+                base_state=base_state,
+                entries=entries,
+                operation=operation,
+                iterations=args.iterations,
+            )
+            print(
+                f"{mode:<8}  {operation:<16}  {result.rendered_rows:>13}  "
+                f"{result.mean_ms:>7.2f}  {result.p95_ms:>6.2f}"
+            )
+
+
+def build_entries(count: int) -> tuple[DirectoryEntryState, ...]:
+    base_time = datetime(2026, 4, 5, 12, 0)
+    return tuple(
+        DirectoryEntryState(
+            path=f"{CURRENT_PATH}/dir_{index:05d}",
+            name=f"dir_{index:05d}",
+            kind="dir",
+            modified_at=base_time - timedelta(minutes=index),
+        )
+        for index in range(count)
+    )
+
+
+def build_benchmark_state(
+    *,
+    entries: tuple[DirectoryEntryState, ...],
+    terminal_height: int,
+    projection_mode: str,
+) -> AppState:
+    state = build_placeholder_app_state(
+        CURRENT_PATH,
+        current_pane_projection_mode=projection_mode,
+    )
+    return replace(
+        state,
+        terminal_height=terminal_height,
+        current_pane=PaneState(
+            directory_path=CURRENT_PATH,
+            entries=entries,
+            cursor_path=entries[0].path if entries else None,
+        ),
+        child_pane=PaneState(directory_path=CURRENT_PATH, entries=()),
+    )
+
+
+class BenchmarkResult:
+    def __init__(self, *, rendered_rows: int, mean_ms: float, p95_ms: float) -> None:
+        self.rendered_rows = rendered_rows
+        self.mean_ms = mean_ms
+        self.p95_ms = p95_ms
+
+
+def benchmark_operation(
+    *,
+    base_state: AppState,
+    entries: tuple[DirectoryEntryState, ...],
+    operation: str,
+    iterations: int,
+) -> BenchmarkResult:
+    if not entries:
+        return BenchmarkResult(rendered_rows=0, mean_ms=0.0, p95_ms=0.0)
+
+    timings_ms: list[float] = []
+    rendered_rows = 0
+    visible_window = compute_current_pane_visible_window(base_state.terminal_height)
+
+    for iteration in range(iterations):
+        state = build_operation_state(
+            base_state=base_state,
+            entries=entries,
+            operation=operation,
+            iteration=iteration,
+            visible_window=visible_window,
+        )
+        started_at = time.perf_counter()
+        select_shell_data(state)
+        timings_ms.append((time.perf_counter() - started_at) * 1_000)
+        if state.current_pane_projection_mode == "viewport":
+            rendered_rows = min(visible_window, len(entries) - state.current_pane_window_start)
+        else:
+            rendered_rows = len(entries)
+
+    return BenchmarkResult(
+        rendered_rows=rendered_rows,
+        mean_ms=mean(timings_ms),
+        p95_ms=percentile(timings_ms, 95),
+    )
+
+
+def build_operation_state(
+    *,
+    base_state: AppState,
+    entries: tuple[DirectoryEntryState, ...],
+    operation: str,
+    iteration: int,
+    visible_window: int,
+) -> AppState:
+    if operation == "cursor_move":
+        target_index = min(len(entries) - 1, (iteration + 1) % len(entries))
+        return apply_cursor_path(base_state, entries[target_index].path)
+
+    if operation == "page_scroll":
+        page_size = max(1, visible_window)
+        target_index = min(len(entries) - 1, ((iteration + 1) * page_size) % len(entries))
+        return apply_cursor_path(base_state, entries[target_index].path)
+
+    if operation == "selection_toggle":
+        target_index = min(len(entries) - 1, iteration % len(entries))
+        target_path = entries[target_index].path
+        selected_paths = frozenset({target_path}) if iteration % 2 == 0 else frozenset()
+        return replace(
+            apply_cursor_path(base_state, target_path),
+            current_pane=replace(
+                base_state.current_pane,
+                cursor_path=target_path,
+                selected_paths=selected_paths,
+            ),
+            current_pane_delta=CurrentPaneDeltaState(
+                changed_paths=(target_path,),
+                revision=iteration + 1,
+            ),
+        )
+
+    if operation == "directory_size_reflect":
+        target_index = min(len(entries) - 1, iteration % len(entries))
+        target_path = entries[target_index].path
+        return replace(
+            apply_cursor_path(base_state, target_path),
+            config=replace(
+                base_state.config,
+                display=replace(base_state.config.display, show_directory_sizes=True),
+            ),
+            directory_size_cache=(
+                DirectorySizeCacheEntry(
+                    path=target_path,
+                    status="ready",
+                    size_bytes=(iteration + 1) * 1024,
+                ),
+            ),
+            directory_size_delta=DirectorySizeDeltaState(
+                changed_paths=(target_path,),
+                revision=iteration + 1,
+            ),
+        )
+
+    raise ValueError(f"Unsupported benchmark operation: {operation}")
+
+
+def apply_cursor_path(state: AppState, cursor_path: str) -> AppState:
+    if state.current_pane_projection_mode != "viewport":
+        return replace(
+            state,
+            current_pane=replace(state.current_pane, cursor_path=cursor_path),
+        )
+
+    visible_entries = state.current_pane.entries
+    cursor_index = next(
+        index for index, entry in enumerate(visible_entries) if entry.path == cursor_path
+    )
+    visible_window = compute_current_pane_visible_window(state.terminal_height)
+    window_start = min(
+        max(0, cursor_index - visible_window + 1),
+        max(0, len(visible_entries) - visible_window),
+    )
+    return replace(
+        state,
+        current_pane=replace(state.current_pane, cursor_path=cursor_path),
+        current_pane_window_start=window_start,
+    )
+
+
+def percentile(values: list[float], value: int) -> float:
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, round((len(ordered) - 1) * (value / 100))))
+    return ordered[index]
+
+
+if __name__ == "__main__":
+    main()

--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -3,6 +3,7 @@
 import threading
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Literal
 
 from textual import events
 from textual.app import App, ComposeResult
@@ -368,6 +369,7 @@ class PeneoApp(App[None]):
         config_path: str | None = None,
         startup_notification: NotificationState | None = None,
         initial_path: str | Path | None = None,
+        current_pane_projection_mode: Literal["full", "viewport"] = "full",
     ) -> None:
         super().__init__()
         self._app_config = app_config or AppConfig()
@@ -382,6 +384,7 @@ class PeneoApp(App[None]):
             confirm_delete=self._app_config.behavior.confirm_delete,
             paste_conflict_action=self._app_config.behavior.paste_conflict_action,
             post_reload_notification=startup_notification,
+            current_pane_projection_mode=current_pane_projection_mode,
         )
         self._snapshot_loader = snapshot_loader or LiveBrowserSnapshotLoader()
         self._clipboard_service = clipboard_service or LiveClipboardOperationService()
@@ -601,6 +604,7 @@ def create_app(
     config_path: str | None = None,
     startup_notification: NotificationState | None = None,
     initial_path: str | Path | None = None,
+    current_pane_projection_mode: Literal["full", "viewport"] = "full",
 ) -> PeneoApp:
     """Create the application instance."""
 
@@ -621,6 +625,7 @@ def create_app(
         config_path=config_path,
         startup_notification=startup_notification,
         initial_path=initial_path,
+        current_pane_projection_mode=current_pane_projection_mode,
     )
 
 

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -44,6 +44,7 @@ CommandPaletteSource = Literal[
 SplitTerminalStatus = Literal["closed", "starting", "running"]
 SplitTerminalFocusTarget = Literal["browser", "terminal"]
 DirectorySizeStatus = Literal["pending", "ready", "failed"]
+CurrentPaneProjectionMode = Literal["full", "viewport"]
 ConfigFieldId = Literal[
     "editor.command",
     "display.show_hidden_files",
@@ -368,6 +369,8 @@ class AppState:
     pending_config_save_request_id: int | None = None
     pending_shell_command_request_id: int | None = None
     terminal_height: int = 24
+    current_pane_projection_mode: CurrentPaneProjectionMode = "full"
+    current_pane_window_start: int = 0
     next_request_id: int = 1
 
 
@@ -380,6 +383,7 @@ def build_initial_app_state(
     confirm_delete: bool = True,
     paste_conflict_action: PasteConflictAction = "prompt",
     post_reload_notification: NotificationState | None = None,
+    current_pane_projection_mode: CurrentPaneProjectionMode = "full",
 ) -> AppState:
     """Return a deterministic initial state used by selector and reducer tests."""
 
@@ -448,6 +452,7 @@ def build_initial_app_state(
         paste_conflict_action=paste_conflict_action,
         filter=FilterState(query="", active=False),
         post_reload_notification=post_reload_notification,
+        current_pane_projection_mode=current_pane_projection_mode,
     )
 
 
@@ -461,6 +466,7 @@ def build_placeholder_app_state(
     confirm_delete: bool = True,
     paste_conflict_action: PasteConflictAction = "prompt",
     post_reload_notification: NotificationState | None = None,
+    current_pane_projection_mode: CurrentPaneProjectionMode = "full",
 ) -> AppState:
     """Return an empty browser state used before the first snapshot loads."""
 
@@ -478,4 +484,5 @@ def build_placeholder_app_state(
         confirm_delete=confirm_delete,
         paste_conflict_action=paste_conflict_action,
         post_reload_notification=post_reload_notification,
+        current_pane_projection_mode=current_pane_projection_mode,
     )

--- a/src/peneo/state/reducer.py
+++ b/src/peneo/state/reducer.py
@@ -17,7 +17,7 @@ from .reducer_mutations import handle_mutation_action
 from .reducer_navigation import handle_navigation_action
 from .reducer_palette import handle_palette_action
 from .reducer_terminal_config import handle_terminal_config_action
-from .selectors import select_visible_current_entry_states
+from .selectors import compute_current_pane_visible_window, select_visible_current_entry_states
 
 
 def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
@@ -54,6 +54,7 @@ def _finalize_reduce_result(
     action: Action,
     result: ReduceResult,
 ) -> ReduceResult:
+    result = _finalize_current_pane_window(previous_state, result)
     result = _finalize_current_pane_delta(previous_state, result)
     if isinstance(action, (DirectorySizesLoaded, DirectorySizesFailed)):
         return result
@@ -61,6 +62,32 @@ def _finalize_reduce_result(
         return result
     return ReduceResult(
         state=_clear_transient_deltas(result.state),
+        effects=result.effects,
+    )
+
+
+def _finalize_current_pane_window(
+    previous_state: AppState,
+    result: ReduceResult,
+) -> ReduceResult:
+    next_state = result.state
+    if next_state == previous_state:
+        return result
+
+    if next_state.current_pane_projection_mode != "viewport":
+        if next_state.current_pane_window_start == 0:
+            return result
+        return ReduceResult(
+            state=replace(next_state, current_pane_window_start=0),
+            effects=result.effects,
+        )
+
+    visible_entries = select_visible_current_entry_states(next_state)
+    window_start = _select_current_pane_window_start(next_state, visible_entries)
+    if window_start == next_state.current_pane_window_start:
+        return result
+    return ReduceResult(
+        state=replace(next_state, current_pane_window_start=window_start),
         effects=result.effects,
     )
 
@@ -116,6 +143,35 @@ def _select_current_pane_changed_paths(
         if (path in previous_selected_paths) != (path in next_selected_paths)
         or (path in previous_cut_paths) != (path in next_cut_paths)
     )
+
+
+def _select_current_pane_window_start(
+    state: AppState,
+    visible_entries,
+) -> int:
+    if not visible_entries:
+        return 0
+
+    visible_window = compute_current_pane_visible_window(state.terminal_height)
+    max_window_start = max(0, len(visible_entries) - visible_window)
+    window_start = min(state.current_pane_window_start, max_window_start)
+    cursor_index = _find_current_cursor_index(visible_entries, state.current_pane.cursor_path)
+    if cursor_index is None:
+        return 0
+    if cursor_index < window_start:
+        return cursor_index
+    if cursor_index >= window_start + visible_window:
+        return cursor_index - visible_window + 1
+    return window_start
+
+
+def _find_current_cursor_index(visible_entries, cursor_path: str | None) -> int | None:
+    if cursor_path is None:
+        return None
+    for index, entry in enumerate(visible_entries):
+        if entry.path == cursor_path:
+            return index
+    return None
 
 
 def _select_cut_paths(state: AppState) -> frozenset[str]:

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -44,6 +44,8 @@ SIDE_PANE_SORT = SortState(field="name", descending=False, directories_first=Tru
 COMMAND_PALETTE_VISIBLE_WINDOW = 8
 MIN_SEARCH_VISIBLE_WINDOW = 3
 _SEARCH_OVERHEAD_ROWS = 5
+MIN_CURRENT_PANE_VISIBLE_WINDOW = 5
+_CURRENT_PANE_OVERHEAD_ROWS = 8
 
 
 def _has_execute_permission(entry: DirectoryEntryState) -> bool:
@@ -56,6 +58,7 @@ def _has_execute_permission(entry: DirectoryEntryState) -> bool:
 @dataclass(frozen=True)
 class _CurrentPaneProjection:
     visible_entries: tuple[DirectoryEntryState, ...]
+    projected_entries: tuple[DirectoryEntryState, ...]
     cursor_index: int | None
     cursor_entry: DirectoryEntryState | None
     summary: CurrentSummaryState
@@ -69,7 +72,7 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
         state.config.display.show_directory_sizes or state.sort.field == "size"
     )
     current_pane_update = _select_current_pane_update_hint(
-        current_pane.visible_entries,
+        current_pane.projected_entries,
         state.directory_size_cache,
         display_directory_sizes,
         state.sort,
@@ -85,7 +88,7 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
         parent_entries=select_parent_entries(state),
         current_entries=(
             _select_current_pane_entries(
-                current_pane.visible_entries,
+                current_pane.projected_entries,
                 state.directory_size_cache,
                 display_directory_sizes,
                 state.current_pane.selected_paths,
@@ -698,10 +701,19 @@ def select_visible_current_entry_states(state: AppState) -> tuple[DirectoryEntry
 
 def _select_current_pane_projection(state: AppState) -> _CurrentPaneProjection:
     visible_entries = select_visible_current_entry_states(state)
-    cursor_index = _find_current_cursor_index(visible_entries, state.current_pane.cursor_path)
-    cursor_entry = None if cursor_index is None else visible_entries[cursor_index]
+    global_cursor_index = _find_current_cursor_index(
+        visible_entries,
+        state.current_pane.cursor_path,
+    )
+    projected_entries, cursor_index = _project_current_pane_entries(
+        state,
+        visible_entries,
+        global_cursor_index,
+    )
+    cursor_entry = None if global_cursor_index is None else visible_entries[global_cursor_index]
     return _CurrentPaneProjection(
         visible_entries=visible_entries,
+        projected_entries=projected_entries,
         cursor_index=cursor_index,
         cursor_entry=cursor_entry,
         summary=_build_current_summary(
@@ -710,6 +722,27 @@ def _select_current_pane_projection(state: AppState) -> _CurrentPaneProjection:
             state.sort,
         ),
     )
+
+
+def _project_current_pane_entries(
+    state: AppState,
+    visible_entries: tuple[DirectoryEntryState, ...],
+    global_cursor_index: int | None,
+) -> tuple[tuple[DirectoryEntryState, ...], int | None]:
+    if state.current_pane_projection_mode != "viewport":
+        return visible_entries, global_cursor_index
+
+    if not visible_entries:
+        return (), None
+
+    visible_window = compute_current_pane_visible_window(state.terminal_height)
+    max_window_start = max(0, len(visible_entries) - visible_window)
+    window_start = min(state.current_pane_window_start, max_window_start)
+    window_end = min(len(visible_entries), window_start + visible_window)
+    local_cursor_index = None
+    if global_cursor_index is not None:
+        local_cursor_index = global_cursor_index - window_start
+    return visible_entries[window_start:window_end], local_cursor_index
 
 
 @lru_cache(maxsize=256)
@@ -730,7 +763,7 @@ def _select_visible_current_entry_states(
 
 @lru_cache(maxsize=256)
 def _select_current_pane_update_hint(
-    visible_entries: tuple[DirectoryEntryState, ...],
+    projected_entries: tuple[DirectoryEntryState, ...],
     directory_size_cache: tuple[DirectorySizeCacheEntry, ...],
     display_directory_sizes: bool,
     sort: SortState,
@@ -745,14 +778,15 @@ def _select_current_pane_update_hint(
         return CurrentPaneUpdateHint(mode="full", revision=max(row_revision, size_revision))
     if row_changed_paths:
         row_updates = _select_current_pane_row_updates(
-            visible_entries,
+            projected_entries,
             directory_size_cache,
             display_directory_sizes,
             selected_paths,
             cut_paths,
             row_changed_paths,
         )
-        if len(row_updates) != len(frozenset(row_changed_paths)):
+        projected_paths = frozenset(entry.path for entry in projected_entries)
+        if len(row_updates) != len(frozenset(row_changed_paths) & projected_paths):
             return CurrentPaneUpdateHint(mode="full", revision=row_revision)
         return CurrentPaneUpdateHint(
             mode="row_delta",
@@ -765,7 +799,7 @@ def _select_current_pane_update_hint(
         mode="size_delta",
         revision=size_revision,
         size_updates=_select_current_pane_size_updates(
-            visible_entries,
+            projected_entries,
             directory_size_cache,
             display_directory_sizes,
             size_changed_paths,
@@ -1003,6 +1037,12 @@ def compute_search_visible_window(terminal_height: int) -> int:
     """Calculate visible search items based on terminal height."""
     palette_rows = max(1, terminal_height // 2)
     return max(MIN_SEARCH_VISIBLE_WINDOW, palette_rows - _SEARCH_OVERHEAD_ROWS)
+
+
+def compute_current_pane_visible_window(terminal_height: int) -> int:
+    """Estimate how many current-pane rows are visible in the terminal."""
+
+    return max(MIN_CURRENT_PANE_VISIBLE_WINDOW, terminal_height - _CURRENT_PANE_OVERHEAD_ROWS)
 
 
 def _select_file_search_window(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -47,6 +47,7 @@ from peneo.state import (
     GrepSearchResultState,
     PaneState,
 )
+from peneo.state.selectors import compute_current_pane_visible_window
 from peneo.ui import (
     AttributeDialog,
     CommandPalette,
@@ -1765,6 +1766,81 @@ async def test_app_directory_size_update_avoids_rebuilding_large_current_pane(mo
 
         assert clear_calls == 0
         assert add_row_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_app_viewport_projection_limits_rendered_rows_for_large_directory() -> None:
+    path = "/tmp/peneo-viewport-large"
+    current_entries = tuple(
+        DirectoryEntryState(f"{path}/file_{index:04d}.txt", f"file_{index:04d}.txt", "file")
+        for index in range(1000)
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+            )
+        }
+    )
+    app = create_app(
+        snapshot_loader=loader,
+        initial_path=path,
+        current_pane_projection_mode="viewport",
+    )
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+        visible_window = compute_current_pane_visible_window(app.app_state.terminal_height)
+        await _wait_for_row_count(app, visible_window, timeout=2.0)
+
+        table = app.query_one("#current-pane-table", DataTable)
+        first_row = table.get_row_at(0)
+
+        assert table.row_count == visible_window
+        assert isinstance(first_row[1], Text)
+        assert first_row[1].plain == "file_0000.txt"
+        assert app.app_state.current_pane_window_start == 0
+
+
+@pytest.mark.asyncio
+async def test_app_viewport_projection_shifts_window_after_cursor_crosses_edge() -> None:
+    path = "/tmp/peneo-viewport-scroll"
+    current_entries = tuple(
+        DirectoryEntryState(f"{path}/file_{index:04d}.txt", f"file_{index:04d}.txt", "file")
+        for index in range(40)
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+            )
+        }
+    )
+    app = create_app(
+        snapshot_loader=loader,
+        initial_path=path,
+        current_pane_projection_mode="viewport",
+    )
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        visible_window = compute_current_pane_visible_window(app.app_state.terminal_height)
+        await _wait_for_row_count(app, visible_window, timeout=2.0)
+
+        table = app.query_one("#current-pane-table", DataTable)
+        for _ in range(visible_window):
+            await pilot.press("down")
+        await _wait_for_cursor_path(app, current_entries[visible_window].path, timeout=2.0)
+        await _wait_for_table_cell(app, "file_0001.txt", 0, 1, timeout=2.0)
+
+        last_row = table.get_row_at(table.row_count - 1)
+
+        assert table.row_count == visible_window
+        assert isinstance(last_row[1], Text)
+        assert last_row[1].plain == f"file_{visible_window:04d}.txt"
+        assert app.app_state.current_pane_window_start == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -59,7 +59,11 @@ from peneo.state import (
 )
 from peneo.state import command_palette as command_palette_module
 from peneo.state.command_palette import CommandPaletteItem
-from peneo.state.selectors import _has_execute_permission, _select_command_palette_window
+from peneo.state.selectors import (
+    _has_execute_permission,
+    _select_command_palette_window,
+    compute_current_pane_visible_window,
+)
 from tests.state_test_helpers import entry, pane, reduce_state
 
 
@@ -697,6 +701,101 @@ def test_select_shell_data_reuses_current_entries_when_only_cursor_changes() -> 
     assert moved_shell.child_entries == initial_shell.child_entries
 
 
+def test_select_shell_data_viewport_projection_limits_rendered_entries() -> None:
+    path = "/tmp/peneo-viewport-selector"
+    current_entries = tuple(
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
+        for index in range(12)
+    )
+    state = replace(
+        build_initial_app_state(current_pane_projection_mode="viewport"),
+        terminal_height=12,
+        current_pane=pane(path, current_entries, cursor_path=current_entries[0].path),
+    )
+
+    shell = select_shell_data(state)
+
+    visible_window = compute_current_pane_visible_window(state.terminal_height)
+    assert len(shell.current_entries) == visible_window
+    assert [entry.name for entry in shell.current_entries] == [
+        f"item_{index:02d}" for index in range(visible_window)
+    ]
+    assert shell.current_cursor_index == 0
+    assert shell.current_summary.item_count == len(current_entries)
+
+
+def test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_inside_window(
+) -> None:
+    path = "/tmp/peneo-viewport-selector"
+    current_entries = tuple(
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
+        for index in range(12)
+    )
+    state = replace(
+        build_initial_app_state(current_pane_projection_mode="viewport"),
+        terminal_height=12,
+        current_pane=pane(path, current_entries, cursor_path=current_entries[0].path),
+    )
+
+    initial_shell = select_shell_data(state)
+    moved_shell = select_shell_data(_reduce_state(state, SetCursorPath(current_entries[3].path)))
+
+    assert moved_shell.current_entries is initial_shell.current_entries
+    assert moved_shell.current_cursor_index == 3
+
+
+def test_select_shell_data_viewport_projection_shifts_window_after_cursor_crosses_edge() -> None:
+    path = "/tmp/peneo-viewport-selector"
+    current_entries = tuple(
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
+        for index in range(12)
+    )
+    state = replace(
+        build_initial_app_state(current_pane_projection_mode="viewport"),
+        terminal_height=12,
+        current_pane=pane(path, current_entries, cursor_path=current_entries[0].path),
+    )
+
+    initial_shell = select_shell_data(state)
+    moved_shell = select_shell_data(_reduce_state(state, SetCursorPath(current_entries[5].path)))
+
+    assert moved_shell.current_entries is not initial_shell.current_entries
+    assert [entry.name for entry in moved_shell.current_entries] == [
+        "item_01",
+        "item_02",
+        "item_03",
+        "item_04",
+        "item_05",
+    ]
+    assert moved_shell.current_cursor_index == 4
+
+
+def test_select_shell_data_viewport_projection_skips_offscreen_row_delta_updates() -> None:
+    path = "/tmp/peneo-viewport-selector"
+    current_entries = tuple(
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
+        for index in range(12)
+    )
+    offscreen_path = current_entries[-1].path
+    state = replace(
+        build_initial_app_state(current_pane_projection_mode="viewport"),
+        terminal_height=12,
+        current_pane=pane(path, current_entries, cursor_path=current_entries[0].path),
+        current_pane_delta=CurrentPaneDeltaState(changed_paths=(offscreen_path,), revision=1),
+    )
+
+    shell = select_shell_data(
+        replace(
+            state,
+            current_pane=replace(state.current_pane, selected_paths=frozenset({offscreen_path})),
+        )
+    )
+
+    assert shell.current_entries is None
+    assert shell.current_pane_update.mode == "row_delta"
+    assert shell.current_pane_update.row_updates == ()
+
+
 def test_select_shell_data_rebuilds_only_current_entries_when_selection_changes() -> None:
     state = build_initial_app_state()
 
@@ -722,6 +821,7 @@ def test_select_shell_data_includes_selected_cut_and_contextual_models() -> None
     state = replace(
         state,
         filter=replace(state.filter, query="read", active=True),
+        current_pane_delta=CurrentPaneDeltaState(),
         notification=NotificationState(level="info", message="Ready"),
     )
 


### PR DESCRIPTION
## Summary
- add a comparison-only viewport projection spike for the current pane and keep `DataTable`
- add a manual benchmark script for full vs viewport projection across cursor, scroll, selection, and directory-size updates
- document the measured 10,000 / 50,000 entry results in `docs/performance.md`

## Testing
- `uv run ruff check src/peneo/app.py src/peneo/state/models.py src/peneo/state/reducer.py src/peneo/state/selectors.py tests/test_state_selectors.py tests/test_app.py scripts/benchmark_current_pane_projection.py`
- `uv run pytest tests/test_state_selectors.py -q`
- `uv run pytest tests/test_app.py -k 'viewport_projection or cursor_move_does_not_rebuild_current_table_rows or selection_toggle_avoids_rebuilding_large_current_pane or directory_size_update_avoids_rebuilding_large_current_pane' -q`
- `uv run python scripts/benchmark_current_pane_projection.py --entries 10000 --iterations 200`
- `uv run python scripts/benchmark_current_pane_projection.py --entries 50000 --iterations 100`

## Benchmark Notes
- 10,000 entries: full 4.77-8.55 ms, viewport 2.42-2.48 ms
- 50,000 entries: full 24.39-42.46 ms, viewport 12.10-12.27 ms
