### PR TITLE
Fix #456: Keep search results visible in palette

### DIFF
--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -578,11 +578,13 @@ def _dispatch_command_palette_input(
         return _supported(MoveCommandPaletteCursor(delta=-1))
 
     if key == "pageup":
-        visible = compute_search_visible_window(state.terminal_height)
+        extra_rows = 2 if palette_source == "grep_search" else 0
+        visible = compute_search_visible_window(state.terminal_height, extra_rows=extra_rows)
         return _supported(MoveCommandPaletteCursor(delta=-visible))
 
     if key == "pagedown":
-        visible = compute_search_visible_window(state.terminal_height)
+        extra_rows = 2 if palette_source == "grep_search" else 0
+        visible = compute_search_visible_window(state.terminal_height, extra_rows=extra_rows)
         return _supported(MoveCommandPaletteCursor(delta=visible))
 
     if key == "home":

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -46,7 +46,8 @@ from .models import (
 SIDE_PANE_SORT = SortState(field="name", descending=False, directories_first=True)
 COMMAND_PALETTE_VISIBLE_WINDOW = 8
 MIN_SEARCH_VISIBLE_WINDOW = 3
-_SEARCH_OVERHEAD_ROWS = 8
+_SEARCH_OVERHEAD_ROWS = 9
+_GREP_SEARCH_EXTRA_INPUT_ROWS = 2
 MIN_CURRENT_PANE_VISIBLE_WINDOW = 5
 _CURRENT_PANE_OVERHEAD_ROWS = 8
 
@@ -1267,10 +1268,13 @@ def _format_sort_label(sort: SortState) -> str:
     return f"{sort.field} {direction} dirs:{directories}"
 
 
-def compute_search_visible_window(terminal_height: int) -> int:
+def compute_search_visible_window(terminal_height: int, *, extra_rows: int = 0) -> int:
     """Calculate visible command-palette items based on terminal height."""
 
-    return max(MIN_SEARCH_VISIBLE_WINDOW, terminal_height - _SEARCH_OVERHEAD_ROWS)
+    return max(
+        MIN_SEARCH_VISIBLE_WINDOW,
+        terminal_height - _SEARCH_OVERHEAD_ROWS - extra_rows,
+    )
 
 
 def _build_command_palette_items_view(
@@ -1342,7 +1346,10 @@ def _select_grep_search_window(
     results: tuple[GrepSearchResultState, ...],
     cursor_index: int,
 ) -> tuple[tuple[tuple[int, GrepSearchResultState], ...], str]:
-    visible_window = compute_search_visible_window(state.terminal_height)
+    visible_window = compute_search_visible_window(
+        state.terminal_height,
+        extra_rows=_GREP_SEARCH_EXTRA_INPUT_ROWS,
+    )
     return _select_search_window(
         results, cursor_index, title="Grep", visible_window=visible_window,
     )

--- a/src/peneo/ui/command_palette.py
+++ b/src/peneo/ui/command_palette.py
@@ -1,5 +1,6 @@
 """Command palette widget."""
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual.containers import Container
 from textual.widgets import Static
@@ -10,6 +11,8 @@ from peneo.ui.panes import truncate_middle
 
 class CommandPalette(Container):
     """Compact command palette shown above the help and status bars."""
+
+    _DEFAULT_RENDER_WIDTH = 120
 
     def __init__(
         self,
@@ -47,14 +50,23 @@ class CommandPalette(Container):
 
         self.set_class(state.has_more_items, "-expanded")
         title_widget.update(state.title)
+        query_width = self._resolve_render_width(query_widget)
+        items_width = self._resolve_render_width(items_widget)
         if state.input_fields:
-            query_widget.update(self._render_input_fields(state.input_fields))
+            query_widget.update(self._render_input_fields(state.input_fields, query_width))
         else:
-            query_widget.update(self._render_query_line(state))
-        items_widget.update(self._render_items(state))
+            query_widget.update(self._render_query_line(state, query_width))
+        items_widget.update(self._render_items(state, items_width))
 
     @staticmethod
-    def _render_query_line(state: CommandPaletteViewState) -> Text:
+    def _resolve_render_width(widget: Static) -> int:
+        for width in (widget.content_region.width, widget.size.width, widget.region.width):
+            if width > 0:
+                return width
+        return CommandPalette._DEFAULT_RENDER_WIDTH
+
+    @classmethod
+    def _render_query_line(cls, state: CommandPaletteViewState, render_width: int) -> Text:
         query_text = Text()
         query_text.append("> ", style="bold")
         placeholder = (
@@ -66,37 +78,44 @@ class CommandPalette(Container):
             if state.title.startswith("Directory History") or state.title.startswith("Go to path")
             else "type a command"
         )
-        query_text.append(state.query or placeholder, style="bold" if state.query else "dim")
+        available_width = max(1, render_width - cell_len("> "))
+        value = truncate_middle(state.query or placeholder, available_width)
+        query_text.no_wrap = True
+        query_text.overflow = "ellipsis"
+        query_text.append(value, style="bold" if state.query else "dim")
         return query_text
 
-    @staticmethod
+    @classmethod
     def _render_input_fields(
+        cls,
         fields: tuple[CommandPaletteInputFieldViewState, ...],
+        render_width: int,
     ) -> Text:
-        rendered = Text()
+        rendered = Text(no_wrap=True, overflow="ellipsis")
         for index, field in enumerate(fields):
             label_style = "reverse bold" if field.active else "bold"
             value_style = "bold" if field.active and field.value else ""
             placeholder_style = "dim"
-            rendered.append(f"{field.label:>8}: ", style=label_style)
+            prefix = f"{field.label:>8}: "
+            rendered.append(prefix, style=label_style)
+            available_width = max(1, render_width - cell_len(prefix))
             if field.value:
-                rendered.append(field.value, style=value_style)
+                rendered.append(truncate_middle(field.value, available_width), style=value_style)
             else:
-                rendered.append(field.placeholder, style=placeholder_style)
+                rendered.append(
+                    truncate_middle(field.placeholder, available_width),
+                    style=placeholder_style,
+                )
             if index < len(fields) - 1:
                 rendered.append("\n")
         return rendered
 
-    @staticmethod
-    def _render_items(state: CommandPaletteViewState) -> Text:
+    @classmethod
+    def _render_items(cls, state: CommandPaletteViewState, render_width: int) -> Text:
         if not state.items:
-            return Text(state.empty_message, style="dim")
+            return Text(state.empty_message, style="dim", no_wrap=True, overflow="ellipsis")
 
-        # Maximum label width for grep/file search results to prevent line wrapping
-        # This ensures single-line display even for long results
-        max_label_width = 120
-
-        rendered = Text()
+        rendered = Text(no_wrap=True, overflow="ellipsis")
         for index, item in enumerate(state.items):
             line = Text()
             if item.selected and item.enabled:
@@ -108,19 +127,20 @@ class CommandPalette(Container):
             else:
                 style = ""
 
-            line.append("> " if item.selected else "  ", style=style)
-
-            # Truncate long labels to prevent wrapping
-            label = item.label
-            if len(label) > max_label_width:
-                label = truncate_middle(label, max_label_width)
-
+            prefix = "> " if item.selected else "  "
+            shortcut_suffix = f" [{item.shortcut}]" if item.shortcut else ""
+            line.append(prefix, style=style)
+            available_width = max(
+                1,
+                render_width - cell_len(prefix) - cell_len(shortcut_suffix),
+            )
+            label = truncate_middle(item.label, available_width)
             line.append(label, style=style)
             if item.shortcut:
                 shortcut_style = "dim"
                 if style:
                     shortcut_style = f"{style} dim"
-                line.append(f" [{item.shortcut}]", style=shortcut_style)
+                line.append(shortcut_suffix, style=shortcut_style)
             rendered.append_text(line)
             if index < len(state.items) - 1:
                 rendered.append("\n")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -50,7 +50,7 @@ from peneo.state import (
     PaneState,
     SetTerminalHeight,
 )
-from peneo.state.selectors import compute_current_pane_visible_window
+from peneo.state.selectors import compute_current_pane_visible_window, select_command_palette_state
 from peneo.ui import (
     AttributeDialog,
     CommandPalette,
@@ -2735,6 +2735,42 @@ async def test_app_file_search_renders_preview_within_current_pane(tmp_path) -> 
 
 
 @pytest.mark.asyncio
+async def test_app_file_search_long_results_stay_single_line_in_palette(tmp_path) -> None:
+    path = str(tmp_path)
+    (tmp_path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    file_search_service = FakeFileSearchService(
+        results_by_query={
+            (path, "deep", False): tuple(
+                FileSearchResultState(
+                    path=f"{path}/deeply/nested/location_{index}/README.md",
+                    display_path=(
+                        f"deeply/nested/location_{index}/"
+                        "subdirectory/with/an-excessively-long-file-name-that-should-not-wrap/"
+                        "README.md"
+                    ),
+                )
+                for index in range(18)
+            )
+        }
+    )
+    app = create_app(file_search_service=file_search_service, initial_path=path)
+
+    async with app.run_test(size=(72, 24)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("f")
+        await pilot.press("d", "e", "e", "p")
+        await _wait_for_request_count(file_search_service, 1)
+        await asyncio.sleep(0.05)
+
+        palette = await _wait_for_command_palette(app)
+        items = palette.query_one("#command-palette-items", Static)
+        palette_state = select_command_palette_state(app.app_state)
+
+        assert palette_state is not None
+        assert items.visual.get_height(items.region.width) == len(palette_state.items)
+
+
+@pytest.mark.asyncio
 async def test_app_file_search_cancel_restores_child_pane_snapshot() -> None:
     path = "/tmp/peneo-file-search-preview-cancel"
     docs_path = f"{path}/docs"
@@ -3059,6 +3095,46 @@ async def test_app_grep_search_renders_context_preview_within_current_pane(tmp_p
         child_pane = app.query_one("#child-pane")
 
         assert command_palette.region.x + command_palette.region.width <= child_pane.region.x
+
+
+@pytest.mark.asyncio
+async def test_app_grep_search_long_results_stay_single_line_in_palette(tmp_path) -> None:
+    path = str(tmp_path)
+    (tmp_path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    grep_search_service = FakeGrepSearchService(
+        results_by_query={
+            (path, "todo", (), (), False): tuple(
+                GrepSearchResultState(
+                    path=f"{path}/src/module_{index}.py",
+                    display_path=(
+                        f"src/features/search/module_{index}/"
+                        "very/deeply/nested/package/file_with_a_name_that_should_not_wrap.py"
+                    ),
+                    line_number=index + 1,
+                    line_text=(
+                        "TODO: keep this grep result on a single visual line even when the "
+                        "matched content is far longer than the available palette width"
+                    ),
+                )
+                for index in range(18)
+            )
+        }
+    )
+    app = create_app(grep_search_service=grep_search_service, initial_path=path)
+
+    async with app.run_test(size=(72, 24)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("g")
+        await pilot.press("t", "o", "d", "o")
+        await _wait_for_request_count(grep_search_service, 1)
+        await asyncio.sleep(0.05)
+
+        palette = await _wait_for_command_palette(app)
+        items = palette.query_one("#command-palette-items", Static)
+        palette_state = select_command_palette_state(app.app_state)
+
+        assert palette_state is not None
+        assert items.visual.get_height(items.region.width) == len(palette_state.items)
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2768,6 +2768,7 @@ async def test_app_file_search_long_results_stay_single_line_in_palette(tmp_path
 
         assert palette_state is not None
         assert items.visual.get_height(items.region.width) == len(palette_state.items)
+        assert items.visual.get_height(items.region.width) <= items.region.height
 
 
 @pytest.mark.asyncio
@@ -3135,6 +3136,7 @@ async def test_app_grep_search_long_results_stay_single_line_in_palette(tmp_path
 
         assert palette_state is not None
         assert items.visual.get_height(items.region.width) == len(palette_state.items)
+        assert items.visual.get_height(items.region.width) <= items.region.height
 
 
 @pytest.mark.asyncio

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -922,7 +922,7 @@ def test_palette_pageup_moves_cursor_by_page() -> None:
 
     actions = dispatch_key_input(state, key="pageup")
 
-    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-16))
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-15))
 
 
 def test_palette_pagedown_moves_cursor_by_page() -> None:
@@ -930,7 +930,31 @@ def test_palette_pagedown_moves_cursor_by_page() -> None:
 
     actions = dispatch_key_input(state, key="pagedown")
 
-    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=16))
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=15))
+
+
+def test_grep_palette_pageup_accounts_for_extra_input_rows() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="grep_search"),
+    )
+
+    actions = dispatch_key_input(state, key="pageup")
+
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-13))
+
+
+def test_grep_palette_pagedown_accounts_for_extra_input_rows() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="grep_search"),
+    )
+
+    actions = dispatch_key_input(state, key="pagedown")
+
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=13))
 
 
 def test_palette_unbound_key_shows_guidance() -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1807,9 +1807,8 @@ def test_select_command_palette_state_windows_large_file_search_results() -> Non
     palette_state = select_command_palette_state(state)
 
     assert palette_state is not None
-    assert palette_state.title == "Find File (3-18 / 20)"
+    assert palette_state.title == "Find File (4-18 / 20)"
     assert [item.label for item in palette_state.items] == [
-        "src/module_2.py",
         "src/module_3.py",
         "src/module_4.py",
         "src/module_5.py",
@@ -1826,7 +1825,7 @@ def test_select_command_palette_state_windows_large_file_search_results() -> Non
         "src/module_16.py",
         "src/module_17.py",
     ]
-    assert palette_state.items[8].selected is True
+    assert palette_state.items[7].selected is True
     assert palette_state.has_more_items is True
 
 
@@ -1855,6 +1854,36 @@ def test_select_command_palette_state_for_grep_search_results() -> None:
     assert [item.label for item in palette_state.items] == [
         "src/peneo/app.py:42: TODO: update palette"
     ]
+
+
+def test_select_command_palette_state_windows_large_grep_search_results() -> None:
+    results = tuple(
+        GrepSearchResultState(
+            path=f"/home/tadashi/develop/peneo/src/module_{index}.py",
+            display_path=f"src/module_{index}.py",
+            line_number=index + 1,
+            line_text="TODO: update palette",
+        )
+        for index in range(20)
+    )
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = replace(
+        state,
+        command_palette=CommandPaletteState(
+            source="grep_search",
+            query="todo",
+            cursor_index=10,
+            grep_search_results=results,
+        ),
+    )
+
+    palette_state = select_command_palette_state(state)
+
+    assert palette_state is not None
+    assert palette_state.title == "Grep (5-17 / 20)"
+    assert len(palette_state.items) == 13
+    assert palette_state.items[6].selected is True
+    assert palette_state.has_more_items is True
 
 
 def test_select_command_palette_state_shows_grep_searching_message() -> None:
@@ -2133,19 +2162,22 @@ class TestComputeSearchVisibleWindow:
     """Tests for dynamic search window size calculation."""
 
     def test_default_terminal_height(self) -> None:
-        assert selectors_module.compute_search_visible_window(24) == 16
+        assert selectors_module.compute_search_visible_window(24) == 15
 
     def test_large_terminal(self) -> None:
-        assert selectors_module.compute_search_visible_window(48) == 40
+        assert selectors_module.compute_search_visible_window(48) == 39
 
     def test_very_large_terminal(self) -> None:
-        assert selectors_module.compute_search_visible_window(80) == 72
+        assert selectors_module.compute_search_visible_window(80) == 71
 
     def test_small_terminal_uses_minimum(self) -> None:
         assert selectors_module.compute_search_visible_window(10) == 3
 
     def test_tiny_terminal_uses_minimum(self) -> None:
         assert selectors_module.compute_search_visible_window(1) == 3
+
+    def test_extra_rows_reduce_visible_window(self) -> None:
+        assert selectors_module.compute_search_visible_window(24, extra_rows=2) == 13
 
 
 class TestSelectSearchWindowWithDynamicSize:
@@ -2381,5 +2413,5 @@ class TestCommandPaletteDynamicWindow:
         palette_state = select_command_palette_state(state)
 
         assert palette_state is not None
-        assert len(palette_state.items) == 16
+        assert len(palette_state.items) == 15
         assert palette_state.has_more_items is True


### PR DESCRIPTION
## Summary
- keep command palette query and result rows to a single visual line based on the widget width
- truncate long search labels against the actual palette width so lower results stay visible
- add regression tests for long `find file` and `grep` results in a narrow palette

## Testing
- `uv run ruff check .`
- `uv run pytest`

Closes #456