### PR TITLE
#425: ディレクトリの容量の表示単位変更

### DIFF
--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -239,7 +239,7 @@ def build_dummy_shell_data() -> ThreePaneShellData:
         PaneEntry(
             "README.md",
             "file",
-            "2.1 KB",
+            "2.1KiB",
             "2026-03-21 08:55",
             path="/home/tadashi/develop/peneo/README.md",
         ),

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -1345,15 +1345,15 @@ def _build_entry_index(entries: tuple[DirectoryEntryState, ...]) -> dict[str, in
 def _format_size_label(size_bytes: int | None) -> str:
     if size_bytes is None:
         return "-"
-    if size_bytes < 1_000:
+    if size_bytes < 1024:
         return f"{size_bytes} B"
-    units = ("KB", "MB", "GB", "TB")
+    units = ("KiB", "MiB", "GiB", "TiB")
     size = float(size_bytes)
     for unit in units:
-        size /= 1_000
-        if size < 1_000 or unit == units[-1]:
-            return f"{size:.1f} {unit}"
-    return f"{size:.1f} TB"
+        size /= 1024
+        if size < 1024 or unit == units[-1]:
+            return f"{size:.1f}{unit}"
+    return f"{size:.1f}TiB"
 
 
 def _format_modified_label(entry: DirectoryEntryState) -> str:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -652,11 +652,11 @@ async def test_app_loads_directory_sizes_when_enabled() -> None:
     async with app.run_test(size=(120, 20)):
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
-        await _wait_for_table_cell(app, "4.2 KB", 0, 2)
+        await _wait_for_table_cell(app, "4.1KiB", 0, 2)
 
         table = app.query_one("#current-pane-table", DataTable)
 
-        assert str(table.get_cell_at((0, 2))) == "4.2 KB"
+        assert str(table.get_cell_at((0, 2))) == "4.1KiB"
 
 
 @pytest.mark.asyncio
@@ -720,7 +720,7 @@ async def test_app_applies_directory_size_updates_without_full_current_pane_refr
         await _wait_for_row_count(app, 2)
         await _wait_for_table_cell(app, "-", 0, 2)
         full_refresh_calls_before_ready = set_entries_calls
-        await _wait_for_table_cell(app, "4.2 KB", 0, 2)
+        await _wait_for_table_cell(app, "4.1KiB", 0, 2)
 
         assert set_entries_calls == full_refresh_calls_before_ready
         assert apply_size_updates_calls == 1
@@ -767,11 +767,11 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
     async with app.run_test():
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 3)
-        await _wait_for_table_cell(app, "4.2 KB", 0, 2)
+        await _wait_for_table_cell(app, "4.1KiB", 0, 2)
 
         table = app.query_one("#current-pane-table", DataTable)
 
-        assert str(table.get_cell_at((0, 2))) == "4.2 KB"
+        assert str(table.get_cell_at((0, 2))) == "4.1KiB"
 
 
 @pytest.mark.asyncio
@@ -2104,7 +2104,7 @@ async def test_app_directory_size_update_avoids_rebuilding_large_current_pane(mo
 
         directory_size_service.release()
         await _wait_for_directory_sizes(app, timeout=2.0)
-        await _wait_for_table_cell(app, "1.0 KB", 0, 2, timeout=2.0)
+        await _wait_for_table_cell(app, "1000 B", 0, 2, timeout=2.0)
 
         assert clear_calls == 0
         assert add_row_calls == 0

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -580,7 +580,7 @@ def test_select_shell_data_emits_size_delta_updates_for_directory_size_changes()
         (update.path, update.size_label)
         for update in shell.current_pane_update.size_updates
     ] == [
-        ("/home/tadashi/develop/peneo/docs", "4.2 KB")
+        ("/home/tadashi/develop/peneo/docs", "4.1KiB")
     ]
 
 
@@ -1609,7 +1609,7 @@ def test_select_attribute_dialog_state_formats_selected_entry() -> None:
     assert "Name: README.md" in dialog.lines
     assert "Type: File" in dialog.lines
     assert "Path: /home/tadashi/develop/peneo/README.md" in dialog.lines
-    assert "Size: 2.1 KB" in dialog.lines
+    assert "Size: 2.1KiB" in dialog.lines
     assert "Hidden: No" in dialog.lines
     assert "Permissions: -rw-r--r-- (644)" in dialog.lines
     assert dialog.options == ("enter close", "esc close")

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -23,12 +23,12 @@ def test_truncate_middle_handles_extremely_narrow_widths() -> None:
 
 
 def test_build_entry_label_truncates_full_name_detail_string() -> None:
-    entry = PaneEntry("archive.tar.gz", "file", name_detail="2.1 KB")
+    entry = PaneEntry("archive.tar.gz", "file", name_detail="2.1KiB")
 
     rendered = truncate_middle(build_entry_label(entry), 15)
 
     assert "~" in rendered
-    assert rendered.endswith("1 KB)")
+    assert rendered.endswith("1KiB)")
 
 
 def test_pane_entry_supports_executable_field() -> None:


### PR DESCRIPTION
## 概要
ファイルサイズの表示単位を 1000 単位（KB/MB/GB/TB）から 1024 単位（KiB/MiB/GiB/TiB）に変更しました。これは IEC 80000-13 規格に準拠した表記です。

## 変更内容
- `_format_size_label` 関数を 1024 単位に変更
- 単位を KB/MB/GB/TB から KiB/MiB/GiB/TiB に変更
- 数値と単位の間のスペースを削除（文字数増加を吸収）
- 例: "4.2 KB" → "4.1KiB"（文字数は同じ 6 文字）

## 変更ファイル
- `src/peneo/state/selectors.py` - 本体実装
- `tests/test_state_selectors.py` - テスト更新
- `tests/test_app.py` - テスト更新
- `tests/test_ui_panes.py` - テスト更新
- `src/peneo/models/shell_data.py` - モックデータ更新

## テスト
すべて 761 個のテストが成功しました。

Fixes #425