### PR TITLE
Issue #414: Continue grep search on permission errors

### DIFF
--- a/src/peneo/services/grep_search.py
+++ b/src/peneo/services/grep_search.py
@@ -94,6 +94,13 @@ class LiveGrepSearchService:
 
         if return_code not in {0, 1}:
             message = stderr_text.strip() or "grep search failed"
+            if self._is_nonfatal_ripgrep_error(return_code, stderr_text, stripped_query):
+                return tuple(
+                    sorted(
+                        self._parse_results(root, stdout_lines),
+                        key=lambda result: (result.display_path.casefold(), result.line_number),
+                    )
+                )
             if is_regex_grep_search_query(stripped_query):
                 raise InvalidGrepSearchQueryError(message)
             raise OSError(message)
@@ -115,6 +122,7 @@ class LiveGrepSearchService:
             "never",
             "--no-heading",
             "--no-ignore",
+            "--no-messages",
         ]
         if show_hidden:
             command.append("--hidden")
@@ -165,6 +173,14 @@ class LiveGrepSearchService:
             return str(path.relative_to(root))
         except ValueError:
             return str(path)
+
+    @staticmethod
+    def _is_nonfatal_ripgrep_error(return_code: int, stderr_text: str, query: str) -> bool:
+        return (
+            return_code == 2
+            and not stderr_text.strip()
+            and not is_regex_grep_search_query(query)
+        )
 
 
 @dataclass

--- a/tests/test_services_grep_search.py
+++ b/tests/test_services_grep_search.py
@@ -66,3 +66,49 @@ def test_live_grep_search_service_raises_invalid_query_for_bad_regex(tmp_path) -
 
     with pytest.raises(InvalidGrepSearchQueryError):
         service.search(str(root), "re:[", show_hidden=False)
+
+
+@skip_if_no_rg
+def test_live_grep_search_service_continues_when_some_paths_are_permission_denied(
+    tmp_path,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "README.md").write_text("TODO: update docs\n", encoding="utf-8")
+    blocked = root / "blocked"
+    blocked.mkdir()
+    (blocked / "secret.txt").write_text("TODO: hidden\n", encoding="utf-8")
+
+    service = LiveGrepSearchService()
+
+    blocked.chmod(0)
+    try:
+        results = service.search(str(root), "todo", show_hidden=False)
+    finally:
+        blocked.chmod(0o700)
+
+    assert [result.display_label for result in results] == ["docs/README.md:1: TODO: update docs"]
+
+
+@skip_if_no_rg
+def test_live_grep_search_service_ignores_permission_denied_without_matches(tmp_path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "README.md").write_text("guide\n", encoding="utf-8")
+    blocked = root / "blocked"
+    blocked.mkdir()
+    (blocked / "secret.txt").write_text("TODO: hidden\n", encoding="utf-8")
+
+    service = LiveGrepSearchService()
+
+    blocked.chmod(0)
+    try:
+        results = service.search(str(root), "todo", show_hidden=False)
+    finally:
+        blocked.chmod(0o700)
+
+    assert results == ()


### PR DESCRIPTION
## Summary
- make grep search ignore non-fatal ripgrep permission errors and continue returning readable matches
- suppress ripgrep permission messages during recursive grep so partial permission failures do not abort the whole search
- add regression tests covering permission-denied paths with and without matches

## Test
- uv run pytest tests/test_services_grep_search.py
- uv run pytest tests/test_state_reducer.py -k grep_search
- uv run pytest tests/test_app.py -k grep_search
- uv run ruff check src/peneo/services/grep_search.py tests/test_services_grep_search.py

## Issue
- Closes #414
