### PR TITLE
Issue #349: Fix search palette j/k input

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The main keys are listed below.
 | Filter input | `Backspace` | Delete one character |
 | Filter input | `Enter` / `↓` | Apply the filter and return to list navigation |
 | Filter input | `Esc` | Clear the filter |
-| Command palette | Text input / `↑` / `↓` / `k` / `j` / `Enter` / `Esc` | Filter, select, run, or cancel commands |
+| Command palette | Text input / `↑` / `↓` / `k` / `j` / `Enter` / `Esc` | Filter, select, run, or cancel commands. In `Find files` and `Grep search`, `j` / `k` are treated as text input and result navigation uses `↑` / `↓`. |
 | Split terminal focus | Text input / arrows / `Enter` / `Backspace` / `Tab` | Send input directly to the embedded shell |
 | Split terminal focus | `Esc` | Close the embedded split terminal |
 | Split terminal focus | `Ctrl+T` | Close the embedded split terminal |

--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -501,6 +501,9 @@ def _dispatch_command_palette_input(
     key: str,
     character: str | None,
 ) -> DispatchedActions:
+    palette_source = state.command_palette.source if state.command_palette is not None else None
+    search_palette = palette_source in {"file_search", "grep_search"}
+
     if (
         key == "tab"
         and state.command_palette is not None
@@ -526,10 +529,10 @@ def _dispatch_command_palette_input(
     if key == "escape":
         return _supported(CancelCommandPalette())
 
-    if key in {"up", "k"}:
+    if key == "up" or (key == "k" and not search_palette):
         return _supported(MoveCommandPaletteCursor(delta=-1))
 
-    if key in {"down", "j"}:
+    if key == "down" or (key == "j" and not search_palette):
         return _supported(MoveCommandPaletteCursor(delta=1))
 
     if key == "pageup":
@@ -563,8 +566,7 @@ def _dispatch_command_palette_input(
         current_query = state.command_palette.query if state.command_palette is not None else ""
         return _supported(SetCommandPaletteQuery(f"{current_query}{character}"))
 
-    source = state.command_palette.source if state.command_palette is not None else None
-    if source in ("grep_search", "file_search"):
+    if search_palette:
         return _warn("Use arrows, type to filter, Enter, Ctrl+E for editor, or Esc")
 
     return _warn("Use arrows, type to filter, Enter to run, or Esc to cancel")

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -251,11 +251,18 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         if state.command_palette is not None and state.command_palette.source == "file_search":
             if state.config.help_bar.palette_file_search:
                 return HelpBarState(state.config.help_bar.palette_file_search)
-            return HelpBarState(("type filename | enter jump | Ctrl+E edit | esc cancel",))
+            return HelpBarState(
+                ("type filename | up/down select | enter jump | Ctrl+E edit | esc cancel",)
+            )
         if state.command_palette is not None and state.command_palette.source == "grep_search":
             if state.config.help_bar.palette_grep_search:
                 return HelpBarState(state.config.help_bar.palette_grep_search)
-            return HelpBarState(("type text / re:pattern | enter jump | Ctrl+E edit | esc cancel",))
+            return HelpBarState(
+                (
+                    "type text / re:pattern | up/down select | "
+                    "enter jump | Ctrl+E edit | esc cancel",
+                )
+            )
         if state.command_palette is not None and state.command_palette.source == "history":
             if state.config.help_bar.palette_history:
                 return HelpBarState(state.config.help_bar.palette_history)

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -634,6 +634,54 @@ def test_palette_down_moves_cursor() -> None:
     assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=1))
 
 
+def test_search_palette_j_key_updates_query() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="file_search", query="ab"),
+    )
+
+    actions = dispatch_key_input(state, key="j", character="j")
+
+    assert actions == (SetNotification(None), SetCommandPaletteQuery("abj"))
+
+
+def test_search_palette_k_key_updates_query() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="grep_search", query="ab"),
+    )
+
+    actions = dispatch_key_input(state, key="k", character="k")
+
+    assert actions == (SetNotification(None), SetCommandPaletteQuery("abk"))
+
+
+def test_commands_palette_j_key_moves_cursor() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="commands", query=""),
+    )
+
+    actions = dispatch_key_input(state, key="j", character="j")
+
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=1))
+
+
+def test_search_palette_down_moves_cursor() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="file_search", query=""),
+    )
+
+    actions = dispatch_key_input(state, key="down")
+
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=1))
+
+
 def test_palette_ctrl_e_opens_grep_result_in_editor() -> None:
     from peneo.state.models import CommandPaletteState
     state = replace(

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1125,7 +1125,9 @@ def test_select_help_bar_state_for_file_search_palette() -> None:
 
     help_bar = select_help_bar_state(state)
 
-    assert help_bar.lines == ("type filename | enter jump | Ctrl+E edit | esc cancel",)
+    assert help_bar.lines == (
+        "type filename | up/down select | enter jump | Ctrl+E edit | esc cancel",
+    )
 
 
 def test_select_help_bar_state_for_grep_search_palette() -> None:
@@ -1137,7 +1139,9 @@ def test_select_help_bar_state_for_grep_search_palette() -> None:
 
     help_bar = select_help_bar_state(state)
 
-    assert help_bar.lines == ("type text / re:pattern | enter jump | Ctrl+E edit | esc cancel",)
+    assert help_bar.lines == (
+        "type text / re:pattern | up/down select | enter jump | Ctrl+E edit | esc cancel",
+    )
 
 
 def test_select_command_palette_state_go_to_path_can_show_candidates_without_selection() -> None:


### PR DESCRIPTION
## Summary
- treat `j` and `k` as text input in `Find files` and `Grep search`
- add arrow-key guidance to the search help bar
- cover the new behavior with dispatcher and selector tests

## Testing
- `uv run pytest tests/test_input_dispatch.py`
- `uv run pytest tests/test_state_selectors.py`
- `uv run pytest tests/test_state_reducer.py`
- `uv run pytest`
- `uv run ruff check .`

Closes #349
