### PR TITLE
refactor(selectors): extract common command palette view builder (#342)

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -1044,7 +1044,9 @@ def _build_command_palette_items_view(
                 shortcut=item.shortcut,
                 enabled=item.enabled,
                 selected=(
-                    (selected_override if selected_override is not None else True) and index == cursor_index
+                    (
+                        selected_override if selected_override is not None else True
+                    ) and index == cursor_index
                 ),
             )
             for index, item in visible_items


### PR DESCRIPTION
## Summary
- `select_command_palette_state` 関数の history、bookmarks、go_to_path セクションから重複コードを抽出
- 共通ロジックを `_build_command_palette_items_view` 関数として分離
- 約37行のコード削減と保守性向上

## Details
### 変更内容
- **新規関数**: `_build_command_palette_items_view` - コマンドパレットのアイテムビューを構築する共通関数
- **History セクション**: 20行 → 6行に削減
- **Bookmarks セクション**: 20行 → 6行に削減  
- **Go to Path セクション**: 25行 → 12行に削減

### 外部仕様の維持
- 各ソースのタイトルと空メッセージは変更なし
- go_to_path の特殊な選択ロジック（`go_to_path_selection_active`）を維持
- 動的ウィンドウサイズ計算（`compute_search_visible_window`）を維持
- すべての既存テストがパス

## Test plan
- [x] 既存テスト `tests/test_state_selectors.py` の107件すべてがパス
- [x] 各ソース（history、bookmarks、go_to_path）の表示テストがパス
- [x] 動的ウィンドウサイズのテストがパス

## 関連 Issue
Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)