### PR TITLE
Fix #396 expand command palette height

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -195,16 +195,15 @@ class PeneoApp(App[None]):
         display: none;
         height: auto;
         min-height: 8;
-        max-height: 70%;
+        max-height: 1fr;
         margin: 0 2;
         padding: 0 1;
         border: round $accent;
         background: $surface;
     }
 
-    #command-palette.search-mode {
-        height: 50%;
-        max-height: 70%;
+    #command-palette.-expanded {
+        height: 1fr;
     }
 
     #command-palette-title {
@@ -214,6 +213,15 @@ class PeneoApp(App[None]):
 
     #command-palette-query {
         margin: 0 0 1 0;
+    }
+
+    #command-palette-items {
+        height: auto;
+        max-height: 1fr;
+    }
+
+    #command-palette.-expanded #command-palette-items {
+        height: 1fr;
     }
 
     #status-bar {

--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -128,6 +128,7 @@ class CommandPaletteViewState:
     query: str
     items: tuple[CommandPaletteItemViewState, ...]
     empty_message: str
+    has_more_items: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -43,7 +43,7 @@ from .models import (
 SIDE_PANE_SORT = SortState(field="name", descending=False, directories_first=True)
 COMMAND_PALETTE_VISIBLE_WINDOW = 8
 MIN_SEARCH_VISIBLE_WINDOW = 3
-_SEARCH_OVERHEAD_ROWS = 5
+_SEARCH_OVERHEAD_ROWS = 8
 MIN_CURRENT_PANE_VISIBLE_WINDOW = 5
 _CURRENT_PANE_OVERHEAD_ROWS = 8
 
@@ -366,6 +366,7 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
                 for index, result in visible_results
             ),
             empty_message=_file_search_empty_message(state),
+            has_more_items=len(state.command_palette.file_search_results) > len(visible_results),
         )
     if state.command_palette.source == "grep_search":
         visible_results, title = _select_grep_search_window(
@@ -386,6 +387,7 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
                 for index, result in visible_results
             ),
             empty_message=_grep_search_empty_message(state),
+            has_more_items=len(state.command_palette.grep_search_results) > len(visible_results),
         )
     if state.command_palette.source == "history":
         return _build_command_palette_items_view(
@@ -419,7 +421,12 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
         )
 
     items = get_command_palette_items(state)
-    visible_items, title = _select_command_palette_window(items, cursor_index)
+    visible_window = compute_search_visible_window(state.terminal_height)
+    visible_items, title = _select_command_palette_window(
+        items,
+        cursor_index,
+        visible_window=visible_window,
+    )
     return CommandPaletteViewState(
         title=title,
         query=state.command_palette.query,
@@ -433,6 +440,7 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
             for index, item in visible_items
         ),
         empty_message="No matching commands",
+        has_more_items=len(items) > len(visible_items),
     )
 
 
@@ -1048,9 +1056,9 @@ def _format_sort_label(sort: SortState) -> str:
 
 
 def compute_search_visible_window(terminal_height: int) -> int:
-    """Calculate visible search items based on terminal height."""
-    palette_rows = max(1, terminal_height // 2)
-    return max(MIN_SEARCH_VISIBLE_WINDOW, palette_rows - _SEARCH_OVERHEAD_ROWS)
+    """Calculate visible command-palette items based on terminal height."""
+
+    return max(MIN_SEARCH_VISIBLE_WINDOW, terminal_height - _SEARCH_OVERHEAD_ROWS)
 
 
 def _build_command_palette_items_view(
@@ -1096,6 +1104,7 @@ def _build_command_palette_items_view(
             for index, item in visible_items
         ),
         empty_message=empty_message or "No items",
+        has_more_items=len(items) > len(visible_items),
     )
 
 

--- a/src/peneo/ui/command_palette.py
+++ b/src/peneo/ui/command_palette.py
@@ -38,22 +38,13 @@ class CommandPalette(Container):
         items_widget = self.query_one("#command-palette-items", Static)
 
         if state is None:
-            self.remove_class("search-mode")
+            self.remove_class("-expanded")
             title_widget.update("Command Palette")
             query_widget.update("")
             items_widget.update("")
             return
 
-        if (
-            state.title.startswith("Find File")
-            or state.title.startswith("Grep")
-            or state.title.startswith("Directory History")
-            or state.title.startswith("Go to path")
-        ):
-            self.add_class("search-mode")
-        else:
-            self.remove_class("search-mode")
-
+        self.set_class(state.has_more_items, "-expanded")
         title_widget.update(state.title)
         query_text = Text()
         query_text.append("> ", style="bold")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2140,8 +2140,41 @@ async def test_app_command_palette_overlay_stays_top_aligned_without_resizing_ma
         palette_layer = app.query_one("#command-palette-layer")
 
         assert palette.region.y == palette_layer.region.y
-        assert palette.region.bottom <= palette_layer.region.bottom
+        assert palette.region.bottom == palette_layer.region.bottom
+        assert "-expanded" in palette.classes
         assert current_pane.region.width == main_pane_width
+
+
+@pytest.mark.asyncio
+async def test_app_command_palette_stays_compact_when_filtered_results_fit() -> None:
+    path = "/tmp/peneo-command-palette-compact"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (
+                    DirectoryEntryState(f"{path}/docs", "docs", "dir"),
+                    DirectoryEntryState(f"{path}/README.md", "README.md", "file"),
+                ),
+                child_path=f"{path}/docs",
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press(":")
+        await pilot.press("r", "e", "n", "a", "m", "e")
+        await asyncio.sleep(0.05)
+
+        palette = await _wait_for_command_palette(app)
+        palette_layer = app.query_one("#command-palette-layer")
+        items = palette.query_one("#command-palette-items", Static)
+
+        assert "-expanded" not in palette.classes
+        assert palette.region.bottom < palette_layer.region.bottom
+        assert "Rename" in str(items.renderable)
 
 
 @pytest.mark.asyncio

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -806,7 +806,7 @@ def test_palette_pageup_moves_cursor_by_page() -> None:
 
     actions = dispatch_key_input(state, key="pageup")
 
-    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-7))
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-16))
 
 
 def test_palette_pagedown_moves_cursor_by_page() -> None:
@@ -814,7 +814,7 @@ def test_palette_pagedown_moves_cursor_by_page() -> None:
 
     actions = dispatch_key_input(state, key="pagedown")
 
-    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=7))
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=16))
 
 
 def test_palette_unbound_key_shows_guidance() -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1546,8 +1546,13 @@ def test_select_command_palette_state_windows_large_file_search_results() -> Non
     palette_state = select_command_palette_state(state)
 
     assert palette_state is not None
-    assert palette_state.title == "Find File (8-14 / 20)"
+    assert palette_state.title == "Find File (3-18 / 20)"
     assert [item.label for item in palette_state.items] == [
+        "src/module_2.py",
+        "src/module_3.py",
+        "src/module_4.py",
+        "src/module_5.py",
+        "src/module_6.py",
         "src/module_7.py",
         "src/module_8.py",
         "src/module_9.py",
@@ -1555,8 +1560,13 @@ def test_select_command_palette_state_windows_large_file_search_results() -> Non
         "src/module_11.py",
         "src/module_12.py",
         "src/module_13.py",
+        "src/module_14.py",
+        "src/module_15.py",
+        "src/module_16.py",
+        "src/module_17.py",
     ]
-    assert palette_state.items[3].selected is True
+    assert palette_state.items[8].selected is True
+    assert palette_state.has_more_items is True
 
 
 def test_select_command_palette_state_for_grep_search_results() -> None:
@@ -1862,13 +1872,13 @@ class TestComputeSearchVisibleWindow:
     """Tests for dynamic search window size calculation."""
 
     def test_default_terminal_height(self) -> None:
-        assert selectors_module.compute_search_visible_window(24) == 7
+        assert selectors_module.compute_search_visible_window(24) == 16
 
     def test_large_terminal(self) -> None:
-        assert selectors_module.compute_search_visible_window(48) == 19
+        assert selectors_module.compute_search_visible_window(48) == 40
 
     def test_very_large_terminal(self) -> None:
-        assert selectors_module.compute_search_visible_window(80) == 35
+        assert selectors_module.compute_search_visible_window(80) == 72
 
     def test_small_terminal_uses_minimum(self) -> None:
         assert selectors_module.compute_search_visible_window(10) == 3
@@ -1905,8 +1915,9 @@ class TestSelectSearchWindowWithDynamicSize:
         palette_state = select_command_palette_state(state)
 
         assert palette_state is not None
-        assert len(palette_state.items) == 19
-        assert palette_state.items[15 - (15 - 9)].selected is True
+        assert len(palette_state.items) == 30
+        assert palette_state.items[15].selected is True
+        assert palette_state.has_more_items is False
 
 
 class TestSelectCommandPaletteWindow:
@@ -2021,8 +2032,7 @@ class TestCommandPaletteDynamicWindow:
     """コマンドパレットの動的表示ウィンドウ計算のテスト."""
 
     def test_go_to_path_uses_dynamic_window_size(self) -> None:
-        """Go to pathで48行端末の場合19件表示されること."""
-        # 48行端末の場合、visible_window = 48 // 2 - 5 = 19
+        """Go to pathで48行端末の場合40件まで表示できること."""
         state = replace(
             _reduce_state(build_initial_app_state(), BeginCommandPalette()),
             terminal_height=48,
@@ -2037,11 +2047,11 @@ class TestCommandPaletteDynamicWindow:
         palette_state = select_command_palette_state(state)
 
         assert palette_state is not None
-        assert len(palette_state.items) == 19
+        assert len(palette_state.items) == 25
+        assert palette_state.has_more_items is False
 
     def test_go_to_path_small_terminal_uses_minimum(self) -> None:
         """Go to pathで小さな端末の場合最小3件表示されること."""
-        # 10行端末の場合、visible_window = max(3, 10 // 2 - 5) = 3
         state = replace(
             _reduce_state(build_initial_app_state(), BeginCommandPalette()),
             terminal_height=10,
@@ -2059,8 +2069,7 @@ class TestCommandPaletteDynamicWindow:
         assert len(palette_state.items) == 3
 
     def test_directory_history_uses_dynamic_window_size(self) -> None:
-        """Directory Historyで48行端末の場合19件表示されること."""
-        # 48行端末の場合、visible_window = 48 // 2 - 5 = 19
+        """Directory Historyで48行端末なら全候補を表示できること."""
         state = replace(
             build_initial_app_state(),
             terminal_height=48,
@@ -2078,11 +2087,11 @@ class TestCommandPaletteDynamicWindow:
         palette_state = select_command_palette_state(state)
 
         assert palette_state is not None
-        assert len(palette_state.items) == 19
+        assert len(palette_state.items) == 25
+        assert palette_state.has_more_items is False
 
     def test_bookmarks_uses_dynamic_window_size(self) -> None:
-        """Bookmarksで48行端末の場合19件表示されること."""
-        # 48行端末の場合、visible_window = 48 // 2 - 5 = 19
+        """Bookmarksで48行端末なら全候補を表示できること."""
         state = replace(
             build_initial_app_state(),
             terminal_height=48,
@@ -2097,4 +2106,19 @@ class TestCommandPaletteDynamicWindow:
         palette_state = select_command_palette_state(state)
 
         assert palette_state is not None
-        assert len(palette_state.items) == 19
+        assert len(palette_state.items) == 25
+        assert palette_state.has_more_items is False
+
+    def test_default_command_palette_uses_terminal_height_for_visible_window(self) -> None:
+        """通常のコマンド一覧も端末高に応じて表示件数が増えること."""
+
+        state = replace(
+            _reduce_state(build_initial_app_state(), BeginCommandPalette()),
+            terminal_height=24,
+        )
+
+        palette_state = select_command_palette_state(state)
+
+        assert palette_state is not None
+        assert len(palette_state.items) == 16
+        assert palette_state.has_more_items is True


### PR DESCRIPTION
## Summary
- expand the command palette to use the full overlay height only when the result list overflows
- use terminal-height-based visible window sizing for all palette modes, including PageUp/PageDown
- add app and selector tests for expanded and compact palette layouts

## Testing
- uv run ruff check .
- uv run pytest -q

Closes #396