### PR TITLE
Fix #355 root parent pane snapshot

### DIFF
--- a/src/peneo/services/browser_snapshot.py
+++ b/src/peneo/services/browser_snapshot.py
@@ -16,6 +16,7 @@ from peneo.state.models import (
     DirectoryEntryState,
     PaneState,
     build_initial_app_state,
+    resolve_parent_directory_path,
 )
 
 DEFAULT_DIRECTORY_CACHE_CAPACITY = 64
@@ -67,20 +68,25 @@ class LiveBrowserSnapshotLoader:
         path: str,
         cursor_path: str | None = None,
     ) -> BrowserSnapshot:
-        resolved_path = str(Path(path).expanduser().resolve())
+        resolved_path, parent_path = resolve_parent_directory_path(path)
         current_entries = self._list_directory(resolved_path)
         resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path)
 
-        parent_path = str(Path(resolved_path).parent)
-        parent_entries = self._list_directory(parent_path)
-        parent_cursor_path = (
-            resolved_path if _contains_path(parent_entries, resolved_path) else None
-        )
+        if parent_path is None:
+            parent_directory_path = resolved_path
+            parent_entries = ()
+            parent_cursor_path = None
+        else:
+            parent_directory_path = parent_path
+            parent_entries = self._list_directory(parent_path)
+            parent_cursor_path = (
+                resolved_path if _contains_path(parent_entries, resolved_path) else None
+            )
 
         return BrowserSnapshot(
             current_path=resolved_path,
             parent_pane=PaneState(
-                directory_path=parent_path,
+                directory_path=parent_directory_path,
                 entries=parent_entries,
                 cursor_path=parent_cursor_path,
             ),
@@ -282,11 +288,10 @@ def _build_fallback_snapshot(path: str, cursor_path: str | None) -> BrowserSnaps
             )
         return snapshot_from_app_state(state)
 
-    resolved_path = str(Path(path).expanduser().resolve())
-    parent_path = str(Path(resolved_path).parent)
+    resolved_path, parent_path = resolve_parent_directory_path(path)
     return BrowserSnapshot(
         current_path=resolved_path,
-        parent_pane=PaneState(directory_path=parent_path, entries=()),
+        parent_pane=PaneState(directory_path=parent_path or resolved_path, entries=()),
         current_pane=PaneState(directory_path=resolved_path, entries=(), cursor_path=cursor_path),
         child_pane=PaneState(directory_path=resolved_path, entries=()),
     )

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -374,6 +374,16 @@ class AppState:
     next_request_id: int = 1
 
 
+def resolve_parent_directory_path(path: str) -> tuple[str, str | None]:
+    """Return the resolved path and its distinct parent, if one exists."""
+
+    resolved_path = Path(path).expanduser().resolve()
+    parent_path = resolved_path.parent
+    if parent_path == resolved_path:
+        return str(resolved_path), None
+    return str(resolved_path), str(parent_path)
+
+
 def build_initial_app_state(
     *,
     config: AppConfig | None = None,
@@ -469,13 +479,12 @@ def build_placeholder_app_state(
 ) -> AppState:
     """Return an empty browser state used before the first snapshot loads."""
 
-    resolved_path = str(Path(current_path).resolve())
-    parent_path = str(Path(resolved_path).parent)
+    resolved_path, parent_path = resolve_parent_directory_path(current_path)
     return AppState(
         current_path=resolved_path,
         config=config or AppConfig(),
         config_path=config_path,
-        parent_pane=PaneState(directory_path=parent_path, entries=()),
+        parent_pane=PaneState(directory_path=parent_path or resolved_path, entries=()),
         current_pane=PaneState(directory_path=resolved_path, entries=()),
         child_pane=PaneState(directory_path=resolved_path, entries=()),
         show_hidden=show_hidden,

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -82,6 +82,27 @@ def test_live_browser_snapshot_loader_returns_empty_child_pane_for_file_cursor(t
     assert snapshot.child_pane.entries == ()
 
 
+def test_live_browser_snapshot_loader_returns_empty_parent_pane_for_root_path() -> None:
+    filesystem = StubFilesystemAdapter(
+        entries_by_path={
+            "/": (
+                DirectoryEntryState("/README", "README", "file"),
+                DirectoryEntryState("/tmp", "tmp", "dir"),
+            )
+        }
+    )
+    loader = LiveBrowserSnapshotLoader(filesystem=filesystem)
+
+    snapshot = loader.load_browser_snapshot("/", cursor_path="/README")
+
+    assert snapshot.current_path == "/"
+    assert snapshot.parent_pane.directory_path == "/"
+    assert snapshot.parent_pane.entries == ()
+    assert snapshot.parent_pane.cursor_path is None
+    assert snapshot.current_pane.entries == filesystem.entries_by_path["/"]
+    assert filesystem.list_directory_calls == ["/"]
+
+
 def test_live_browser_snapshot_loader_normalizes_not_found_error() -> None:
     loader = LiveBrowserSnapshotLoader(
         filesystem=StubFilesystemAdapter(errors_by_path={"/missing": FileNotFoundError("nope")})
@@ -193,3 +214,14 @@ def test_fake_browser_snapshot_loader_records_invalidated_directory_listing_path
     assert loader.invalidated_directory_listing_paths == [
         ("/tmp/project", "/tmp/project/docs"),
     ]
+
+
+def test_fake_browser_snapshot_loader_returns_empty_parent_pane_for_root_path() -> None:
+    loader = FakeBrowserSnapshotLoader()
+
+    snapshot = loader.load_browser_snapshot("/")
+
+    assert snapshot.current_path == "/"
+    assert snapshot.parent_pane.directory_path == "/"
+    assert snapshot.parent_pane.entries == ()
+    assert snapshot.parent_pane.cursor_path is None

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -41,6 +41,7 @@ from peneo.state import (
     ToggleSelection,
     ZipCompressConfirmationState,
     build_initial_app_state,
+    build_placeholder_app_state,
     select_attribute_dialog_state,
     select_child_entries,
     select_command_palette_state,
@@ -109,6 +110,15 @@ def test_select_current_entries_hides_hidden_by_default() -> None:
     entries = select_current_entries(state)
 
     assert [entry.name for entry in entries] == ["docs"]
+
+
+def test_build_placeholder_app_state_keeps_parent_pane_empty_at_root() -> None:
+    state = build_placeholder_app_state("/")
+
+    assert state.current_path == "/"
+    assert state.parent_pane.directory_path == "/"
+    assert state.parent_pane.entries == ()
+    assert state.parent_pane.cursor_path is None
 
 
 def test_select_visible_current_entries_sorts_by_modified_with_missing_values_last() -> None:


### PR DESCRIPTION
## Summary
- fix parent pane resolution when the current path is the filesystem root
- keep placeholder and fallback snapshots consistent with the live loader
- add regression coverage for root parent pane behavior

## Testing
- uv run ruff check .
- uv run pytest

Closes #355
