### PR TITLE
Update CI actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- update `actions/checkout` from `v4` to `v6`
- update `astral-sh/setup-uv` from `v4` to `v8.0.0`
- remove the GitHub Actions Node.js 20 deprecation annotation from Python CI

## Testing
- verified by running the updated GitHub Actions workflow on this branch

References:
- https://github.com/actions/checkout/releases/tag/v6.0.2
- https://github.com/astral-sh/setup-uv#readme