### PR TITLE
Fix #438: grep結果を折り返して表示しない

### DIFF
--- a/src/peneo/ui/command_palette.py
+++ b/src/peneo/ui/command_palette.py
@@ -1,5 +1,6 @@
 """Command palette widget."""
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual.containers import Container
 from textual.widgets import Static
@@ -87,7 +88,7 @@ class CommandPalette(Container):
 
             # Truncate long labels to prevent wrapping
             label = item.label
-            if len(label) > max_label_width:
+            if cell_len(label) > max_label_width:
                 label = truncate_middle(label, max_label_width)
 
             line.append(label, style=style)

--- a/src/peneo/ui/command_palette.py
+++ b/src/peneo/ui/command_palette.py
@@ -28,6 +28,8 @@ class CommandPalette(Container):
         yield Static("", id="command-palette-items")
 
     def on_mount(self) -> None:
+        items_widget = self.query_one("#command-palette-items", Static)
+        items_widget.word_wrap = False
         self.set_state(self.state)
 
     def set_state(self, state: CommandPaletteViewState | None) -> None:

--- a/tests/test_command_palette.py
+++ b/tests/test_command_palette.py
@@ -1,0 +1,118 @@
+"""Tests for the command palette widget."""
+
+from peneo.models import CommandPaletteItemViewState, CommandPaletteViewState
+from peneo.ui.command_palette import CommandPalette
+
+
+def test_truncation_with_multibyte_text() -> None:
+    """マルチバイト文字を含むラベルが表示幅に基づいて切り詰められること"""
+    # 文字数は短いが表示幅が長いラベル
+    label = "file_" + "日本語" * 30 + "_description.txt"
+    # len(label) = 111, cell_len(label) = 201
+
+    state = CommandPaletteViewState(
+        title="Test",
+        query="test",
+        items=(
+            CommandPaletteItemViewState(
+                label=label,
+                shortcut=None,
+                enabled=True,
+                selected=False,
+            ),
+        ),
+        empty_message="No results",
+        has_more_items=False,
+    )
+
+    palette = CommandPalette(state)
+    rendered = palette._render_items(state)
+
+    # 切り詰められていることを確認
+    rendered_text = str(rendered)
+    assert len(rendered_text) < len(label), "ラベルは切り詰められている必要があります"
+    # 切り詰めマーカーが含まれていることを確認
+    assert "…" in rendered_text or "~" in rendered_text, "切り詰めマーカーが含まれている必要があります"
+
+
+def test_no_truncation_for_short_labels() -> None:
+    """短いラベルは切り詰められないこと"""
+    label = "検索結果.txt"  # 短い日本語ファイル名
+
+    state = CommandPaletteViewState(
+        title="Test",
+        query="test",
+        items=(
+            CommandPaletteItemViewState(
+                label=label,
+                shortcut=None,
+                enabled=True,
+                selected=False,
+            ),
+        ),
+        empty_message="No results",
+        has_more_items=False,
+    )
+
+    palette = CommandPalette(state)
+    rendered = palette._render_items(state)
+
+    # 完全なラベルが含まれていることを確認
+    rendered_text = str(rendered)
+    assert label in rendered_text, "短いラベルはそのまま表示される必要があります"
+
+
+def test_truncation_with_ascii_text() -> None:
+    """ASCII テキストも正しく切り詰められること"""
+    # 120 文字を超える ASCII ラベル
+    label = "a" * 200
+
+    state = CommandPaletteViewState(
+        title="Test",
+        query="test",
+        items=(
+            CommandPaletteItemViewState(
+                label=label,
+                shortcut=None,
+                enabled=True,
+                selected=False,
+            ),
+        ),
+        empty_message="No results",
+        has_more_items=False,
+    )
+
+    palette = CommandPalette(state)
+    rendered = palette._render_items(state)
+
+    # 切り詰められていることを確認
+    rendered_text = str(rendered)
+    assert len(rendered_text) < len(label), "長い ASCII ラベルは切り詰められている必要があります"
+    assert "…" in rendered_text or "~" in rendered_text, "切り詰めマーカーが含まれている必要があります"
+
+
+def test_no_truncation_for_short_ascii_labels() -> None:
+    """短い ASCII ラベルは切り詰められないこと"""
+    label = "search_result.txt"  # 短い ASCII ファイル名
+
+    state = CommandPaletteViewState(
+        title="Test",
+        query="test",
+        items=(
+            CommandPaletteItemViewState(
+                label=label,
+                shortcut=None,
+                enabled=True,
+                selected=False,
+            ),
+        ),
+        empty_message="No results",
+        has_more_items=False,
+    )
+
+    palette = CommandPalette(state)
+    rendered = palette._render_items(state)
+
+    # 完全なラベルが含まれていることを確認
+    rendered_text = str(rendered)
+    assert label in rendered_text, "短い ASCII ラベルはそのまま表示される必要があります"


### PR DESCRIPTION
## Summary

- grep 検索結果のラベルが長い場合に、表示幅に基づいて正しく切り詰められるように修正
- `len(label)` の代わりに `cell_len(label)` を使用して、マルチバイト文字の表示幅を正確に計算
- 日本語などのマルチバイト文字を含むラベルが正しく切り詰められ、折り返し表示が発生しなくなりました

## Test plan

- [x] 既存テストがパスすることを確認 (777 passed)
- [x] マルチバイト文字を含むラベルの切り詰めテストを追加
- [x] ASCII テキストの既存動作が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)