### PR TITLE
Align file browser colors with GNU coreutils (#446)

### DIFF
--- a/src/peneo/adapters/filesystem.py
+++ b/src/peneo/adapters/filesystem.py
@@ -57,10 +57,18 @@ class LocalFilesystemAdapter:
 
 
 def _build_directory_entry(entry: os.DirEntry[str]) -> DirectoryEntryState | None:
+    is_symlink = entry.is_symlink()
     try:
         stat_result = entry.stat()
     except FileNotFoundError:
-        # Skip broken symlinks or entries removed during iteration.
+        if is_symlink:
+            return DirectoryEntryState(
+                path=entry.path,
+                name=entry.name,
+                kind="file",
+                hidden=entry.name.startswith("."),
+                symlink=True,
+            )
         return None
     kind = "dir" if entry.is_dir() else "file"
     return DirectoryEntryState(
@@ -71,6 +79,7 @@ def _build_directory_entry(entry: os.DirEntry[str]) -> DirectoryEntryState | Non
         modified_at=datetime.fromtimestamp(stat_result.st_mtime),
         hidden=entry.name.startswith("."),
         permissions_mode=stat_result.st_mode,
+        symlink=is_symlink,
     )
 
 

--- a/src/peneo/models/shell_data.py
+++ b/src/peneo/models/shell_data.py
@@ -19,12 +19,15 @@ class PaneEntry:
     selected: bool = False
     cut: bool = False
     executable: bool = False
+    symlink: bool = False
     path: str = ""
 
     @property
     def kind_label(self) -> str:
         """Return the short label shown in the center table."""
 
+        if self.symlink:
+            return "LINK"
         return "DIR" if self.kind == "dir" else "FILE"
 
     @property

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -71,6 +71,7 @@ class DirectoryEntryState:
     modified_at: datetime | None = None
     hidden: bool = False
     permissions_mode: int | None = None
+    symlink: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -1323,6 +1323,7 @@ def _to_pane_entry(
         selected=selected,
         cut=cut,
         executable=_has_execute_permission(entry),
+        symlink=entry.symlink,
         path=entry.path,
     )
 

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -101,12 +101,15 @@ class SidePane(Vertical):
     """Lightweight pane used for parent and child directory listings."""
 
     CUT_STYLE = "bright_black dim"
-    EXECUTABLE_STYLE = "cyan"
-    EXECUTABLE_SELECTED_STYLE = "bold cyan"
-    EXECUTABLE_CUT_STYLE = "cyan dim"
-    DIRECTORY_STYLE = "blue"
-    DIRECTORY_SELECTED_STYLE = "bold white on blue"
-    DIRECTORY_CUT_STYLE = "blue dim"
+    EXECUTABLE_STYLE = "bold #55FF55"
+    EXECUTABLE_SELECTED_STYLE = "bold #55FF55"
+    EXECUTABLE_CUT_STYLE = "bold #55FF55 dim"
+    DIRECTORY_STYLE = "bold #5555FF"
+    DIRECTORY_SELECTED_STYLE = "bold white on #5555FF"
+    DIRECTORY_CUT_STYLE = "bold #5555FF dim"
+    SYMLINK_STYLE = "bold #55FFFF"
+    SYMLINK_SELECTED_STYLE = "bold #55FFFF"
+    SYMLINK_CUT_STYLE = "bold #55FFFF dim"
     ENTRY_HORIZONTAL_PADDING = 2
 
     def __init__(
@@ -183,11 +186,19 @@ class SidePane(Vertical):
 
         # カット状態が最優先
         if entry.cut:
+            if entry.symlink:
+                return Text(label, style=cls.SYMLINK_CUT_STYLE)
             if entry.kind == "dir":
                 return Text(label, style=cls.DIRECTORY_CUT_STYLE)
             if entry.executable:
                 return Text(label, style=cls.EXECUTABLE_CUT_STYLE)
             return Text(label, style=cls.CUT_STYLE)
+
+        # シンボリックリンク
+        if entry.symlink:
+            if entry.selected:
+                return Text(label, style=cls.SYMLINK_SELECTED_STYLE)
+            return Text(label, style=cls.SYMLINK_STYLE)
 
         # ディレクトリ（実行権限に関わらずディレクトリ色を優先）
         if entry.kind == "dir":
@@ -203,7 +214,7 @@ class SidePane(Vertical):
 
         # 選択状態
         if entry.selected:
-            return Text(label, style="bold green")
+            return Text(label, style="bold #55FF55")
 
         return Text(label)
 
@@ -327,15 +338,18 @@ class MainPane(Vertical):
 
     COLUMN_LABELS = ("Sel", "Name", "Size", "Modified")
     COLUMN_KEYS = ("sel", "name", "size", "modified")
-    SELECTED_STYLE = "bold green"
+    SELECTED_STYLE = "bold #55FF55"
     CUT_STYLE = "bright_black dim"
     SELECTED_CUT_STYLE = "bold bright_black"
-    EXECUTABLE_STYLE = "cyan"
-    EXECUTABLE_SELECTED_STYLE = "bold cyan"
-    EXECUTABLE_CUT_STYLE = "cyan dim"
-    DIRECTORY_STYLE = "blue"
-    DIRECTORY_SELECTED_STYLE = "bold blue"
-    DIRECTORY_CUT_STYLE = "blue dim"
+    EXECUTABLE_STYLE = "bold #55FF55"
+    EXECUTABLE_SELECTED_STYLE = "bold #55FF55"
+    EXECUTABLE_CUT_STYLE = "bold #55FF55 dim"
+    DIRECTORY_STYLE = "bold #5555FF"
+    DIRECTORY_SELECTED_STYLE = "bold #5555FF"
+    DIRECTORY_CUT_STYLE = "bold #5555FF dim"
+    SYMLINK_STYLE = "bold #55FFFF"
+    SYMLINK_SELECTED_STYLE = "bold #55FFFF"
+    SYMLINK_CUT_STYLE = "bold #55FFFF dim"
     NAME_MIN_WIDTH = 3
     FIXED_COLUMN_PREFERRED_WIDTHS = {
         "sel": 1,
@@ -503,6 +517,7 @@ class MainPane(Vertical):
                         entry.cut,
                         entry.executable,
                         entry.kind,
+                        entry.symlink,
                     ),
                 )
             except KeyError:
@@ -641,6 +656,7 @@ class MainPane(Vertical):
                 entry.cut,
                 entry.executable,
                 entry.kind,
+                entry.symlink,
             ),
             cls._render_cell(
                 truncate_middle(build_entry_label(entry), column_widths["name"]),
@@ -648,6 +664,7 @@ class MainPane(Vertical):
                 entry.cut,
                 entry.executable,
                 entry.kind,
+                entry.symlink,
             ),
             cls._render_cell(
                 entry.size_label,
@@ -655,6 +672,7 @@ class MainPane(Vertical):
                 entry.cut,
                 entry.executable,
                 entry.kind,
+                entry.symlink,
             ),
             cls._render_cell(
                 entry.modified_label,
@@ -662,6 +680,7 @@ class MainPane(Vertical):
                 entry.cut,
                 entry.executable,
                 entry.kind,
+                entry.symlink,
             ),
         )
 
@@ -703,9 +722,12 @@ class MainPane(Vertical):
         cut: bool,
         executable: bool = False,
         kind: str | None = None,
+        symlink: bool = False,
     ) -> Text:
         # カット状態が最優先
         if cut:
+            if symlink:
+                return Text(value, style=cls.SYMLINK_CUT_STYLE)
             if kind == "dir":
                 return Text(value, style=cls.DIRECTORY_CUT_STYLE)
             if executable:
@@ -713,6 +735,12 @@ class MainPane(Vertical):
             if selected:
                 return Text(value, style=cls.SELECTED_CUT_STYLE)
             return Text(value, style=cls.CUT_STYLE)
+
+        # シンボリックリンク
+        if symlink:
+            if selected:
+                return Text(value, style=cls.SYMLINK_SELECTED_STYLE)
+            return Text(value, style=cls.SYMLINK_STYLE)
 
         # ディレクトリ（実行権限に関わらずディレクトリ色を優先）
         if kind == "dir":

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -33,7 +33,7 @@ def test_local_filesystem_adapter_lists_entries_with_metadata(tmp_path) -> None:
     assert readme_entry.permissions_mode is not None
 
 
-def test_local_filesystem_adapter_skips_broken_symlink_entries(tmp_path) -> None:
+def test_local_filesystem_adapter_includes_broken_symlink_entries(tmp_path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
     broken = tmp_path / "broken-link"
@@ -43,7 +43,8 @@ def test_local_filesystem_adapter_skips_broken_symlink_entries(tmp_path) -> None
 
     entries = adapter.list_directory(str(tmp_path))
 
-    assert [entry.name for entry in entries] == ["docs"]
+    assert [entry.name for entry in entries] == ["docs", "broken-link"]
+    assert entries[1].symlink is True
 
 
 def test_local_filesystem_adapter_treats_directory_symlink_as_dir(tmp_path) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -822,7 +822,7 @@ async def test_app_live_snapshot_highlights_current_directory_in_parent_pane(tmp
         assert app.app_state.parent_pane.cursor_path == str(tmp_path)
         assert isinstance(parent_renderable, Text)
         assert tmp_path.name in parent_renderable.plain.splitlines()
-        assert any(span.style == "bold white on blue" for span in parent_renderable.spans)
+        assert any(span.style == "bold white on #5555FF" for span in parent_renderable.spans)
 
 
 @pytest.mark.asyncio
@@ -870,7 +870,7 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
         assert parent_entries == ["peneo-app", "sibling"]
         parent_renderable = parent_list.renderable
         assert isinstance(parent_renderable, Text)
-        assert any(span.style == "bold white on blue" for span in parent_renderable.spans)
+        assert any(span.style == "bold white on #5555FF" for span in parent_renderable.spans)
         assert headers == ["Sel", "Name", "Size", "Modified"]
         assert current_table.row_count == 2
         assert child_entries == ["spec.md"]
@@ -1306,7 +1306,7 @@ async def test_app_keyboard_input_updates_selection_and_child_pane() -> None:
 
         assert isinstance(first_row[0], Text)
         assert first_row[0].plain == "*"
-        assert first_row[0].style == "bold blue"
+        assert first_row[0].style == "bold #5555FF"
         assert first_row[1].plain == "docs"
         await _wait_for_child_pane_runtime_idle(app, timeout=1.0)
 
@@ -1479,7 +1479,7 @@ async def test_app_cut_marks_row_with_dimmed_style() -> None:
         assert app.app_state.clipboard.paths == (f"{path}/docs",)
         assert isinstance(first_row[1], Text)
         assert first_row[1].plain == "docs"
-        assert first_row[1].style == "blue dim"
+        assert first_row[1].style == "bold #5555FF dim"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -51,4 +51,4 @@ def test_side_pane_selected_directory_uses_background_highlight() -> None:
 
     rendered = SidePane._render_label(entry)
 
-    assert rendered.style == "bold white on blue"
+    assert rendered.style == "bold white on #5555FF"

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "peneo"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },


### PR DESCRIPTION
## Summary
- ディレクトリ・実行ファイル・シンボリックリンクの配色を GNU coreutils (`ls --color`) 標準に合わせる
- Textual の MONOKAI テーマが ANSI blue を紫に変換する問題を、hex カラー直接指定で回避
- シンボリックリンクの検出と bold cyan 表示を追加（壊れたシンボリックリンクも表示）

## 変更内容
| 要素 | 旧カラー | 新カラー (coreutils 準拠) |
|---|---|---|
| ディレクトリ | `blue` (紫に変換) | `#5555FF` (標準blue) |
| 実行ファイル | `cyan` | `#55FF55` (標準green) |
| シンボリックリンク | (未対応) | `#55FFFF` (標準cyan) |
| 通常ファイル選択 | `green` (黄緑に変換) | `#55FF55` |

## Test plan
- [x] `uv run pytest` — 761 tests passed
- [x] `uv run ruff check .` — All checks passed
- [ ] アプリを起動しディレクトリが青、実行ファイルが緑、シンボリックリンクがシアンに表示されることを目視確認

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)