### PR TITLE
fix: add --index-strategy unsafe-best-match to uv pip install in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
               --refresh \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
               "peneo==${VERSION}"; then
               exit 0
             fi


### PR DESCRIPTION
This PR adds the `--index-strategy unsafe-best-match` flag to `uv pip install` in the `verify-testpypi` job of the release workflow to fix package installation issues from TestPyPI.