### PR TITLE
Add preview support for file search (#437)

### DIFF
--- a/src/peneo/state/reducer_palette.py
+++ b/src/peneo/state/reducer_palette.py
@@ -60,6 +60,7 @@ from .models import (
     AttributeInspectionState,
     CommandPaletteState,
     ConfigEditorState,
+    FileSearchResultState,
     GrepSearchResultState,
     NotificationState,
 )
@@ -179,6 +180,8 @@ def _handle_move_palette_cursor(
     )
     if state.command_palette.source == "grep_search":
         return _sync_grep_preview(next_state)
+    if state.command_palette.source == "file_search":
+        return _sync_file_search_preview(next_state)
     return done(next_state)
 
 
@@ -217,7 +220,7 @@ def _handle_set_file_search_query(
 ) -> ReduceResult:
     stripped_query = query.strip()
     if not stripped_query:
-        return done(
+        return _sync_file_search_preview(
             replace(
                 state,
                 command_palette=replace(
@@ -227,6 +230,7 @@ def _handle_set_file_search_query(
                 ),
                 pending_file_search_request_id=None,
                 pending_grep_search_request_id=None,
+                pending_child_pane_request_id=None,
             )
         )
 
@@ -239,7 +243,7 @@ def _handle_set_file_search_query(
         and state.command_palette.file_search_cache_root_path == state.current_path
         and state.command_palette.file_search_cache_show_hidden == state.show_hidden
     ):
-        return done(
+        return _sync_file_search_preview(
             replace(
                 state,
                 command_palette=replace(
@@ -905,7 +909,7 @@ def _handle_file_search_completed(
         cache_query = action.query.casefold()
         cache_results = action.results
 
-    return done(
+    return _sync_file_search_preview(
         replace(
             state,
             command_palette=replace(
@@ -931,7 +935,7 @@ def _handle_file_search_failed(
         return done(state)
 
     if state.command_palette is not None and action.invalid_query:
-        return done(
+        return _sync_file_search_preview(
             replace(
                 state,
                 command_palette=replace(
@@ -940,6 +944,7 @@ def _handle_file_search_failed(
                     file_search_error_message=action.message,
                 ),
                 pending_file_search_request_id=None,
+                pending_child_pane_request_id=None,
             )
         )
 
@@ -1057,6 +1062,51 @@ def _sync_grep_preview(state: AppState) -> ReduceResult:
     )
 
 
+def _selected_file_search_result(state: AppState) -> FileSearchResultState | None:
+    if state.command_palette is None or state.command_palette.source != "file_search":
+        return None
+    results = state.command_palette.file_search_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def _matches_file_search_preview(
+    state: AppState,
+    result: FileSearchResultState,
+) -> bool:
+    return (
+        state.child_pane.mode == "preview"
+        and state.child_pane.preview_path == result.path
+    )
+
+
+def _sync_file_search_preview(state: AppState) -> ReduceResult:
+    selected_result = _selected_file_search_result(state)
+    if selected_result is None or not state.config.display.show_preview:
+        return done(replace(state, pending_child_pane_request_id=None))
+
+    if state.pending_child_pane_request_id is None and _matches_file_search_preview(
+        state,
+        selected_result,
+    ):
+        return done(state)
+
+    request_id = state.next_request_id
+    return done(
+        replace(
+            state,
+            pending_child_pane_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        LoadChildPaneSnapshotEffect(
+            request_id=request_id,
+            current_path=state.current_path,
+            cursor_path=selected_result.path,
+        ),
+    )
+
+
 def handle_palette_action(
     state: AppState,
     action: Action,
@@ -1082,7 +1132,11 @@ def handle_palette_action(
 
     if isinstance(action, CancelCommandPalette):
         next_state = _restore_browsing_from_palette(state, clear_name_conflict=True)
-        if state.command_palette is not None and state.command_palette.source == "grep_search":
+        preview_sources = ("grep_search", "file_search")
+        if (
+            state.command_palette is not None
+            and state.command_palette.source in preview_sources
+        ):
             return sync_child_pane(next_state, next_state.current_pane.cursor_path, reduce_state)
         return done(next_state)
 

--- a/src/peneo/state/reducer_palette.py
+++ b/src/peneo/state/reducer_palette.py
@@ -1086,10 +1086,10 @@ def _sync_file_search_preview(state: AppState) -> ReduceResult:
     if selected_result is None or not state.config.display.show_preview:
         return done(replace(state, pending_child_pane_request_id=None))
 
-    if state.pending_child_pane_request_id is None and _matches_file_search_preview(
-        state,
-        selected_result,
-    ):
+    # file_search では、preview_highlight_line がないので、preview_path のみで一致を判定
+    # カーソル移動時の無限ループを防ぐため、pending_child_pane_request_id が None の場合のみ
+    # preview_path が一致する場合はスキップ
+    if state.pending_child_pane_request_id is None and _matches_file_search_preview(state, selected_result):
         return done(state)
 
     request_id = state.next_request_id

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2870,6 +2870,9 @@ async def test_app_file_search_shows_invalid_regex_message_in_palette(tmp_path) 
 
 
 @pytest.mark.asyncio
+
+
+@pytest.mark.asyncio
 async def test_app_command_palette_grep_jumps_to_matching_parent_directory() -> None:
     path = "/tmp/peneo-command-palette-grep"
     docs_path = f"{path}/docs"

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -2413,8 +2413,14 @@ def test_set_command_palette_query_reuses_completed_file_search_results_for_pref
 
     result = reduce_app_state(state, SetCommandPaletteQuery("readm"))
 
-    assert result.effects == ()
     assert result.state.pending_file_search_request_id is None
+    assert len(result.effects) == 1
+    assert result.effects[0] == LoadChildPaneSnapshotEffect(
+        request_id=5,
+        current_path="/home/tadashi/develop/peneo",
+        cursor_path="/home/tadashi/develop/peneo/README.md",
+    )
+    assert result.state.next_request_id == 6
     assert result.state.command_palette is not None
     assert result.state.command_palette.file_search_results == (
         FileSearchResultState(
@@ -2422,7 +2428,6 @@ def test_set_command_palette_query_reuses_completed_file_search_results_for_pref
             display_path="README.md",
         ),
     )
-    assert result.state.next_request_id == 5
 
 
 def test_set_command_palette_query_runs_new_search_when_query_is_not_prefix_extension() -> None:
@@ -2600,6 +2605,149 @@ def test_file_search_failed_sets_inline_error_for_invalid_regex() -> None:
     )
     assert next_state.notification is None
     assert next_state.pending_file_search_request_id is None
+
+
+def test_file_search_completed_requests_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(state.command_palette, query="read"),
+        pending_file_search_request_id=4,
+    )
+    file_result = FileSearchResultState(
+        path="/home/tadashi/develop/peneo/README.md",
+        display_path="README.md",
+    )
+
+    result = reduce_app_state(
+        search_state,
+        FileSearchCompleted(
+            request_id=4,
+            query="read",
+            results=(file_result,),
+        ),
+    )
+
+    assert result.state.pending_child_pane_request_id == 1
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=1,
+            current_path="/home/tadashi/develop/peneo",
+            cursor_path="/home/tadashi/develop/peneo/README.md",
+        ),
+    )
+
+
+def test_file_search_completed_skips_preview_when_preview_disabled() -> None:
+    file_result = FileSearchResultState(
+        path="/home/tadashi/develop/peneo/README.md",
+        display_path="README.md",
+    )
+    search_state = replace(
+        _reduce_state(build_initial_app_state(), BeginFileSearch()),
+        config=replace(
+            build_initial_app_state().config,
+            display=replace(build_initial_app_state().config.display, show_preview=False),
+        ),
+        command_palette=replace(
+            _reduce_state(build_initial_app_state(), BeginFileSearch()).command_palette,
+            query="read",
+        ),
+        pending_file_search_request_id=4,
+    )
+
+    result = reduce_app_state(
+        search_state,
+        FileSearchCompleted(
+            request_id=4,
+            query="read",
+            results=(file_result,),
+        ),
+    )
+
+    assert result.state.config.display.show_preview is False
+    assert result.state.pending_child_pane_request_id is None
+    assert result.effects == ()
+
+
+def test_file_search_move_cursor_requests_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    file_results = (
+        FileSearchResultState(
+            path="/home/tadashi/develop/peneo/README.md",
+            display_path="README.md",
+        ),
+        FileSearchResultState(
+            path="/home/tadashi/develop/peneo/docs/spec.md",
+            display_path="docs/spec.md",
+        ),
+    )
+    search_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="read",
+            file_search_results=file_results,
+            cursor_index=0,
+        ),
+    )
+
+    result = reduce_app_state(search_state, MoveCommandPaletteCursor(delta=1))
+
+    assert result.state.pending_child_pane_request_id == 1
+    assert result.state.command_palette.cursor_index == 1
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=1,
+            current_path="/home/tadashi/develop/peneo",
+            cursor_path="/home/tadashi/develop/peneo/docs/spec.md",
+        ),
+    )
+
+
+def test_cancel_file_search_command_palette_restores_current_cursor_preview() -> None:
+    path = "/home/tadashi/develop/peneo/README.md"
+    state = replace(
+        build_initial_app_state(),
+        current_pane=replace(
+            build_initial_app_state().current_pane,
+            entries=(
+                DirectoryEntryState(
+                    path=path,
+                    name="README.md",
+                    kind="file",
+                ),
+            ),
+            cursor_path=path,
+        ),
+    )
+    state = _reduce_state(state, BeginFileSearch())
+    file_results = (
+        FileSearchResultState(
+            path="/home/tadashi/develop/peneo/docs/spec.md",
+            display_path="docs/spec.md",
+        ),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="spec",
+            file_search_results=file_results,
+        ),
+    )
+
+    result = reduce_app_state(state, CancelCommandPalette())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.command_palette is None
+    assert result.state.pending_child_pane_request_id == 1
+    assert len(result.effects) == 1
+    assert result.effects[0] == LoadChildPaneSnapshotEffect(
+        request_id=1,
+        current_path="/home/tadashi/develop/peneo",
+        cursor_path=path,
+    )
 
 
 def test_submit_command_palette_uses_inline_error_message_when_present() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "peneo"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },


### PR DESCRIPTION
## Summary
- Add file search preview functionality to match the existing grep search preview feature
- When files are found using the command palette (Ctrl+P), the selected file is now displayed in the child pane preview

## Changes
- Add `_selected_file_search_result`, `_matches_file_search_preview`, and `_sync_file_search_preview` helper functions
- Update `_handle_move_palette_cursor` to sync preview on cursor movement
- Update `_handle_set_file_search_query` to sync preview on query changes
- Update `_handle_file_search_completed` to request preview on search completion
- Update `_handle_file_search_failed` to clear preview on invalid regex
- Update `CancelCommandPalette` handler to restore current cursor preview
- Add `FileSearchResultState` to imports

## Test plan
- [x] All existing tests pass
- [x] Add test_file_search_completed_requests_preview
- [x] Add test_file_search_completed_skips_preview_when_preview_disabled
- [x] Add test_file_search_move_cursor_requests_preview
- [x] Add test_cancel_file_search_command_palette_restores_current_cursor_preview
- [x] Update test_set_command_palette_query_reuses_completed_file_search_results_for_prefix_extension

## Verification
To test:
1. Run `uv run peneo`
2. Press `Ctrl+P` to open file search
3. Type a query to find files
4. Navigate with arrow keys - preview should update for each file
5. Press `ESC` to cancel - preview should restore to current cursor file

🤖 Generated with [Claude Code](https://claude.com/claude-code)