### PR TITLE
#415 Hide stale child pane content during refresh

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -162,18 +162,17 @@ def _select_child_pane_for_cursor(
         return _build_child_entries_view((), syntax_theme)
 
     is_archive = cursor_entry.kind == "file" and is_supported_archive_path(cursor_entry.path)
-    if state.pending_child_pane_request_id is None:
-        if cursor_entry.kind == "dir" or is_archive:
-            if (
-                state.child_pane.mode != "entries"
-                or cursor_entry.path != state.child_pane.directory_path
-            ):
-                return _build_child_entries_view((), syntax_theme)
-        elif (
-            state.child_pane.mode != "preview"
-            or cursor_entry.path != state.child_pane.preview_path
+    if cursor_entry.kind == "dir" or is_archive:
+        if (
+            state.child_pane.mode != "entries"
+            or cursor_entry.path != state.child_pane.directory_path
         ):
             return _build_child_entries_view((), syntax_theme)
+    elif (
+        state.child_pane.mode != "preview"
+        or cursor_entry.path != state.child_pane.preview_path
+    ):
+        return _build_child_entries_view((), syntax_theme)
 
     if state.child_pane.mode == "preview" and state.child_pane.preview_content is not None:
         preview_path = state.child_pane.preview_path or cursor_entry.path

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -272,6 +272,7 @@ class ChildPane(Vertical):
         preview_widget.display = state.is_preview
         self._last_render_width = 0
         self._refresh_rendered_content()
+        self.call_after_refresh(self._refresh_rendered_content)
 
     def _refresh_rendered_content(self) -> None:
         if self._state.is_preview:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1210,6 +1210,47 @@ async def test_app_child_pane_updates_immediately_on_rapid_cursor_moves() -> Non
 
 
 @pytest.mark.asyncio
+async def test_app_hides_stale_child_entries_while_new_child_snapshot_is_pending() -> None:
+    path = "/tmp/peneo-child-pane-pending"
+    current_entries = (
+        DirectoryEntryState(f"{path}/docs", "docs", "dir"),
+        DirectoryEntryState(f"{path}/src", "src", "dir"),
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                current_entries,
+                child_path=f"{path}/docs",
+                child_entries=(DirectoryEntryState(f"{path}/docs/spec.md", "spec.md", "file"),),
+            )
+        },
+        child_panes={
+            (path, f"{path}/src"): PaneState(
+                directory_path=f"{path}/src",
+                entries=(DirectoryEntryState(f"{path}/src/main.py", "main.py", "file"),),
+            ),
+        },
+        child_delay_seconds={
+            (path, f"{path}/src"): 0.2,
+        },
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test(size=(120, 20)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 2)
+        await _wait_for_child_entries(app, ["spec.md"])
+
+        await pilot.press("down")
+        await _wait_for_cursor_path(app, f"{path}/src")
+        await _wait_for_child_pane_request_count(loader, 1, timeout=1.0)
+        await _wait_for_child_entries(app, [], timeout=1.0)
+        await _wait_for_child_entries(app, ["main.py"], timeout=1.0)
+        await _wait_for_child_pane_runtime_idle(app, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_app_shift_down_selects_range_and_down_clears_it() -> None:
     path = "/tmp/peneo-range-selection"
     current_entries = (
@@ -4428,7 +4469,9 @@ async def test_app_large_directory_smoke_with_1000_entries(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_app_cursor_move_updates_large_child_pane_without_clearing(monkeypatch) -> None:
+async def test_app_cursor_move_refreshes_large_child_pane_without_remount(
+    monkeypatch,
+) -> None:
     path = "/tmp/peneo-large-child-pane"
     current_entries = (
         DirectoryEntryState(f"{path}/docs", "docs", "dir"),
@@ -4490,7 +4533,7 @@ async def test_app_cursor_move_updates_large_child_pane_without_clearing(monkeyp
 
         assert app.query_one("#child-pane-list", Static) is child_list
         assert len(_side_pane_lines(child_list)) == 1000
-        assert update_calls == 1
+        assert update_calls == 2
 
 
 # --- Pane visibility on narrow terminals (Issue #390) ---

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -999,6 +999,74 @@ async def test_app_hides_text_preview_in_child_pane_when_preview_disabled() -> N
 
 
 @pytest.mark.asyncio
+async def test_app_updates_child_preview_when_cursor_moves_between_files() -> None:
+    path = "/tmp/peneo-preview-switch"
+    readme = f"{path}/README.md"
+    config = f"{path}/config.toml"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(
+                        DirectoryEntryState(path, "peneo-preview-switch", "dir"),
+                        DirectoryEntryState("/tmp/sibling", "sibling", "dir"),
+                    ),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(
+                        DirectoryEntryState(readme, "README.md", "file"),
+                        DirectoryEntryState(config, "config.toml", "file"),
+                    ),
+                    cursor_path=readme,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=readme,
+                    preview_content="# Title\npreview body\n",
+                ),
+            )
+        },
+        child_panes={
+            (path, config): PaneState(
+                directory_path=path,
+                entries=(),
+                mode="preview",
+                preview_path=config,
+                preview_content="[display]\nshow_preview = true\n",
+            ),
+        },
+        child_delay_seconds={
+            (path, config): 0.2,
+        },
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test(size=(120, 20)):
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 2)
+        await _wait_for_child_preview(app, "Preview: README.md", "# Title")
+
+        await app.dispatch_actions(
+            (
+                MoveCursor(
+                    delta=1,
+                    visible_paths=(readme, config),
+                ),
+            )
+        )
+        await _wait_for_cursor_path(app, config)
+        await _wait_for_child_entries(app, [], timeout=1.0)
+        await _wait_for_child_preview(app, "Preview: config.toml", "show_preview = true")
+        await _wait_for_child_pane_runtime_idle(app, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_app_truncates_long_labels_in_all_panes_when_narrow() -> None:
     path = "/tmp/peneo-narrow-truncate"
     current_entries = (

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -301,7 +301,7 @@ def test_select_parent_entries_marks_current_directory_selected() -> None:
     assert entries[1].selected is True
 
 
-def test_select_child_entries_keeps_previous_snapshot_visible_while_request_is_pending() -> None:
+def test_select_child_entries_clears_stale_snapshot_while_request_is_pending() -> None:
     state = replace(
         build_initial_app_state(),
         current_pane=PaneState(
@@ -325,7 +325,37 @@ def test_select_child_entries_keeps_previous_snapshot_visible_while_request_is_p
         pending_child_pane_request_id=7,
     )
 
-    assert [entry.name for entry in select_child_entries(state)] == ["spec.md"]
+    assert select_child_entries(state) == ()
+
+
+def test_select_shell_data_hides_stale_preview_while_request_is_pending() -> None:
+    current_path = "/home/tadashi/develop/peneo"
+    previous_preview_path = f"{current_path}/README.md"
+    requested_preview_path = f"{current_path}/pyproject.toml"
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path=current_path,
+            entries=(
+                DirectoryEntryState(previous_preview_path, "README.md", "file"),
+                DirectoryEntryState(requested_preview_path, "pyproject.toml", "file"),
+            ),
+            cursor_path=requested_preview_path,
+        ),
+        child_pane=PaneState(
+            directory_path=current_path,
+            entries=(),
+            mode="preview",
+            preview_path=previous_preview_path,
+            preview_content="# Preview\n",
+        ),
+        pending_child_pane_request_id=7,
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is False
+    assert shell.child_pane.entries == ()
 
 
 def test_select_pane_entries_show_directory_sizes_from_cache() -> None:
@@ -752,7 +782,7 @@ def test_select_shell_data_reuses_current_entries_when_only_cursor_changes() -> 
 
     assert moved_shell.current_entries is initial_shell.current_entries
     assert moved_shell.current_cursor_index == 2
-    assert moved_shell.child_pane.entries == initial_shell.child_pane.entries
+    assert moved_shell.child_pane.entries == ()
 
 
 def test_select_shell_data_viewport_projection_limits_rendered_entries() -> None:


### PR DESCRIPTION
## Summary
- hide stale child pane entries and previews unless they match the current cursor target
- add regression coverage for pending child pane requests and stale preview rendering
- keep large child pane refreshes on the same widget while accepting the clear-then-fill update flow

## Testing
- uv run ruff check .
- uv run pytest