### PR TITLE
Issue #362 Limit directory size calculation to current pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The supported settings are:
 | `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. The config key is accepted even though native Windows runtime is not currently supported. |
 | `editor` | `command` | Shell-style string, for example `nvim -u NONE` | Optional terminal editor command used by `e`. Do not include the file path; Peneo appends it automatically. Unsupported GUI editors or invalid commands are ignored. |
 | `display` | `show_hidden_files` | `true` / `false` | Default hidden-file visibility when the app starts. |
-| `display` | `show_directory_sizes` | `true` / `false` | Shows recursive directory sizes in the panes. Defaults to `false` because large directories can be expensive to scan. Peneo also calculates sizes automatically while the main pane is sorted by `size`. |
+| `display` | `show_directory_sizes` | `true` / `false` | Shows recursive directory sizes in the current pane. Defaults to `false` because large directories can be expensive to scan. Peneo also calculates sizes automatically while the main pane is sorted by `size`. |
 | `display` | `show_preview` | `true` / `false` | Shows the text-file preview in the right pane. Defaults to `true`. Directory and archive child panes are unaffected. |
 | `display` | `show_help_bar` | `true` / `false` | Shows the help bar at the bottom of the screen. Defaults to `true`. The help bar is always shown when the command palette or split terminal is open, regardless of this setting. |
 | `display` | `theme` | `textual-dark` / `textual-light` | Default UI theme applied on startup and after saving from the settings editor. |

--- a/src/peneo/adapters/filesystem.py
+++ b/src/peneo/adapters/filesystem.py
@@ -83,22 +83,25 @@ def _calculate_directory_size(
         raise DirectorySizeCancelled()
 
     total_size = 0
-    with os.scandir(directory) as iterator:
-        for child in iterator:
-            if is_cancelled is not None and is_cancelled():
-                raise DirectorySizeCancelled()
-            try:
-                if child.is_symlink():
+    try:
+        with os.scandir(directory) as iterator:
+            for child in iterator:
+                if is_cancelled is not None and is_cancelled():
+                    raise DirectorySizeCancelled()
+                try:
+                    if child.is_symlink():
+                        continue
+                    if child.is_dir(follow_symlinks=False):
+                        total_size += _calculate_directory_size(
+                            Path(child.path),
+                            is_cancelled=is_cancelled,
+                        )
+                        continue
+                    total_size += child.stat(follow_symlinks=False).st_size
+                except (FileNotFoundError, PermissionError):
                     continue
-                if child.is_dir(follow_symlinks=False):
-                    total_size += _calculate_directory_size(
-                        Path(child.path),
-                        is_cancelled=is_cancelled,
-                    )
-                    continue
-                total_size += child.stat(follow_symlinks=False).st_size
-            except FileNotFoundError:
-                continue
+    except PermissionError:
+        return 0
     return total_size
 
 

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -461,22 +461,15 @@ def maybe_request_directory_sizes(
 
 
 def directory_size_target_paths(state: AppState) -> tuple[str, ...]:
-    display_directory_sizes = state.config.display.show_directory_sizes
-    target_paths: list[str] = []
-    if display_directory_sizes:
-        target_paths.extend(visible_directory_paths(state.parent_pane.entries, state.show_hidden))
-    target_paths.extend(
-        visible_directory_paths(select_visible_current_entry_states(state), show_hidden=True)
-    )
-    if display_directory_sizes:
-        target_paths.extend(visible_directory_paths(state.child_pane.entries, state.show_hidden))
-    if not display_directory_sizes and state.sort.field != "size":
+    if not state.config.display.show_directory_sizes and state.sort.field != "size":
         return ()
-    if display_directory_sizes:
-        return tuple(dict.fromkeys(target_paths))
+
     return tuple(
         dict.fromkeys(
-            visible_directory_paths(select_visible_current_entry_states(state), show_hidden=True)
+            visible_directory_paths(
+                select_visible_current_entry_states(state),
+                show_hidden=True,
+            )
         )
     )
 

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -90,3 +90,24 @@ def test_local_filesystem_adapter_directory_size_ignores_symlinks(tmp_path) -> N
     size = adapter.calculate_directory_size(str(docs))
 
     assert size == len("guide")
+
+
+def test_local_filesystem_adapter_directory_size_skips_permission_denied_descendants(
+    tmp_path,
+) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("guide", encoding="utf-8")
+    private = docs / "private"
+    private.mkdir()
+    (private / "secret.txt").write_text("secret", encoding="utf-8")
+
+    adapter = LocalFilesystemAdapter()
+
+    private.chmod(0)
+    try:
+        size = adapter.calculate_directory_size(str(docs))
+    finally:
+        private.chmod(0o755)
+
+    assert size == len("guide")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -635,11 +635,8 @@ async def test_app_loads_directory_sizes_when_enabled() -> None:
     )
     directory_size_service = FakeDirectorySizeService(
         results_by_paths={
-            (path, "/tmp/sibling", f"{path}/docs", f"{path}/docs/api"): (
-                (path, 10_000),
-                ("/tmp/sibling", 2_000),
+            (f"{path}/docs",): (
                 (f"{path}/docs", 4_200),
-                (f"{path}/docs/api", 88_000),
             )
         }
     )
@@ -686,9 +683,7 @@ async def test_app_applies_directory_size_updates_without_full_current_pane_refr
 
     directory_size_service = SlowDirectorySizeService(
         results_by_paths={
-            (path, "/tmp/sibling", f"{path}/docs"): (
-                (path, 10_000),
-                ("/tmp/sibling", 2_000),
+            (f"{path}/docs",): (
                 (f"{path}/docs", 4_200),
             )
         }
@@ -740,6 +735,7 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
                 path,
                 (
                     DirectoryEntryState(f"{path}/docs", "docs", "dir"),
+                    DirectoryEntryState(f"{path}/private", "private", "dir"),
                     DirectoryEntryState(f"{path}/README.md", "README.md", "file", size_bytes=120),
                 ),
                 child_path=f"{path}/docs",
@@ -749,15 +745,13 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
     )
     directory_size_service = FakeDirectorySizeService(
         results_by_paths={
-            (path, "/tmp/sibling", f"{path}/docs", f"{path}/docs/api"): (
-                (path, 10_000),
+            (f"{path}/docs", f"{path}/private"): (
                 (f"{path}/docs", 4_200),
-                (f"{path}/docs/api", 88_000),
             )
         },
         failures_by_paths={
-            (path, "/tmp/sibling", f"{path}/docs", f"{path}/docs/api"): (
-                ("/tmp/sibling", "permission denied"),
+            (f"{path}/docs", f"{path}/private"): (
+                (f"{path}/private", "permission denied"),
             )
         },
     )
@@ -772,7 +766,7 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
 
     async with app.run_test():
         await _wait_for_snapshot_loaded(app, path)
-        await _wait_for_row_count(app, 2)
+        await _wait_for_row_count(app, 3)
         await _wait_for_table_cell(app, "4.2 KB", 0, 2)
 
         table = app.query_one("#current-pane-table", DataTable)
@@ -2110,7 +2104,7 @@ async def test_app_directory_size_update_avoids_rebuilding_large_current_pane(mo
 
         directory_size_service.release()
         await _wait_for_directory_sizes(app, timeout=2.0)
-        await _wait_for_table_cell(app, "3.0 KB", 0, 2, timeout=2.0)
+        await _wait_for_table_cell(app, "1.0 KB", 0, 2, timeout=2.0)
 
         assert clear_calls == 0
         assert add_row_calls == 0

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -60,6 +60,7 @@ from peneo.state import (
 )
 from peneo.state import command_palette as command_palette_module
 from peneo.state.command_palette import CommandPaletteItem
+from peneo.state.reducer_common import directory_size_target_paths
 from peneo.state.selectors import (
     _has_execute_permission,
     _select_command_palette_window,
@@ -415,6 +416,118 @@ def test_select_pane_entries_show_directory_sizes_from_cache() -> None:
     assert parent_entries[0].name_detail is None
     assert current_entries[0].size_label == "-"
     assert child_entries[0].name_detail is None
+
+
+def test_directory_size_target_paths_only_uses_current_pane_directories() -> None:
+    state = replace(
+        build_initial_app_state(
+            config=AppConfig(
+                display=replace(
+                    AppConfig().display,
+                    show_directory_sizes=True,
+                )
+            )
+        ),
+        parent_pane=PaneState(
+            directory_path="/tmp",
+            entries=(DirectoryEntryState("/tmp/peneo", "peneo", "dir"),),
+            cursor_path="/tmp/peneo",
+        ),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/peneo",
+            entries=(
+                DirectoryEntryState("/home/tadashi/develop/peneo/docs", "docs", "dir"),
+                DirectoryEntryState(
+                    "/home/tadashi/develop/peneo/.cache",
+                    ".cache",
+                    "dir",
+                    hidden=True,
+                ),
+                DirectoryEntryState(
+                    "/home/tadashi/develop/peneo/README.md",
+                    "README.md",
+                    "file",
+                ),
+            ),
+            cursor_path="/home/tadashi/develop/peneo/docs",
+        ),
+        child_pane=PaneState(
+            directory_path="/home/tadashi/develop/peneo/docs",
+            entries=(DirectoryEntryState("/home/tadashi/develop/peneo/docs/api", "api", "dir"),),
+        ),
+    )
+
+    assert directory_size_target_paths(state) == ("/home/tadashi/develop/peneo/docs",)
+
+
+def test_directory_size_target_paths_respects_current_hidden_visibility() -> None:
+    state = replace(
+        build_initial_app_state(
+            config=AppConfig(
+                display=replace(
+                    AppConfig().display,
+                    show_directory_sizes=True,
+                )
+            )
+        ),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/peneo",
+            entries=(
+                DirectoryEntryState("/home/tadashi/develop/peneo/docs", "docs", "dir"),
+                DirectoryEntryState(
+                    "/home/tadashi/develop/peneo/.cache",
+                    ".cache",
+                    "dir",
+                    hidden=True,
+                ),
+            ),
+            cursor_path="/home/tadashi/develop/peneo/docs",
+        ),
+    )
+
+    assert directory_size_target_paths(state) == ("/home/tadashi/develop/peneo/docs",)
+    assert directory_size_target_paths(replace(state, show_hidden=True)) == (
+        "/home/tadashi/develop/peneo/.cache",
+        "/home/tadashi/develop/peneo/docs",
+    )
+
+
+def test_directory_size_target_paths_returns_empty_when_directory_sizes_are_disabled() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/peneo",
+            entries=(DirectoryEntryState("/home/tadashi/develop/peneo/docs", "docs", "dir"),),
+            cursor_path="/home/tadashi/develop/peneo/docs",
+        ),
+    )
+
+    assert directory_size_target_paths(state) == ()
+
+
+def test_directory_size_target_paths_uses_current_pane_for_size_sort() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/peneo",
+            entries=(
+                DirectoryEntryState("/home/tadashi/develop/peneo/docs", "docs", "dir"),
+                DirectoryEntryState("/home/tadashi/develop/peneo/src", "src", "dir"),
+                DirectoryEntryState(
+                    "/home/tadashi/develop/peneo/README.md",
+                    "README.md",
+                    "file",
+                ),
+            ),
+            cursor_path="/home/tadashi/develop/peneo/docs",
+        ),
+        sort=replace(build_initial_app_state().sort, field="size"),
+    )
+
+    assert directory_size_target_paths(state) == (
+        "/home/tadashi/develop/peneo/docs",
+        "/home/tadashi/develop/peneo/src",
+    )
 
 
 def test_select_visible_current_entries_skip_size_overlay_when_not_sorting_by_size() -> None:


### PR DESCRIPTION
## Summary
- limit directory size requests to visible directories in the current pane only
- keep current-pane size display and size-sort behavior unchanged while removing parent/child pane requests
- update selector/app tests and README wording to match the current-pane-only behavior

## Testing
- uv run ruff check .
- uv run pytest tests/test_state_selectors.py -q
- uv run pytest tests/test_app.py -k directory_size -q
- uv run pytest tests/test_services_directory_size.py -q

Closes #362
