### PR TITLE
fix(369): split terminal でタブ補完が効くようにする

### DIFF
--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -143,6 +143,7 @@ CONFLICT_KEYMAP = {
 }
 
 TERMINAL_KEYMAP = {
+    "tab": "terminal_tab",
     "ctrl+v": "paste_from_clipboard",
     "enter": "terminal_enter",
     "backspace": "terminal_backspace",
@@ -255,14 +256,10 @@ def _dispatch_browsing_input(
         return _supported(MoveCursor(delta=1, visible_paths=visible_paths))
 
     if command == "cursor_up_selecting":
-        return _supported(
-            MoveCursorAndSelectRange(delta=-1, visible_paths=visible_paths)
-        )
+        return _supported(MoveCursorAndSelectRange(delta=-1, visible_paths=visible_paths))
 
     if command == "cursor_down_selecting":
-        return _supported(
-            MoveCursorAndSelectRange(delta=1, visible_paths=visible_paths)
-        )
+        return _supported(MoveCursorAndSelectRange(delta=1, visible_paths=visible_paths))
 
     if command == "toggle_selection" and state.current_pane.cursor_path is not None:
         return _supported(
@@ -482,6 +479,7 @@ def _terminal_control_character(key: str) -> str | None:
 
     letter = suffix.lower()
     return chr(ord(letter) - ord("a") + 1)
+
 
 def _dispatch_command_palette_input(
     state: AppState,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3145,6 +3145,35 @@ async def test_app_split_terminal_focus_routes_input_to_session() -> None:
         session = split_terminal_service.sessions[0]
         assert session.writes == ["a", "\r"]
 
+@pytest.mark.asyncio
+async def test_app_split_terminal_focus_sends_tab() -> None:
+    path = "/tmp/peneo-split-terminal-tab"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (DirectoryEntryState(f"{path}/docs", "docs", "dir"),),
+                child_path=f"{path}/docs",
+            )
+        }
+    )
+    split_terminal_service = FakeSplitTerminalService()
+    app = create_app(
+        snapshot_loader=loader,
+        split_terminal_service=split_terminal_service,
+        initial_path=path,
+    )
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("t")
+        await asyncio.sleep(0.05)
+        await pilot.press("tab")
+        await asyncio.sleep(0.05)
+
+        session = split_terminal_service.sessions[0]
+        assert session.writes == ["\t"]
+
 
 @pytest.mark.asyncio
 async def test_app_split_terminal_coalesces_rapid_output_updates() -> None:

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -876,6 +876,13 @@ def test_split_terminal_focus_sends_navigation_sequences() -> None:
         SendSplitTerminalInput("\x1b[6~"),
     )
 
+def test_split_terminal_focus_sends_tab() -> None:
+    state = _focused_split_terminal_state()
+
+    actions = dispatch_key_input(state, key="tab")
+
+    assert actions == (SetNotification(None), SendSplitTerminalInput("\t"))
+
 
 def test_split_terminal_focus_takes_priority_over_browsing_navigation() -> None:
     state = _focused_split_terminal_state()


### PR DESCRIPTION
## 概要
Issue #369 にて報告されていた、split terminal でのタブ補完が効かない問題を修正します。

## 原因
 に  が定義されておらず、 キーが Textual の標準フォーカス移動に流れていました。

## 変更点
- :  に  を追加
- :  キーが  を送信することを確認するテストを追加
- : アプリレベルで  キーが PTY に  を送信することを確認するテストを追加

## テスト結果
すべてのテストが成功しました。