### PR TITLE
fix: add --index-strategy unsafe-best-match to uv sync for CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: sudo apt-get install -y ripgrep
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --index-strategy unsafe-best-match
 
       - name: Prepare temp directory
         run: mkdir -p "$RUNNER_TEMP/peneo-tmp"


### PR DESCRIPTION
This PR adds the `--index-strategy unsafe-best-match` flag to `uv sync` in the CI workflow to fix dependency resolution issues.