### PR TITLE
Fix #442: restore peneo-cd support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -266,6 +266,21 @@ brew install ripgrep
 peneo
 ```
 
+`peneo` 単体では親シェルのカレントディレクトリを変更できません。終了時に最後に見ていたディレクトリへ親シェルも追従させたい場合は、先に shell integration を読み込みます。
+
+```bash
+eval "$(peneo init bash)"  # bash 用
+eval "$(peneo init zsh)"   # zsh 用
+```
+
+これにより `peneo-cd` というシェル関数が定義されます。終了後に親シェルを最後のディレクトリへ `cd` させたいときは、`peneo` ではなく `peneo-cd` で起動します。
+
+```bash
+peneo-cd
+```
+
+ディレクトリ追従が不要な場合は、従来どおり `peneo` を使ってください。
+
 ファイルにカーソルを合わせた状態で `e` を押すと、現在のターミナル上でターミナルエディタへ切り替えられます。`config.toml` の `editor.command` が設定されていればそれを優先し、未設定なら `$EDITOR`、さらに `nvim`、`vim`、`nano` などの組み込み候補へフォールバックします。
 
 ## 設定ファイル

--- a/README.md
+++ b/README.md
@@ -260,6 +260,21 @@ To update, pull the latest changes and run the same install command again.
 peneo
 ```
 
+`peneo` itself cannot change the current directory of the parent shell. If you want your shell to follow the last directory you visited after quitting Peneo, add shell integration first:
+
+```bash
+eval "$(peneo init bash)"  # for bash
+eval "$(peneo init zsh)"   # for zsh
+```
+
+This defines a shell function named `peneo-cd`. Start Peneo with `peneo-cd` when you want the parent shell to `cd` into the last directory on exit:
+
+```bash
+peneo-cd
+```
+
+Use plain `peneo` when you only want to browse without changing the shell's working directory.
+
 When a file is focused, press `e` to switch into a terminal editor in the current terminal session. Peneo prefers `config.toml` `editor.command` when set, then falls back to `$EDITOR`, then built-in defaults such as `nvim`, `vim`, or `nano`.
 When a supported text file is focused, the right pane also shows a non-wrapping syntax-highlighted preview of the beginning of the file. Supported targets include common source, config, markup, and log file extensions as well as extensionless text files such as `Dockerfile` or `.env`. You can disable this behavior with `display.show_preview`.
 

--- a/src/peneo/__main__.py
+++ b/src/peneo/__main__.py
@@ -6,10 +6,20 @@ import argparse
 import logging
 import sys
 from collections.abc import Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import IO, Iterator
 
 from .app import create_app
 from .services import configure_file_logging, load_app_config
 from .state import NotificationState
+
+
+@dataclass(frozen=True)
+class _StandardStreams:
+    stdin: IO[str]
+    stdout: IO[str]
+    stderr: IO[str]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -67,12 +77,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     logger = _app_logger()
     try:
-        app = create_app(
-            app_config=config_result.config,
-            config_path=config_result.path,
-            startup_notification=startup_notification,
-        )
-        app.run(mouse=False)
+        with _shell_integration_stdio(args.print_last_dir):
+            app = create_app(
+                app_config=config_result.config,
+                config_path=config_result.path,
+                startup_notification=startup_notification,
+            )
+            app.run(mouse=False)
     except Exception:
         logger.exception("Peneo crashed during startup or runtime")
         raise
@@ -98,6 +109,61 @@ def _startup_notification(
 
 def _app_logger() -> logging.Logger:
     return logging.getLogger("peneo")
+
+
+def _capture_standard_streams() -> _StandardStreams:
+    return _StandardStreams(
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+
+def _install_standard_streams(streams: _StandardStreams) -> None:
+    sys.stdin = streams.stdin
+    sys.stdout = streams.stdout
+    sys.stderr = streams.stderr
+    sys.__stdin__ = streams.stdin
+    sys.__stdout__ = streams.stdout
+    sys.__stderr__ = streams.stderr
+
+
+def _should_use_tty_streams(print_last_dir: bool) -> bool:
+    return print_last_dir and not sys.stdout.isatty() and sys.stderr.isatty()
+
+
+def _open_tty_streams() -> _StandardStreams:
+    return _StandardStreams(
+        stdin=open("/dev/tty", encoding="utf-8"),
+        stdout=open("/dev/tty", "w", encoding="utf-8", buffering=1),
+        stderr=open("/dev/tty", "w", encoding="utf-8", buffering=1),
+    )
+
+
+def _close_standard_streams(streams: _StandardStreams) -> None:
+    for stream in (streams.stdin, streams.stdout, streams.stderr):
+        stream.close()
+
+
+@contextmanager
+def _shell_integration_stdio(print_last_dir: bool) -> Iterator[None]:
+    if not _should_use_tty_streams(print_last_dir):
+        yield
+        return
+
+    try:
+        tty_streams = _open_tty_streams()
+    except OSError:
+        yield
+        return
+
+    original_streams = _capture_standard_streams()
+    try:
+        _install_standard_streams(tty_streams)
+        yield
+    finally:
+        _install_standard_streams(original_streams)
+        _close_standard_streams(tty_streams)
 
 
 if __name__ == "__main__":

--- a/src/peneo/adapters/external_launcher.py
+++ b/src/peneo/adapters/external_launcher.py
@@ -5,6 +5,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -426,6 +427,9 @@ def _run_foreground_command(command: Sequence[str], cwd: str | None) -> None:
             list(command),
             cwd=cwd,
             check=True,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
         )
     except subprocess.CalledProcessError as error:
         raise OSError(str(error) or f"{command[0]} failed") from error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import io
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -22,6 +24,15 @@ class DummyApp:
 
     def run(self, *, mouse: bool = True) -> None:
         self.run_calls += 1
+
+
+class DummyTextStream(io.StringIO):
+    def __init__(self, *, isatty: bool) -> None:
+        super().__init__()
+        self._isatty = isatty
+
+    def isatty(self) -> bool:
+        return self._isatty
 
 
 def test_render_shell_init_outputs_peneo_cd_function() -> None:
@@ -64,6 +75,100 @@ def test_main_print_last_dir_falls_back_to_current_path(capsys, monkeypatch) -> 
     assert return_code == 0
     assert app.run_calls == 1
     assert capsys.readouterr().out == "/tmp/peneo-fallback\n"
+
+
+def test_shell_integration_stdio_redirects_standard_streams_to_tty(monkeypatch) -> None:
+    original_stdin = DummyTextStream(isatty=True)
+    original_stdout = DummyTextStream(isatty=False)
+    original_stderr = DummyTextStream(isatty=True)
+    tty_stdin = DummyTextStream(isatty=True)
+    tty_stdout = DummyTextStream(isatty=True)
+    tty_stderr = DummyTextStream(isatty=True)
+
+    monkeypatch.setattr(sys, "stdin", original_stdin)
+    monkeypatch.setattr(sys, "stdout", original_stdout)
+    monkeypatch.setattr(sys, "stderr", original_stderr)
+    monkeypatch.setattr(sys, "__stdin__", original_stdin, raising=False)
+    monkeypatch.setattr(sys, "__stdout__", original_stdout, raising=False)
+    monkeypatch.setattr(sys, "__stderr__", original_stderr, raising=False)
+    monkeypatch.setattr(
+        cli,
+        "_open_tty_streams",
+        lambda: cli._StandardStreams(
+            stdin=tty_stdin,
+            stdout=tty_stdout,
+            stderr=tty_stderr,
+        ),
+    )
+
+    with cli._shell_integration_stdio(True):
+        assert sys.stdin is tty_stdin
+        assert sys.stdout is tty_stdout
+        assert sys.stderr is tty_stderr
+        assert sys.__stdin__ is tty_stdin
+        assert sys.__stdout__ is tty_stdout
+        assert sys.__stderr__ is tty_stderr
+
+    assert sys.stdin is original_stdin
+    assert sys.stdout is original_stdout
+    assert sys.stderr is original_stderr
+    assert tty_stdin.closed is True
+    assert tty_stdout.closed is True
+    assert tty_stderr.closed is True
+
+
+def test_main_print_last_dir_runs_app_with_tty_streams_when_stdout_is_captured(
+    monkeypatch,
+) -> None:
+    original_stdin = DummyTextStream(isatty=True)
+    original_stdout = DummyTextStream(isatty=False)
+    original_stderr = DummyTextStream(isatty=True)
+    tty_stdin = DummyTextStream(isatty=True)
+    tty_stdout = DummyTextStream(isatty=True)
+    tty_stderr = DummyTextStream(isatty=True)
+    app = DummyApp(return_value="/tmp/peneo-last-dir")
+
+    def run_with_tty_streams(*, mouse: bool = True) -> None:
+        app.run_calls += 1
+        assert mouse is False
+        assert sys.stdin is tty_stdin
+        assert sys.stdout is tty_stdout
+        assert sys.stderr is tty_stderr
+        assert sys.__stdout__ is tty_stdout
+        assert sys.__stderr__ is tty_stderr
+
+    app.run = run_with_tty_streams  # type: ignore[method-assign]
+
+    monkeypatch.setattr(sys, "stdin", original_stdin)
+    monkeypatch.setattr(sys, "stdout", original_stdout)
+    monkeypatch.setattr(sys, "stderr", original_stderr)
+    monkeypatch.setattr(sys, "__stdin__", original_stdin, raising=False)
+    monkeypatch.setattr(sys, "__stdout__", original_stdout, raising=False)
+    monkeypatch.setattr(sys, "__stderr__", original_stderr, raising=False)
+    monkeypatch.setattr(cli, "load_app_config", lambda: ConfigLoadResult(config=AppConfig()))
+    monkeypatch.setattr(
+        cli,
+        "configure_file_logging",
+        lambda **_kwargs: LoggingSetupResult(enabled=True, path="/tmp/peneo.log"),
+    )
+    monkeypatch.setattr(cli, "create_app", lambda **_kwargs: app)
+    monkeypatch.setattr(
+        cli,
+        "_open_tty_streams",
+        lambda: cli._StandardStreams(
+            stdin=tty_stdin,
+            stdout=tty_stdout,
+            stderr=tty_stderr,
+        ),
+    )
+
+    return_code = cli.main(["--print-last-dir"])
+
+    assert return_code == 0
+    assert app.run_calls == 1
+    assert original_stdout.getvalue() == "/tmp/peneo-last-dir\n"
+    assert sys.stdout is original_stdout
+    assert tty_stdout.closed is True
 
 
 def test_main_passes_loaded_config_and_warnings_to_create_app(monkeypatch) -> None:

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -1,8 +1,12 @@
+import io
+import sys
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 
 import pytest
 
 from peneo.adapters import LocalExternalLaunchAdapter
+from peneo.adapters.external_launcher import _run_foreground_command
 from peneo.models import EditorConfig, ExternalLaunchRequest, TerminalConfig
 from peneo.services import LiveExternalLaunchService
 
@@ -592,6 +596,34 @@ def test_live_external_launch_service_opens_editor_with_line_number(tmp_path) ->
     assert runner.executed == [
         (("vim", "+42", str(readme.resolve())), str(tmp_path.resolve()))
     ]
+
+
+def test_run_foreground_command_uses_current_standard_streams(monkeypatch) -> None:
+    stdin = io.StringIO()
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    captured: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr("peneo.adapters.external_launcher.subprocess.run", fake_run)
+
+    _run_foreground_command(("nvim", "README.md"), "/tmp/project")
+
+    assert captured["args"] == (["nvim", "README.md"],)
+    assert captured["kwargs"] == {
+        "cwd": "/tmp/project",
+        "check": True,
+        "stdin": stdin,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
 
 
 def runner_not_expected(


### PR DESCRIPTION
## Summary
- restore documented `peneo-cd` shell integration support
- run the app with tty-backed stdio when `--print-last-dir` is captured
- add CLI regression coverage for shell integration stream handling

## Testing
- uv run pytest
- uv run ruff check .