### PR TITLE
#351 Parent Directoryをハイライト

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -122,6 +122,7 @@ def select_parent_entries(state: AppState) -> tuple[PaneEntry, ...]:
         visible_entries,
         state.directory_size_cache,
         display_directory_sizes=False,
+        selected_path=state.parent_pane.cursor_path,
         cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
     )
 
@@ -165,6 +166,7 @@ def _select_child_entries_for_cursor(
         visible_entries,
         state.directory_size_cache,
         display_directory_sizes=False,
+        selected_path=None,
         cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
     )
 
@@ -869,6 +871,7 @@ def _select_side_pane_entries(
     visible_entries: tuple[DirectoryEntryState, ...],
     directory_size_cache: tuple[DirectorySizeCacheEntry, ...],
     display_directory_sizes: bool,
+    selected_path: str | None,
     cut_paths: frozenset[str],
 ) -> tuple[PaneEntry, ...]:
     return tuple(
@@ -879,6 +882,7 @@ def _select_side_pane_entries(
                 directory_size_cache,
                 display_directory_sizes=display_directory_sizes,
             ),
+            selected=entry.path == selected_path,
             cut=entry.path in cut_paths,
         )
         for entry in visible_entries

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -103,7 +103,7 @@ class SidePane(Vertical):
     EXECUTABLE_SELECTED_STYLE = "bold cyan"
     EXECUTABLE_CUT_STYLE = "cyan dim"
     DIRECTORY_STYLE = "blue"
-    DIRECTORY_SELECTED_STYLE = "bold blue"
+    DIRECTORY_SELECTED_STYLE = "bold white on blue"
     DIRECTORY_CUT_STYLE = "blue dim"
     ENTRY_HORIZONTAL_PADDING = 2
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -778,6 +778,25 @@ async def test_app_uses_cwd_for_default_initial_path(tmp_path, monkeypatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_app_live_snapshot_highlights_current_directory_in_parent_pane(tmp_path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")
+    app = create_app(initial_path=tmp_path)
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, str(tmp_path))
+        await _wait_for_row_count(app, 2)
+
+        parent_list = app.query_one("#parent-pane-list", Static)
+        parent_renderable = parent_list.renderable
+
+        assert app.app_state.parent_pane.cursor_path == str(tmp_path)
+        assert isinstance(parent_renderable, Text)
+        assert tmp_path.name in parent_renderable.plain.splitlines()
+        assert any(span.style == "bold white on blue" for span in parent_renderable.spans)
+
+
+@pytest.mark.asyncio
 async def test_app_renders_loaded_three_pane_shell() -> None:
     path = "/tmp/peneo-app"
     current_entries = (
@@ -820,6 +839,9 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
         assert str(current_title.renderable) == "Current Directory"
         assert str(child_title.renderable) == "Child Directory"
         assert parent_entries == ["peneo-app", "sibling"]
+        parent_renderable = parent_list.renderable
+        assert isinstance(parent_renderable, Text)
+        assert any(span.style == "bold white on blue" for span in parent_renderable.spans)
         assert headers == ["Sel", "Name", "Size", "Modified"]
         assert current_table.row_count == 2
         assert child_entries == ["spec.md"]

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -271,6 +271,26 @@ def test_select_parent_and_child_entries_hide_hidden_unless_enabled() -> None:
     ]
 
 
+def test_select_parent_entries_marks_current_directory_selected() -> None:
+    state = replace(
+        build_initial_app_state(),
+        parent_pane=PaneState(
+            directory_path="/tmp",
+            entries=(
+                DirectoryEntryState("/tmp/alpha", "alpha", "dir"),
+                DirectoryEntryState("/tmp/peneo", "peneo", "dir"),
+            ),
+            cursor_path="/tmp/peneo",
+        ),
+    )
+
+    entries = select_parent_entries(state)
+
+    assert [entry.name for entry in entries] == ["alpha", "peneo"]
+    assert entries[0].selected is False
+    assert entries[1].selected is True
+
+
 def test_select_child_entries_keeps_previous_snapshot_visible_while_request_is_pending() -> None:
     state = replace(
         build_initial_app_state(),

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -1,5 +1,5 @@
 from peneo.models import PaneEntry
-from peneo.ui.panes import build_entry_label, truncate_middle
+from peneo.ui.panes import SidePane, build_entry_label, truncate_middle
 
 
 def test_truncate_middle_keeps_text_when_width_is_sufficient() -> None:
@@ -44,3 +44,11 @@ def test_pane_entry_defaults_executable_to_false() -> None:
     entry = PaneEntry("README.md", "file")
 
     assert entry.executable is False
+
+
+def test_side_pane_selected_directory_uses_background_highlight() -> None:
+    entry = PaneEntry("docs", "dir", selected=True)
+
+    rendered = SidePane._render_label(entry)
+
+    assert rendered.style == "bold white on blue"


### PR DESCRIPTION
## Summary
- reflect `parent_pane.cursor_path` into the parent pane selected state
- use a background-highlighted selected style in side panes so the current directory is clearly visible on real terminals
- add selector, live snapshot, and UI regression coverage

## Test
- `uv run ruff check .`
- `uv run pytest`

## Issue
- Closes #351