### PR TITLE
Issue #426 ヘルプバーを4行から3行に削減

### DIFF
--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -328,10 +328,9 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         return HelpBarState(state.config.help_bar.browsing)
     return HelpBarState(
         (
-            "enter open | e edit | i info | space select | c copy | x cut | p paste | C path",
-            "/ filter | s sort | d dir-first | . hidden | a select-all | ~ home",
-            "f find | g grep | G go-to | H history | b bookmarks | B toggle-bookmark",
-            "n new-file | N new-dir | r rename | R reload | t term | : palette | q quit",
+            "enter open | e edit | i info | space select | c copy | x cut | p paste | r rename",
+            "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to",
+            "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit",
         )
     )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2361,10 +2361,9 @@ async def test_app_displays_browsing_help_bar() -> None:
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
-        "enter open | e edit | i info | space select | c copy | x cut | p paste | C path\n"
-        "/ filter | s sort | d dir-first | . hidden | a select-all | ~ home\n"
-        "f find | g grep | G go-to | H history | b bookmarks | B toggle-bookmark\n"
-        "n new-file | N new-dir | r rename | R reload | t term | : palette | q quit"
+        "enter open | e edit | i info | space select | c copy | x cut | p paste | r rename\n"
+        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to\n"
+        "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit"
     )
 
     async with app.run_test():

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1130,16 +1130,14 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     help_state = select_help_bar_state(state)
 
     assert help_state.lines == (
-        "enter open | e edit | i info | space select | c copy | x cut | p paste | C path",
-        "/ filter | s sort | d dir-first | . hidden | a select-all | ~ home",
-        "f find | g grep | G go-to | H history | b bookmarks | B toggle-bookmark",
-        "n new-file | N new-dir | r rename | R reload | t term | : palette | q quit",
+        "enter open | e edit | i info | space select | c copy | x cut | p paste | r rename",
+        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to",
+        "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit",
     )
     assert help_state.text == (
-        "enter open | e edit | i info | space select | c copy | x cut | p paste | C path\n"
-        "/ filter | s sort | d dir-first | . hidden | a select-all | ~ home\n"
-        "f find | g grep | G go-to | H history | b bookmarks | B toggle-bookmark\n"
-        "n new-file | N new-dir | r rename | R reload | t term | : palette | q quit"
+        "enter open | e edit | i info | space select | c copy | x cut | p paste | r rename\n"
+        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to\n"
+        "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit"
     )
 
 


### PR DESCRIPTION
## 概要
メイン画面のヘルプバーを4行から3行に削減し、画面領域を有効活用できるようにしました。

## 変更内容
- デフォルトのヘルプバーを4行から3行に変更
- 使用頻度の低いコマンドを削除し、重要な操作に集中

## 削除したコマンドと代替手段
| コマンド | 代替手段 |
|---------|---------|
| `C` (path copy) | Command palette → "Copy path" |
| `d` (dir-first) | Config display.directories_first |
| `a` (select-all) | Shift+↑/↓ で範囲選択 |
| `R` (reload) | Command palette → "Reload" |
| `B` (toggle-bookmark) | `b` → ブックマーク一覧 |

## 新しい3行構成
```
第1行: enter open | e edit | i info | space select | c copy | x cut | p paste | r rename
第2行: / filter | s sort | . hidden | ~ home | f find | g grep | G go-to
第3行: n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit
```

## テスト
- 既存テストの期待値を更新
- 全テストがパスすることを確認 (761 passed)

## 影響範囲
- `src/peneo/state/selectors.py` - デフォルトヘルプバーの定義
- `tests/test_state_selectors.py` - テスト期待値更新
- `tests/test_app.py` - テスト期待値更新

Closes #426