### PR TITLE
docs: add --index-strategy unsafe-best-match to installation instructions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -364,5 +364,6 @@ uv run pytest
 uv tool install \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple/ \
+  --index-strategy unsafe-best-match \
   peneo
 ```

--- a/README.md
+++ b/README.md
@@ -358,5 +358,6 @@ For testing pre-release versions, install from TestPyPI:
 uv tool install \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple/ \
+  --index-strategy unsafe-best-match \
   peneo
 ```


### PR DESCRIPTION
## Summary
- Add `--index-strategy unsafe-best-match` flag to installation examples in both README.md and README.ja.md
- Aligns documentation with recent CI changes (commit f15e42f)

## Test plan
- [ ] Reviewed README changes match CI configuration
- [ ] Verified installation instructions are consistent across both language versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)