### PR TITLE
#418 #421 Clarify unavailable preview states

### DIFF
--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -77,6 +77,7 @@ class ChildPaneViewState:
     entries: tuple[PaneEntry, ...] = ()
     preview_path: str | None = None
     preview_content: str | None = None
+    preview_message: str | None = None
     preview_truncated: bool = False
     syntax_theme: str = "monokai"
 
@@ -84,7 +85,7 @@ class ChildPaneViewState:
     def is_preview(self) -> bool:
         """Return whether the pane should render a text preview."""
 
-        return self.preview_content is not None
+        return self.preview_content is not None or self.preview_message is not None
 
 
 @dataclass(frozen=True)

--- a/src/peneo/services/browser_snapshot.py
+++ b/src/peneo/services/browser_snapshot.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from time import sleep
-from typing import Mapping, Protocol
+from typing import Literal, Mapping, Protocol
 
 from peneo.adapters import DirectoryReader, LocalFilesystemAdapter
 from peneo.archive_utils import is_supported_archive_path
@@ -180,6 +180,9 @@ TEXT_PREVIEW_FILENAMES = frozenset(
         "dockerfile",
     }
 )
+PREVIEW_PERMISSION_DENIED_MESSAGE = "Preview unavailable: permission denied"
+PREVIEW_UNSUPPORTED_MESSAGE = "Preview unavailable for this file type"
+PREVIEW_ERROR_MESSAGE = "Preview unavailable"
 
 
 class BrowserSnapshotLoader(Protocol):
@@ -279,15 +282,15 @@ class LiveBrowserSnapshotLoader:
                 return PaneState(directory_path=current_path, entries=())
 
         preview = _load_text_preview(child_path)
-        if preview is not None:
-            preview_content, preview_truncated = preview
+        if preview.kind != "unavailable":
             return PaneState(
                 directory_path=current_path,
                 entries=(),
                 mode="preview",
                 preview_path=str(child_path),
-                preview_content=preview_content,
-                preview_truncated=preview_truncated,
+                preview_content=preview.content,
+                preview_message=preview.message,
+                preview_truncated=preview.truncated,
             )
 
         return PaneState(directory_path=current_path, entries=())
@@ -485,29 +488,53 @@ def _normalize_directory_cache_path(path: str) -> str:
     return str(Path(path).expanduser().resolve())
 
 
-def _load_text_preview(path: Path) -> tuple[str, bool] | None:
+def _load_text_preview(path: Path) -> "FilePreviewState":
     if not _is_preview_candidate(path):
-        return None
+        return FilePreviewState.unsupported()
 
     try:
         with path.open("rb") as handle:
             chunk = handle.read(TEXT_PREVIEW_MAX_BYTES + 1)
+    except PermissionError:
+        return FilePreviewState.permission_denied()
     except OSError:
-        return None
+        return FilePreviewState.error()
 
     if b"\x00" in chunk[:TEXT_PREVIEW_MAX_BYTES]:
-        return None
+        return FilePreviewState.unsupported()
 
     truncated = len(chunk) > TEXT_PREVIEW_MAX_BYTES
     preview_bytes = chunk[:TEXT_PREVIEW_MAX_BYTES]
     try:
         preview_text = preview_bytes.decode("utf-8")
     except UnicodeDecodeError:
-        return None
+        return FilePreviewState.unsupported()
 
-    return preview_text, truncated
+    return FilePreviewState.with_content(preview_text, truncated)
 
 
+@dataclass(frozen=True)
+class FilePreviewState:
+    kind: Literal["content", "message", "unavailable"]
+    content: str | None = None
+    message: str | None = None
+    truncated: bool = False
+
+    @classmethod
+    def with_content(cls, content: str, truncated: bool) -> "FilePreviewState":
+        return cls(kind="content", content=content, truncated=truncated)
+
+    @classmethod
+    def permission_denied(cls) -> "FilePreviewState":
+        return cls(kind="message", message=PREVIEW_PERMISSION_DENIED_MESSAGE)
+
+    @classmethod
+    def unsupported(cls) -> "FilePreviewState":
+        return cls(kind="message", message=PREVIEW_UNSUPPORTED_MESSAGE)
+
+    @classmethod
+    def error(cls) -> "FilePreviewState":
+        return cls(kind="message", message=PREVIEW_ERROR_MESSAGE)
 def _is_preview_candidate(path: Path) -> bool:
     if path.name.casefold() in TEXT_PREVIEW_FILENAMES:
         return True

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -85,6 +85,7 @@ class PaneState:
     mode: Literal["entries", "preview"] = "entries"
     preview_path: str | None = None
     preview_content: str | None = None
+    preview_message: str | None = None
     preview_truncated: bool = False
 
 

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -179,6 +179,16 @@ def _select_child_pane_for_cursor(
         return _build_child_preview_view(
             preview_path,
             state.child_pane.preview_content,
+            state.child_pane.preview_message,
+            state.child_pane.preview_truncated,
+            syntax_theme,
+        )
+    if state.child_pane.mode == "preview" and state.child_pane.preview_message is not None:
+        preview_path = state.child_pane.preview_path or cursor_entry.path
+        return _build_child_preview_view(
+            preview_path,
+            state.child_pane.preview_content,
+            state.child_pane.preview_message,
             state.child_pane.preview_truncated,
             syntax_theme,
         )
@@ -986,7 +996,8 @@ def _build_child_entries_view(
 @lru_cache(maxsize=256)
 def _build_child_preview_view(
     preview_path: str,
-    preview_content: str,
+    preview_content: str | None,
+    preview_message: str | None,
     preview_truncated: bool,
     syntax_theme: str,
 ) -> ChildPaneViewState:
@@ -994,6 +1005,7 @@ def _build_child_preview_view(
         title=_format_child_preview_title(preview_path, preview_truncated),
         preview_path=preview_path,
         preview_content=preview_content,
+        preview_message=preview_message,
         preview_truncated=preview_truncated,
         syntax_theme=syntax_theme,
     )

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -299,6 +299,9 @@ class ChildPane(Vertical):
 
     @staticmethod
     def _render_preview(state: ChildPaneViewState, render_width: int):
+        if state.preview_message is not None:
+            return Text(state.preview_message, style="italic dim")
+
         if state.preview_content is None:
             return Text()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -505,10 +505,10 @@ async def _wait_for_child_preview(
             preview = None
         if child_title is not None and preview is not None and preview.display:
             code = getattr(preview.renderable, "code", None)
+            rendered_text = code if code is not None else str(preview.renderable)
             if (
                 str(child_title.renderable) == expected_title
-                and code is not None
-                and expected_snippet in code
+                and expected_snippet in rendered_text
             ):
                 return
         if asyncio.get_running_loop().time() >= deadline:
@@ -1064,6 +1064,92 @@ async def test_app_updates_child_preview_when_cursor_moves_between_files() -> No
         await _wait_for_child_entries(app, [], timeout=1.0)
         await _wait_for_child_preview(app, "Preview: config.toml", "show_preview = true")
         await _wait_for_child_pane_runtime_idle(app, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_app_renders_preview_message_for_unsupported_file_cursor() -> None:
+    path = "/tmp/peneo-preview-unsupported"
+    binary = f"{path}/archive.bin"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(
+                        DirectoryEntryState(path, "peneo-preview-unsupported", "dir"),
+                        DirectoryEntryState("/tmp/sibling", "sibling", "dir"),
+                    ),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(DirectoryEntryState(binary, "archive.bin", "file"),),
+                    cursor_path=binary,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=binary,
+                    preview_message="Preview unavailable for this file type",
+                ),
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 1)
+        await _wait_for_child_preview(
+            app,
+            "Preview: archive.bin",
+            "Preview unavailable for this file type",
+        )
+
+
+@pytest.mark.asyncio
+async def test_app_renders_preview_message_for_permission_denied_file_cursor() -> None:
+    path = "/tmp/peneo-preview-permission-denied"
+    readme = f"{path}/README.md"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(
+                        DirectoryEntryState(path, "peneo-preview-permission-denied", "dir"),
+                        DirectoryEntryState("/tmp/sibling", "sibling", "dir"),
+                    ),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(DirectoryEntryState(readme, "README.md", "file"),),
+                    cursor_path=readme,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=readme,
+                    preview_message="Preview unavailable: permission denied",
+                ),
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 1)
+        await _wait_for_child_preview(
+            app,
+            "Preview: README.md",
+            "Preview unavailable: permission denied",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 
@@ -131,8 +132,37 @@ def test_live_browser_snapshot_loader_returns_empty_child_pane_for_binary_file_c
     assert snapshot.current_pane.cursor_path == str(binary)
     assert snapshot.child_pane.directory_path == str(project)
     assert snapshot.child_pane.entries == ()
-    assert snapshot.child_pane.mode == "entries"
+    assert snapshot.child_pane.mode == "preview"
+    assert snapshot.child_pane.preview_path == str(binary)
     assert snapshot.child_pane.preview_content is None
+    assert snapshot.child_pane.preview_message == "Preview unavailable for this file type"
+
+
+def test_live_browser_snapshot_loader_marks_permission_denied_preview_candidate(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    readme = project / "README.md"
+    readme.write_text("secret\n", encoding="utf-8")
+
+    original_open = Path.open
+
+    def _blocked_open(self: Path, *args, **kwargs):
+        if self == readme:
+            raise PermissionError("blocked")
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _blocked_open)
+    loader = LiveBrowserSnapshotLoader()
+
+    snapshot = loader.load_browser_snapshot(str(project), cursor_path=str(readme))
+
+    assert snapshot.child_pane.mode == "preview"
+    assert snapshot.child_pane.preview_path == str(readme)
+    assert snapshot.child_pane.preview_content is None
+    assert snapshot.child_pane.preview_message == "Preview unavailable: permission denied"
 
 
 def test_live_browser_snapshot_loader_truncates_large_text_preview(tmp_path) -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -659,6 +659,36 @@ def test_select_shell_data_builds_child_preview_for_text_file() -> None:
     assert shell.child_pane.title == "Preview: README.md (truncated)"
     assert shell.child_pane.preview_path == path
     assert shell.child_pane.preview_content == "# Preview\n"
+    assert shell.child_pane.preview_message is None
+
+
+def test_select_shell_data_builds_child_preview_message_for_unavailable_file() -> None:
+    initial_state = build_initial_app_state()
+    path = "/home/tadashi/develop/peneo/archive.bin"
+    state = replace(
+        initial_state,
+        current_pane=replace(
+            initial_state.current_pane,
+            entries=initial_state.current_pane.entries
+            + (DirectoryEntryState(path, "archive.bin", "file"),),
+            cursor_path=path,
+        ),
+        child_pane=PaneState(
+            directory_path="/home/tadashi/develop/peneo",
+            entries=(),
+            mode="preview",
+            preview_path=path,
+            preview_message="Preview unavailable for this file type",
+        ),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is True
+    assert shell.child_pane.title == "Preview: archive.bin"
+    assert shell.child_pane.preview_path == path
+    assert shell.child_pane.preview_content is None
+    assert shell.child_pane.preview_message == "Preview unavailable for this file type"
 
 
 def test_select_parent_and_child_entries_keep_fixed_name_sort() -> None:


### PR DESCRIPTION
## Summary
- keep file cursors in the Preview pane even when no preview text can be shown
- distinguish permission-denied files from unsupported preview targets and render explicit messages
- add service, selector, and app regression coverage for unavailable preview states

## Testing
- `uv run ruff check .`
- `uv run pytest`
- `uv run python -m compileall src tests`

Closes #418
Closes #421
