### PR TITLE
[#437] Add preview support for find files

### DIFF
--- a/src/peneo/state/reducer_palette.py
+++ b/src/peneo/state/reducer_palette.py
@@ -60,6 +60,7 @@ from .models import (
     AttributeInspectionState,
     CommandPaletteState,
     ConfigEditorState,
+    FileSearchResultState,
     GrepSearchResultState,
     NotificationState,
 )
@@ -177,6 +178,8 @@ def _handle_move_palette_cursor(
         state,
         command_palette=next_palette,
     )
+    if state.command_palette.source == "file_search":
+        return _sync_file_search_preview(next_state)
     if state.command_palette.source == "grep_search":
         return _sync_grep_preview(next_state)
     return done(next_state)
@@ -217,7 +220,7 @@ def _handle_set_file_search_query(
 ) -> ReduceResult:
     stripped_query = query.strip()
     if not stripped_query:
-        return done(
+        return _sync_file_search_preview(
             replace(
                 state,
                 command_palette=replace(
@@ -227,6 +230,7 @@ def _handle_set_file_search_query(
                 ),
                 pending_file_search_request_id=None,
                 pending_grep_search_request_id=None,
+                pending_child_pane_request_id=None,
             )
         )
 
@@ -239,7 +243,7 @@ def _handle_set_file_search_query(
         and state.command_palette.file_search_cache_root_path == state.current_path
         and state.command_palette.file_search_cache_show_hidden == state.show_hidden
     ):
-        return done(
+        return _sync_file_search_preview(
             replace(
                 state,
                 command_palette=replace(
@@ -905,7 +909,7 @@ def _handle_file_search_completed(
         cache_query = action.query.casefold()
         cache_results = action.results
 
-    return done(
+    return _sync_file_search_preview(
         replace(
             state,
             command_palette=replace(
@@ -931,7 +935,7 @@ def _handle_file_search_failed(
         return done(state)
 
     if state.command_palette is not None and action.invalid_query:
-        return done(
+        return _sync_file_search_preview(
             replace(
                 state,
                 command_palette=replace(
@@ -1018,6 +1022,54 @@ def _selected_grep_result(state: AppState) -> GrepSearchResultState | None:
     return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
 
 
+def _selected_file_search_result(state: AppState) -> FileSearchResultState | None:
+    if state.command_palette is None or state.command_palette.source != "file_search":
+        return None
+    results = state.command_palette.file_search_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def _matches_file_search_preview(
+    state: AppState,
+    result: FileSearchResultState,
+) -> bool:
+    return (
+        state.child_pane.mode == "preview"
+        and state.child_pane.preview_path == result.path
+        and state.child_pane.preview_title is None
+        and state.child_pane.preview_start_line is None
+        and state.child_pane.preview_highlight_line is None
+    )
+
+
+def _sync_file_search_preview(state: AppState) -> ReduceResult:
+    selected_result = _selected_file_search_result(state)
+    if selected_result is None or not state.config.display.show_preview:
+        return done(replace(state, pending_child_pane_request_id=None))
+
+    if state.pending_child_pane_request_id is None and _matches_file_search_preview(
+        state,
+        selected_result,
+    ):
+        return done(state)
+
+    request_id = state.next_request_id
+    return done(
+        replace(
+            state,
+            pending_child_pane_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        LoadChildPaneSnapshotEffect(
+            request_id=request_id,
+            current_path=state.current_path,
+            cursor_path=selected_result.path,
+        ),
+    )
+
+
 def _matches_grep_preview(
     state: AppState,
     result: GrepSearchResultState,
@@ -1082,7 +1134,10 @@ def handle_palette_action(
 
     if isinstance(action, CancelCommandPalette):
         next_state = _restore_browsing_from_palette(state, clear_name_conflict=True)
-        if state.command_palette is not None and state.command_palette.source == "grep_search":
+        if state.command_palette is not None and state.command_palette.source in {
+            "file_search",
+            "grep_search",
+        }:
             return sync_child_pane(next_state, next_state.current_pane.cursor_path, reduce_state)
         return done(next_state)
 

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -158,9 +158,9 @@ def _select_child_pane_for_cursor(
     cursor_entry: DirectoryEntryState | None,
 ) -> ChildPaneViewState:
     syntax_theme = _select_child_syntax_theme(state.config.display.theme)
-    grep_preview = _select_grep_preview_pane(state, syntax_theme)
-    if grep_preview is not None:
-        return grep_preview
+    palette_preview = _select_command_palette_preview_pane(state, syntax_theme)
+    if palette_preview is not None:
+        return palette_preview
 
     if cursor_entry is None:
         return _build_child_entries_view((), syntax_theme)
@@ -216,17 +216,58 @@ def _select_child_pane_for_cursor(
     )
 
 
-def _select_grep_preview_pane(
+def _select_command_palette_preview_pane(
     state: AppState,
     syntax_theme: str,
 ) -> ChildPaneViewState | None:
-    if (
-        state.ui_mode != "PALETTE"
-        or state.command_palette is None
-        or state.command_palette.source != "grep_search"
-    ):
+    if state.ui_mode != "PALETTE" or state.command_palette is None:
         return None
+    if state.command_palette.source == "file_search":
+        return _select_file_search_preview_pane(state, syntax_theme)
+    if state.command_palette.source == "grep_search":
+        return _select_grep_preview_pane(state, syntax_theme)
+    return None
 
+
+def _select_file_search_preview_pane(
+    state: AppState,
+    syntax_theme: str,
+) -> ChildPaneViewState:
+    if not state.config.display.show_preview:
+        return _build_child_entries_view((), syntax_theme)
+
+    results = state.command_palette.file_search_results
+    if not results:
+        return _build_child_entries_view((), syntax_theme)
+
+    selected_result = results[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    if (
+        state.child_pane.mode != "preview"
+        or state.child_pane.preview_path != selected_result.path
+        or state.child_pane.preview_title is not None
+        or state.child_pane.preview_start_line is not None
+        or state.child_pane.preview_highlight_line is not None
+    ):
+        return _build_child_entries_view((), syntax_theme)
+
+    return _build_child_preview_view(
+        state.child_pane.preview_title,
+        state.child_pane.preview_path or selected_result.path,
+        state.child_pane.preview_content,
+        state.child_pane.preview_message,
+        state.child_pane.preview_truncated,
+        state.child_pane.preview_start_line,
+        state.child_pane.preview_highlight_line,
+        syntax_theme,
+    )
+
+
+def _select_grep_preview_pane(
+    state: AppState,
+    syntax_theme: str,
+) -> ChildPaneViewState:
     if not state.config.display.show_preview:
         return _build_child_entries_view((), syntax_theme)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2694,6 +2694,102 @@ async def test_app_command_palette_find_file_jumps_to_matching_parent_directory(
 
 
 @pytest.mark.asyncio
+async def test_app_file_search_renders_preview_within_current_pane(tmp_path) -> None:
+    path = str(tmp_path)
+    notes = tmp_path / "notes.txt"
+    notes.write_text("alpha\nbeta\nTODO: update docs\ndelta\n", encoding="utf-8")
+    file_search_service = FakeFileSearchService(
+        results_by_query={
+            (path, "note", False): (
+                FileSearchResultState(
+                    path=str(notes),
+                    display_path="notes.txt",
+                ),
+            )
+        }
+    )
+    app = create_app(
+        file_search_service=file_search_service,
+        initial_path=path,
+    )
+
+    async with app.run_test(size=(240, 40)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("f")
+        await pilot.press("n", "o", "t", "e")
+        await _wait_for_request_count(file_search_service, 1)
+        await _wait_for_child_preview(app, "Preview: notes.txt", "TODO: update docs")
+
+        command_palette = app.query_one("#command-palette")
+        child_pane = app.query_one("#child-pane")
+
+        assert command_palette.region.x + command_palette.region.width <= child_pane.region.x
+
+
+@pytest.mark.asyncio
+async def test_app_file_search_cancel_restores_child_pane_snapshot() -> None:
+    path = "/tmp/peneo-file-search-preview-cancel"
+    docs_path = f"{path}/docs"
+    notes_path = f"{path}/notes.txt"
+    child_entries = (
+        DirectoryEntryState(f"{docs_path}/README.md", "README.md", "file"),
+        DirectoryEntryState(f"{docs_path}/guide.md", "guide.md", "file"),
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (
+                    DirectoryEntryState(docs_path, "docs", "dir"),
+                    DirectoryEntryState(notes_path, "notes.txt", "file"),
+                ),
+                child_path=docs_path,
+                child_entries=child_entries,
+            ),
+        },
+        child_panes={
+            (path, docs_path): PaneState(directory_path=docs_path, entries=child_entries),
+            (
+                path,
+                notes_path,
+            ): PaneState(
+                directory_path=path,
+                entries=(),
+                mode="preview",
+                preview_path=notes_path,
+                preview_content="alpha\nbeta\n",
+            ),
+        },
+    )
+    file_search_service = FakeFileSearchService(
+        results_by_query={
+            (path, "note", False): (
+                FileSearchResultState(
+                    path=notes_path,
+                    display_path="notes.txt",
+                ),
+            )
+        }
+    )
+    app = create_app(
+        snapshot_loader=loader,
+        file_search_service=file_search_service,
+        initial_path=path,
+    )
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_child_entries(app, ["guide.md", "README.md"])
+        await pilot.press("f")
+        await pilot.press("n", "o", "t", "e")
+        await _wait_for_request_count(file_search_service, 1)
+        await _wait_for_child_preview(app, "Preview: notes.txt", "alpha")
+
+        await pilot.press("escape")
+        await _wait_for_child_entries(app, ["guide.md", "README.md"])
+
+
+@pytest.mark.asyncio
 async def test_app_file_search_debounces_rapid_query_updates(tmp_path) -> None:
     path = str(tmp_path)
     (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -2413,8 +2413,15 @@ def test_set_command_palette_query_reuses_completed_file_search_results_for_pref
 
     result = reduce_app_state(state, SetCommandPaletteQuery("readm"))
 
-    assert result.effects == ()
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=5,
+            current_path="/home/tadashi/develop/peneo",
+            cursor_path="/home/tadashi/develop/peneo/README.md",
+        ),
+    )
     assert result.state.pending_file_search_request_id is None
+    assert result.state.pending_child_pane_request_id == 5
     assert result.state.command_palette is not None
     assert result.state.command_palette.file_search_results == (
         FileSearchResultState(
@@ -2422,7 +2429,7 @@ def test_set_command_palette_query_reuses_completed_file_search_results_for_pref
             display_path="README.md",
         ),
     )
-    assert result.state.next_request_id == 5
+    assert result.state.next_request_id == 6
 
 
 def test_set_command_palette_query_runs_new_search_when_query_is_not_prefix_extension() -> None:


### PR DESCRIPTION
## Summary
- add child-pane preview syncing for `find files` results in the command palette
- render file-search preview in the same right pane used by grep and normal file preview
- add app and reducer coverage for preview rendering and cancel/restore behavior

## Testing
- `uv run pytest tests/test_app.py -k "file_search or grep_search"`
- `uv run pytest tests/test_services_browser_snapshot.py`
- `uv run pytest tests/test_state_reducer.py -k "prefix_extension or file_search"`
- `uv run pytest`
- `uv run ruff check .`

Closes #437
