### PR TITLE
refactor: Rename done() to finalize() in reducer_common (#471)

### DIFF
--- a/src/peneo/state/reducer.py
+++ b/src/peneo/state/reducer.py
@@ -13,7 +13,7 @@ from .actions import (
 )
 from .effects import ReduceResult
 from .models import AppState, sync_active_browser_tab
-from .reducer_common import done
+from .reducer_common import finalize
 from .reducer_mutations import handle_mutation_action
 from .reducer_navigation import handle_navigation_action
 from .reducer_palette import handle_palette_action
@@ -27,16 +27,16 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
     """Return a new state after applying a reducer action."""
 
     if isinstance(action, InitializeState):
-        return done(action.state)
+        return finalize(action.state)
 
     if isinstance(action, SetUiMode):
-        return _finalize_reduce_result(state, action, done(replace(state, ui_mode=action.mode)))
+        return _finalize_reduce_result(state, action, finalize(replace(state, ui_mode=action.mode)))
 
     if isinstance(action, SetNotification):
         return _finalize_reduce_result(
             state,
             action,
-            done(replace(state, notification=action.notification)),
+            finalize(replace(state, notification=action.notification)),
         )
 
     for handler in (
@@ -52,7 +52,7 @@ def reduce_app_state(state: AppState, action: Action) -> ReduceResult:
             return _finalize_reduce_result(state, action, result)
 
     logger.debug("No handler processed action: %s", type(action).__name__)
-    return _finalize_reduce_result(state, action, done(state))
+    return _finalize_reduce_result(state, action, finalize(state))
 
 
 def _finalize_reduce_result(

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -58,6 +58,12 @@ REGEX_GREP_SEARCH_PREFIX = "re:"
 
 
 def finalize(next_state: AppState, *effects: Effect) -> ReduceResult:
+    """Wrap a state transition and optional side effects into a ReduceResult.
+
+    This is the standard way to return from reducer action handlers.
+    The result will be further processed by _finalize_reduce_result in
+    reducer.py (viewport adjustment, tab sync, transient delta clearing).
+    """
     return ReduceResult(state=next_state, effects=effects)
 
 

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -57,7 +57,7 @@ REGEX_FILE_SEARCH_PREFIX = "re:"
 REGEX_GREP_SEARCH_PREFIX = "re:"
 
 
-def done(next_state: AppState, *effects: Effect) -> ReduceResult:
+def finalize(next_state: AppState, *effects: Effect) -> ReduceResult:
     return ReduceResult(state=next_state, effects=effects)
 
 

--- a/src/peneo/state/reducer_mutations.py
+++ b/src/peneo/state/reducer_mutations.py
@@ -78,7 +78,7 @@ from .reducer_common import (
     current_entry_for_path,
     current_entry_paths,
     cursor_path_after_file_mutation,
-    done,
+    finalize,
     format_clipboard_message,
     is_name_conflict_validation_error,
     move_cursor,
@@ -120,7 +120,7 @@ def _handle_begin_extract_archive_input(
     action: BeginExtractArchiveInput,
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="EXTRACT",
@@ -149,7 +149,7 @@ def _handle_begin_zip_compress_input(
     action: BeginZipCompressInput,
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="ZIP",
@@ -183,8 +183,8 @@ def _handle_begin_rename_input(
 ) -> ReduceResult | None:
     entry = current_entry_for_path(state, action.path)
     if entry is None:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             ui_mode="RENAME",
@@ -214,9 +214,9 @@ def _handle_begin_delete_targets(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if not action.paths:
-        return done(state)
+        return finalize(state)
     if action.mode == "permanent" or state.confirm_delete:
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="CONFIRM",
@@ -261,7 +261,7 @@ def _handle_begin_create_input(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     prompt = "New file: " if action.kind == "file" else "New directory: "
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="CREATE",
@@ -291,7 +291,7 @@ def _handle_begin_empty_trash(
 ) -> ReduceResult | None:
     platform_kind = _detect_platform()
     if platform_kind not in ("linux", "darwin"):
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=NotificationState(
@@ -301,7 +301,7 @@ def _handle_begin_empty_trash(
             )
         )
 
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="CONFIRM",
@@ -336,8 +336,8 @@ def _handle_set_pending_input_value(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.pending_input is None:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             pending_input=replace(state.pending_input, value=action.value),
@@ -350,7 +350,7 @@ def _handle_cancel_pending_input(
     action: CancelPendingInput,
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="BROWSING",
@@ -380,11 +380,11 @@ def _handle_submit_pending_input(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.pending_input is None:
-        return done(state)
+        return finalize(state)
     validation_error = validate_pending_input(state)
     if validation_error is not None:
         if is_name_conflict_validation_error(state, validation_error):
-            return done(
+            return finalize(
                 replace(
                     state,
                     ui_mode="CONFIRM",
@@ -397,7 +397,7 @@ def _handle_submit_pending_input(
                     ),
                 )
             )
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=NotificationState(level="error", message=validation_error),
@@ -412,11 +412,11 @@ def _handle_submit_pending_input(
     if zip_request is not None:
         return run_zip_compress_prepare_request(state, zip_request)
     if request is None:
-        return done(state)
+        return finalize(state)
     if isinstance(request, RenameRequest):
         current_name = Path(request.source_path).name
         if current_name == request.new_name:
-            return done(
+            return finalize(
                 replace(
                     state,
                     ui_mode="BROWSING",
@@ -438,7 +438,7 @@ def _handle_toggle_selection(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.path not in current_entry_paths(state):
-        return done(state)
+        return finalize(state)
     active_entries = active_current_entries(state)
     selected_paths = set(
         normalize_selected_paths(
@@ -450,7 +450,7 @@ def _handle_toggle_selection(
         selected_paths.remove(action.path)
     else:
         selected_paths.add(action.path)
-    return done(
+    return finalize(
         replace(
             state,
             current_pane=replace(
@@ -468,7 +468,7 @@ def _handle_toggle_selection_and_advance(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.path not in current_entry_paths(state):
-        return done(state)
+        return finalize(state)
     active_entries = active_current_entries(state)
     selected_paths = set(
         normalize_selected_paths(
@@ -499,7 +499,7 @@ def _handle_clear_selection(
     action: ClearSelection,
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
-    return done(
+    return finalize(
         replace(
             state,
             current_pane=replace(
@@ -521,7 +521,7 @@ def _handle_select_all_visible_entries(
         frozenset(action.paths),
         active_entries,
     )
-    return done(
+    return finalize(
         replace(
             state,
             current_pane=replace(
@@ -545,13 +545,13 @@ def _handle_copy_targets(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if not action.paths:
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=NotificationState(level="warning", message="Nothing to copy"),
             )
         )
-    return done(
+    return finalize(
         replace(
             state,
             clipboard=ClipboardState(mode="copy", paths=action.paths),
@@ -569,13 +569,13 @@ def _handle_cut_targets(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if not action.paths:
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=NotificationState(level="warning", message="Nothing to cut"),
             )
         )
-    return done(
+    return finalize(
         replace(
             state,
             clipboard=ClipboardState(mode="cut", paths=action.paths),
@@ -593,7 +593,7 @@ def _handle_paste_clipboard(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.clipboard.mode == "none" or not state.clipboard.paths:
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=NotificationState(level="warning", message="Clipboard is empty"),
@@ -614,7 +614,7 @@ def _handle_resolve_paste_conflict(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.paste_conflict is None:
-        return done(state)
+        return finalize(state)
     request = replace(
         state.paste_conflict.request,
         conflict_resolution=action.resolution,
@@ -637,7 +637,7 @@ def _handle_cancel_paste_conflict(
     action: CancelPasteConflict,
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
-    return done(
+    return finalize(
         replace(
             state,
             paste_conflict=None,
@@ -654,7 +654,7 @@ def _handle_clipboard_paste_needs_resolution(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_paste_request_id or not action.conflicts:
-        return done(state)
+        return finalize(state)
     if state.paste_conflict_action != "prompt":
         request = replace(
             action.request,
@@ -672,7 +672,7 @@ def _handle_clipboard_paste_needs_resolution(
             ),
             request,
         )
-    return done(
+    return finalize(
         replace(
             state,
             paste_conflict=PasteConflictState(
@@ -694,7 +694,7 @@ def _handle_clipboard_paste_completed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_paste_request_id:
-        return done(state)
+        return finalize(state)
 
     next_clipboard = state.clipboard
     if state.clipboard.mode == "cut" and action.summary.success_count > 0:
@@ -720,8 +720,8 @@ def _handle_clipboard_paste_failed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_paste_request_id:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -745,7 +745,7 @@ def _handle_confirm_delete_targets(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.delete_confirmation is None:
-        return done(state)
+        return finalize(state)
     return run_file_mutation_request(
         replace(
             state,
@@ -766,7 +766,7 @@ def _handle_confirm_archive_extract(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.archive_extract_confirmation is None:
-        return done(state)
+        return finalize(state)
     return run_archive_extract_request(
         replace(
             state,
@@ -786,7 +786,7 @@ def _handle_confirm_zip_compress(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.zip_compress_confirmation is None:
-        return done(state)
+        return finalize(state)
     return run_zip_compress_request(
         replace(
             state,
@@ -804,7 +804,7 @@ def _handle_confirm_empty_trash(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.empty_trash_confirmation is None:
-        return done(state)
+        return finalize(state)
 
     from peneo.services import resolve_trash_service
 
@@ -812,7 +812,7 @@ def _handle_confirm_empty_trash(
     removed_count, error_message = trash_service.empty_trash()
 
     if error_message and removed_count == 0:
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -829,7 +829,7 @@ def _handle_confirm_empty_trash(
         message = f"Emptied {removed_count} {noun} from trash"
         level = "info"
 
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="BROWSING",
@@ -850,7 +850,7 @@ def _handle_cancel_delete_confirmation(
         and state.delete_confirmation.mode == "permanent"
         else "Delete cancelled"
     )
-    return done(
+    return finalize(
         replace(
             state,
             delete_confirmation=None,
@@ -866,8 +866,8 @@ def _handle_cancel_archive_extract_confirmation(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.archive_extract_confirmation is None:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             archive_extract_confirmation=None,
@@ -886,8 +886,8 @@ def _handle_cancel_zip_compress_confirmation(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.zip_compress_confirmation is None:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             zip_compress_confirmation=None,
@@ -906,7 +906,7 @@ def _handle_cancel_empty_trash_confirmation(
     action: CancelEmptyTrashConfirmation,
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="BROWSING",
@@ -922,8 +922,8 @@ def _handle_dismiss_name_conflict(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if state.name_conflict is None:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=None,
@@ -944,10 +944,10 @@ def _handle_archive_preparation_completed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_archive_prepare_request_id:
-        return done(state)
+        return finalize(state)
 
     if action.conflict_count > 0 and action.first_conflict_path is not None:
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -983,8 +983,8 @@ def _handle_archive_preparation_failed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_archive_prepare_request_id:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -1004,12 +1004,12 @@ def _handle_archive_extract_progress(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_archive_extract_request_id:
-        return done(state)
+        return finalize(state)
 
     message = f"Extracting archive {action.completed_entries}/{action.total_entries}"
     if action.current_path is not None:
         message = f"{message}: {Path(action.current_path).name}"
-    return done(
+    return finalize(
         replace(
             state,
             archive_extract_progress=ArchiveExtractProgressState(
@@ -1028,7 +1028,7 @@ def _handle_archive_extract_completed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_archive_extract_request_id:
-        return done(state)
+        return finalize(state)
 
     next_state = replace(
         state,
@@ -1066,8 +1066,8 @@ def _handle_archive_extract_failed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_archive_extract_request_id:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -1087,10 +1087,10 @@ def _handle_zip_compress_preparation_completed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_zip_compress_prepare_request_id:
-        return done(state)
+        return finalize(state)
 
     if action.destination_exists:
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -1122,8 +1122,8 @@ def _handle_zip_compress_preparation_failed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_zip_compress_prepare_request_id:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -1141,12 +1141,12 @@ def _handle_zip_compress_progress(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_zip_compress_request_id:
-        return done(state)
+        return finalize(state)
 
     message = f"Compressing as zip {action.completed_entries}/{action.total_entries}"
     if action.current_path is not None:
         message = f"{message}: {Path(action.current_path).name}"
-    return done(
+    return finalize(
         replace(
             state,
             zip_compress_progress=ZipCompressProgressState(
@@ -1165,7 +1165,7 @@ def _handle_zip_compress_completed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_zip_compress_request_id:
-        return done(state)
+        return finalize(state)
 
     next_state = replace(
         state,
@@ -1201,8 +1201,8 @@ def _handle_zip_compress_failed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_zip_compress_request_id:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -1220,7 +1220,7 @@ def _handle_file_mutation_completed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_file_mutation_request_id:
-        return done(state)
+        return finalize(state)
     selected_paths = state.current_pane.selected_paths
     if action.result.removed_paths:
         selected_paths = frozenset(
@@ -1261,8 +1261,8 @@ def _handle_file_mutation_failed(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if action.request_id != state.pending_file_mutation_request_id:
-        return done(state)
-    return done(
+        return finalize(state)
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),

--- a/src/peneo/state/reducer_navigation.py
+++ b/src/peneo/state/reducer_navigation.py
@@ -55,7 +55,7 @@ from .reducer_common import (
     build_history_after_snapshot_load,
     current_entry_for_path,
     current_entry_paths,
-    done,
+    finalize,
     maybe_request_directory_sizes,
     move_cursor,
     normalize_child_pane_for_display,
@@ -256,19 +256,19 @@ def handle_navigation_action(
     if isinstance(action, ActivateNextTab):
         tabs = select_browser_tabs(state)
         if len(tabs) <= 1:
-            return done(state)
+            return finalize(state)
         return _activate_tab(state, (state.active_tab_index + 1) % len(tabs), reduce_state)
 
     if isinstance(action, ActivatePreviousTab):
         tabs = select_browser_tabs(state)
         if len(tabs) <= 1:
-            return done(state)
+            return finalize(state)
         return _activate_tab(state, (state.active_tab_index - 1) % len(tabs), reduce_state)
 
     if isinstance(action, CloseCurrentTab):
         tabs = list(select_browser_tabs(state))
         if len(tabs) <= 1:
-            return done(
+            return finalize(
                 replace(
                     state,
                     notification=NotificationState(
@@ -288,7 +288,7 @@ def handle_navigation_action(
         return maybe_request_directory_sizes(next_state, reduce_state)
 
     if isinstance(action, BeginFilterInput):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="FILTER",
@@ -308,7 +308,7 @@ def handle_navigation_action(
         )
 
     if isinstance(action, ConfirmFilterInput):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -321,7 +321,7 @@ def handle_navigation_action(
         )
 
     if isinstance(action, CancelFilterInput):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -358,7 +358,7 @@ def handle_navigation_action(
 
     if isinstance(action, MoveCursorAndSelectRange):
         if not action.visible_paths:
-            return done(state)
+            return finalize(state)
         base_cursor_path = (
             state.current_pane.cursor_path
             if state.current_pane.cursor_path in action.visible_paths
@@ -372,7 +372,7 @@ def handle_navigation_action(
             anchor_path = base_cursor_path
         cursor_path = move_cursor(base_cursor_path, action.visible_paths, action.delta)
         if cursor_path is None:
-            return done(state)
+            return finalize(state)
         next_state = replace(
             state,
             current_pane=replace(
@@ -391,7 +391,7 @@ def handle_navigation_action(
 
     if isinstance(action, JumpCursor):
         if not action.visible_paths:
-            return done(state)
+            return finalize(state)
         cursor_path = (
             action.visible_paths[0]
             if action.position == "start"
@@ -410,7 +410,7 @@ def handle_navigation_action(
 
     if isinstance(action, MoveCursorByPage):
         if not action.visible_paths:
-            return done(state)
+            return finalize(state)
         current_index = (
             action.visible_paths.index(state.current_pane.cursor_path)
             if state.current_pane.cursor_path in action.visible_paths
@@ -434,7 +434,7 @@ def handle_navigation_action(
 
     if isinstance(action, SetCursorPath):
         if action.path is not None and action.path not in current_entry_paths(state):
-            return done(state)
+            return finalize(state)
         next_state = replace(
             state,
             current_pane=replace(
@@ -449,7 +449,7 @@ def handle_navigation_action(
     if isinstance(action, EnterCursorDirectory):
         entry = current_entry_for_path(state, state.current_pane.cursor_path)
         if entry is None or entry.kind != "dir":
-            return done(state)
+            return finalize(state)
         if _can_promote_child_pane(state, entry.path):
             next_state = _promote_child_pane_to_current(state, entry.path)
             return sync_child_pane(next_state, next_state.current_pane.cursor_path, reduce_state)
@@ -478,7 +478,7 @@ def handle_navigation_action(
 
     if isinstance(action, GoBack):
         if not state.history.back:
-            return done(state)
+            return finalize(state)
         return reduce_state(
             state,
             RequestBrowserSnapshot(state.history.back[-1], blocking=True),
@@ -486,7 +486,7 @@ def handle_navigation_action(
 
     if isinstance(action, GoForward):
         if not state.history.forward:
-            return done(state)
+            return finalize(state)
         return reduce_state(
             state,
             RequestBrowserSnapshot(state.history.forward[0], blocking=True),
@@ -515,7 +515,7 @@ def handle_navigation_action(
         visible_paths = tuple(
             entry.path for entry in select_visible_current_entry_states(next_state)
         )
-        return done(
+        return finalize(
             replace(
                 next_state,
                 current_pane=replace(
@@ -604,7 +604,7 @@ def handle_navigation_action(
             next_request_id=request_id + 1,
             ui_mode="BUSY" if action.blocking else state.ui_mode,
         )
-        return done(
+        return finalize(
             next_state,
             LoadBrowserSnapshotEffect(
                 request_id=request_id,
@@ -618,7 +618,7 @@ def handle_navigation_action(
     if isinstance(action, RequestDirectorySizes):
         unique_paths = tuple(dict.fromkeys(action.paths))
         if not unique_paths:
-            return done(state)
+            return finalize(state)
         request_id = state.next_request_id
         next_state = replace(
             state,
@@ -632,7 +632,7 @@ def handle_navigation_action(
             pending_directory_size_request_id=request_id,
             next_request_id=request_id + 1,
         )
-        return done(
+        return finalize(
             next_state,
             RunDirectorySizeEffect(request_id=request_id, paths=unique_paths),
         )
@@ -640,7 +640,7 @@ def handle_navigation_action(
     if isinstance(action, BrowserSnapshotLoaded):
         tab_index = _find_browser_snapshot_tab_index(state, action.request_id)
         if tab_index is None:
-            return done(state)
+            return finalize(state)
         tab = select_browser_tabs(state)[tab_index]
         next_state = _replace_browser_tab(
             state,
@@ -648,7 +648,7 @@ def handle_navigation_action(
             _apply_loaded_snapshot_to_tab(state, tab, action),
         )
         if tab_index != state.active_tab_index:
-            return done(replace(next_state, post_reload_notification=None))
+            return finalize(replace(next_state, post_reload_notification=None))
         next_state = replace(
             next_state,
             notification=state.post_reload_notification,
@@ -660,7 +660,7 @@ def handle_navigation_action(
     if isinstance(action, BrowserSnapshotFailed):
         tab_index = _find_browser_snapshot_tab_index(state, action.request_id)
         if tab_index is None:
-            return done(state)
+            return finalize(state)
         tab = replace(
             select_browser_tabs(state)[tab_index],
             pending_browser_snapshot_request_id=None,
@@ -668,8 +668,8 @@ def handle_navigation_action(
         )
         next_state = _replace_browser_tab(state, tab_index, tab)
         if tab_index != state.active_tab_index:
-            return done(replace(next_state, post_reload_notification=None))
-        return done(
+            return finalize(replace(next_state, post_reload_notification=None))
+        return finalize(
             replace(
                 next_state,
                 notification=NotificationState(level="error", message=action.message),
@@ -681,7 +681,7 @@ def handle_navigation_action(
     if isinstance(action, ChildPaneSnapshotLoaded):
         tab_index = _find_child_pane_snapshot_tab_index(state, action.request_id)
         if tab_index is None:
-            return done(state)
+            return finalize(state)
         tab = select_browser_tabs(state)[tab_index]
         next_state = _replace_browser_tab(
             state,
@@ -697,14 +697,14 @@ def handle_navigation_action(
             ),
         )
         if tab_index != state.active_tab_index:
-            return done(next_state)
+            return finalize(next_state)
         next_state = replace(next_state, notification=None)
         return maybe_request_directory_sizes(next_state, reduce_state)
 
     if isinstance(action, ChildPaneSnapshotFailed):
         tab_index = _find_child_pane_snapshot_tab_index(state, action.request_id)
         if tab_index is None:
-            return done(state)
+            return finalize(state)
         tab = select_browser_tabs(state)[tab_index]
         next_state = _replace_browser_tab(
             state,
@@ -716,8 +716,8 @@ def handle_navigation_action(
             ),
         )
         if tab_index != state.active_tab_index:
-            return done(next_state)
-        return done(
+            return finalize(next_state)
+        return finalize(
             replace(
                 next_state,
                 notification=NotificationState(level="error", message=action.message),
@@ -726,7 +726,7 @@ def handle_navigation_action(
 
     if isinstance(action, DirectorySizesLoaded):
         if action.request_id != state.pending_directory_size_request_id:
-            return done(state)
+            return finalize(state)
         loaded_entries = tuple(
             DirectorySizeCacheEntry(
                 path=path,
@@ -757,11 +757,11 @@ def handle_navigation_action(
             ),
             pending_directory_size_request_id=None,
         )
-        return done(next_state)
+        return finalize(next_state)
 
     if isinstance(action, DirectorySizesFailed):
         if action.request_id != state.pending_directory_size_request_id:
-            return done(state)
+            return finalize(state)
         next_state = replace(
             state,
             directory_size_cache=upsert_directory_size_entries(
@@ -781,6 +781,6 @@ def handle_navigation_action(
             ),
             pending_directory_size_request_id=None,
         )
-        return done(next_state)
+        return finalize(next_state)
 
     return None

--- a/src/peneo/state/reducer_palette.py
+++ b/src/peneo/state/reducer_palette.py
@@ -74,9 +74,9 @@ from .models import (
 )
 from .reducer_common import (
     ReducerFn,
-    finalize,
     expand_and_validate_path,
     filter_file_search_results,
+    finalize,
     is_regex_file_search_query,
     list_matching_directory_paths,
     run_external_launch_request,

--- a/src/peneo/state/reducer_palette.py
+++ b/src/peneo/state/reducer_palette.py
@@ -74,7 +74,7 @@ from .models import (
 )
 from .reducer_common import (
     ReducerFn,
-    done,
+    finalize,
     expand_and_validate_path,
     filter_file_search_results,
     is_regex_file_search_query,
@@ -162,7 +162,7 @@ def _notify(
     level: str,
     message: str,
 ) -> ReduceResult:
-    return done(
+    return finalize(
         replace(
             state,
             notification=NotificationState(level=level, message=message),
@@ -227,11 +227,11 @@ def _request_palette_snapshot(
 
 def _handle_begin_history_search(state: AppState) -> ReduceResult:
     history_items = tuple(dict.fromkeys(state.history.visited_all))
-    return done(_enter_palette(state, source="history", history_results=history_items))
+    return finalize(_enter_palette(state, source="history", history_results=history_items))
 
 
 def _handle_begin_bookmark_search(state: AppState) -> ReduceResult:
-    return done(_enter_palette(state, source="bookmarks"))
+    return finalize(_enter_palette(state, source="bookmarks"))
 
 
 def _handle_move_palette_cursor(
@@ -239,7 +239,7 @@ def _handle_move_palette_cursor(
     action: MoveCommandPaletteCursor,
 ) -> ReduceResult:
     if state.command_palette is None:
-        return done(state)
+        return finalize(state)
     next_palette = replace(
         state.command_palette,
         cursor_index=normalize_command_palette_cursor(
@@ -257,7 +257,7 @@ def _handle_move_palette_cursor(
         return _sync_file_search_preview(next_state)
     if state.command_palette.source == "grep_search":
         return _sync_grep_preview(next_state)
-    return done(next_state)
+    return finalize(next_state)
 
 
 def _next_palette_query_state(state: AppState, query: str) -> CommandPaletteState:
@@ -275,7 +275,7 @@ def _handle_set_palette_query(
     action: SetCommandPaletteQuery,
 ) -> ReduceResult:
     if state.command_palette is None:
-        return done(state)
+        return finalize(state)
 
     next_palette = _next_palette_query_state(state, action.query)
 
@@ -285,7 +285,7 @@ def _handle_set_palette_query(
         return _handle_set_grep_search_field(state, "keyword", action.query)
     if state.command_palette.source == "go_to_path":
         return _handle_set_go_to_path_query(state, next_palette, action.query)
-    return done(replace(state, command_palette=next_palette))
+    return finalize(replace(state, command_palette=next_palette))
 
 
 def _handle_set_file_search_query(
@@ -341,7 +341,7 @@ def _handle_set_file_search_query(
         pending_grep_search_request_id=None,
         next_request_id=request_id + 1,
     )
-    return done(
+    return finalize(
         next_state,
         RunFileSearchEffect(
             request_id=request_id,
@@ -400,7 +400,7 @@ def _handle_set_grep_search_field(
         pending_grep_search_request_id=request_id,
         next_request_id=request_id + 1,
     )
-    return done(
+    return finalize(
         next_state,
         RunGrepSearchEffect(
             request_id=request_id,
@@ -418,10 +418,10 @@ def _handle_cycle_grep_search_field(
     action: CycleGrepSearchField,
 ) -> ReduceResult:
     if state.command_palette is None or state.command_palette.source != "grep_search":
-        return done(state)
+        return finalize(state)
     current_index = _GREP_SEARCH_FIELDS.index(state.command_palette.grep_search_active_field)
     next_index = (current_index + action.delta) % len(_GREP_SEARCH_FIELDS)
-    return done(
+    return finalize(
         replace(
             state,
             command_palette=replace(
@@ -439,7 +439,7 @@ def _handle_set_go_to_path_query(
 ) -> ReduceResult:
     matches = list_matching_directory_paths(query, state.current_path)
     has_trailing_separator = query.endswith("/")
-    return done(
+    return finalize(
         replace(
             state,
             command_palette=replace(
@@ -456,7 +456,7 @@ def _handle_submit_palette(
     reduce_state: ReducerFn,
 ) -> ReduceResult:
     if state.command_palette is None:
-        return done(state)
+        return finalize(state)
 
     if state.command_palette.source == "file_search":
         return _handle_submit_file_search_palette(state, reduce_state)
@@ -717,7 +717,7 @@ def _run_palette_command_item(
         return _run_create_file_command(next_state, reduce_state)
     if item_id == "create_dir":
         return _run_create_dir_command(next_state, reduce_state)
-    return done(next_state)
+    return finalize(next_state)
 
 
 def _run_new_tab_command(
@@ -835,7 +835,7 @@ def _run_show_attributes_command(state: AppState) -> ReduceResult:
             message="Show attributes requires a single target",
         )
 
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="DETAIL",
@@ -996,7 +996,7 @@ def _run_toggle_hidden_command(
 
 
 def _run_edit_config_command(state: AppState) -> ReduceResult:
-    return done(
+    return finalize(
         replace(
             state,
             ui_mode="CONFIG",
@@ -1054,7 +1054,7 @@ def _handle_file_search_completed(
         source="file_search",
         query=action.query,
     ):
-        return done(state)
+        return finalize(state)
 
     cache_query = ""
     cache_results = ()
@@ -1085,7 +1085,7 @@ def _handle_file_search_failed(
     action: FileSearchFailed,
 ) -> ReduceResult:
     if action.request_id != state.pending_file_search_request_id:
-        return done(state)
+        return finalize(state)
 
     if state.command_palette is not None and action.invalid_query:
         return _sync_file_search_preview(
@@ -1100,7 +1100,7 @@ def _handle_file_search_failed(
             )
         )
 
-    return done(
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -1118,7 +1118,7 @@ def _handle_grep_search_completed(
         or state.command_palette is None
         or state.command_palette.source != "grep_search"
     ):
-        return done(state)
+        return finalize(state)
 
     return _sync_grep_preview(
         replace(
@@ -1139,7 +1139,7 @@ def _handle_grep_search_failed(
     action: GrepSearchFailed,
 ) -> ReduceResult:
     if action.request_id != state.pending_grep_search_request_id:
-        return done(state)
+        return finalize(state)
 
     if state.command_palette is not None and action.invalid_query:
         return _sync_grep_preview(
@@ -1156,7 +1156,7 @@ def _handle_grep_search_failed(
             )
         )
 
-    return done(
+    return finalize(
         replace(
             state,
             notification=NotificationState(level="error", message=action.message),
@@ -1199,16 +1199,16 @@ def _matches_file_search_preview(
 def _sync_file_search_preview(state: AppState) -> ReduceResult:
     selected_result = _selected_file_search_result(state)
     if selected_result is None or not state.config.display.show_preview:
-        return done(replace(state, pending_child_pane_request_id=None))
+        return finalize(replace(state, pending_child_pane_request_id=None))
 
     if state.pending_child_pane_request_id is None and _matches_file_search_preview(
         state,
         selected_result,
     ):
-        return done(state)
+        return finalize(state)
 
     request_id = state.next_request_id
-    return done(
+    return finalize(
         replace(
             state,
             pending_child_pane_request_id=request_id,
@@ -1236,16 +1236,16 @@ def _matches_grep_preview(
 def _sync_grep_preview(state: AppState) -> ReduceResult:
     selected_result = _selected_grep_result(state)
     if selected_result is None or not state.config.display.show_preview:
-        return done(replace(state, pending_child_pane_request_id=None))
+        return finalize(replace(state, pending_child_pane_request_id=None))
 
     if state.pending_child_pane_request_id is None and _matches_grep_preview(
         state,
         selected_result,
     ):
-        return done(state)
+        return finalize(state)
 
     request_id = state.next_request_id
-    return done(
+    return finalize(
         replace(
             state,
             pending_child_pane_request_id=request_id,
@@ -1267,13 +1267,13 @@ def handle_palette_action(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if isinstance(action, BeginCommandPalette):
-        return done(_enter_palette(state))
+        return finalize(_enter_palette(state))
 
     if isinstance(action, BeginFileSearch):
-        return done(_enter_palette(state, source="file_search"))
+        return finalize(_enter_palette(state, source="file_search"))
 
     if isinstance(action, BeginGrepSearch):
-        return done(_enter_palette(state, source="grep_search"))
+        return finalize(_enter_palette(state, source="grep_search"))
 
     if isinstance(action, BeginHistorySearch):
         return _handle_begin_history_search(state)
@@ -1282,7 +1282,7 @@ def handle_palette_action(
         return _handle_begin_bookmark_search(state)
 
     if isinstance(action, BeginGoToPath):
-        return done(_enter_palette(state, source="go_to_path"))
+        return finalize(_enter_palette(state, source="go_to_path"))
 
     if isinstance(action, CancelCommandPalette):
         next_state = _restore_browsing_from_palette(state, clear_name_conflict=True)
@@ -1291,10 +1291,10 @@ def handle_palette_action(
             "grep_search",
         }:
             return sync_child_pane(next_state, next_state.current_pane.cursor_path, reduce_state)
-        return done(next_state)
+        return finalize(next_state)
 
     if isinstance(action, DismissAttributeDialog):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",

--- a/src/peneo/state/reducer_terminal_config.py
+++ b/src/peneo/state/reducer_terminal_config.py
@@ -52,7 +52,7 @@ from .reducer_common import (
     ReducerFn,
     apply_config_to_runtime_state,
     cycle_config_editor_value,
-    done,
+    finalize,
     normalize_config_editor_cursor,
     notification_for_external_launch,
     run_external_launch_request,
@@ -68,7 +68,7 @@ def handle_terminal_config_action(
     reduce_state: ReducerFn,
 ) -> ReduceResult | None:
     if isinstance(action, BeginShellCommandInput):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="SHELL",
@@ -86,7 +86,7 @@ def handle_terminal_config_action(
         )
 
     if isinstance(action, DismissConfigEditor):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -96,7 +96,7 @@ def handle_terminal_config_action(
         )
 
     if isinstance(action, CancelShellCommandInput):
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -107,8 +107,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, SetShellCommandValue):
         if state.shell_command is None:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 shell_command=replace(state.shell_command, command=action.command),
@@ -117,8 +117,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, MoveConfigEditorCursor):
         if state.config_editor is None:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 config_editor=replace(
@@ -132,13 +132,13 @@ def handle_terminal_config_action(
 
     if isinstance(action, CycleConfigEditorValue):
         if state.config_editor is None:
-            return done(state)
+            return finalize(state)
         next_draft = cycle_config_editor_value(
             state.config_editor.draft,
             state.config_editor.cursor_index,
             action.delta,
         )
-        return done(
+        return finalize(
             replace(
                 state,
                 config_editor=replace(
@@ -151,9 +151,9 @@ def handle_terminal_config_action(
 
     if isinstance(action, SaveConfigEditor):
         if state.config_editor is None:
-            return done(state)
+            return finalize(state)
         request_id = state.next_request_id
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -169,10 +169,10 @@ def handle_terminal_config_action(
 
     if isinstance(action, SubmitShellCommand):
         if state.shell_command is None:
-            return done(state)
+            return finalize(state)
         command = state.shell_command.command.strip()
         if not command:
-            return done(
+            return finalize(
                 replace(
                     state,
                     notification=NotificationState(
@@ -182,7 +182,7 @@ def handle_terminal_config_action(
                 )
             )
         request_id = state.next_request_id
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BUSY",
@@ -200,7 +200,7 @@ def handle_terminal_config_action(
 
     if isinstance(action, AddBookmark):
         if action.path in state.config.bookmarks.paths:
-            return done(
+            return finalize(
                 replace(
                     state,
                     notification=NotificationState(
@@ -216,7 +216,7 @@ def handle_terminal_config_action(
             ),
         )
         request_id = state.next_request_id
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -232,7 +232,7 @@ def handle_terminal_config_action(
 
     if isinstance(action, RemoveBookmark):
         if action.path not in state.config.bookmarks.paths:
-            return done(
+            return finalize(
                 replace(
                     state,
                     notification=NotificationState(
@@ -248,7 +248,7 @@ def handle_terminal_config_action(
             ),
         )
         request_id = state.next_request_id
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -268,7 +268,7 @@ def handle_terminal_config_action(
             help_bar=HelpBarConfig(),
         )
         request_id = state.next_request_id
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -307,7 +307,7 @@ def handle_terminal_config_action(
     if isinstance(action, CopyPathsToClipboard):
         target_paths = select_target_paths(state)
         if not target_paths:
-            return done(
+            return finalize(
                 replace(
                     state,
                     notification=NotificationState(level="warning", message="Nothing to copy"),
@@ -327,8 +327,8 @@ def handle_terminal_config_action(
             )
             session_id = state.split_terminal.session_id
             if session_id is None:
-                return done(next_state)
-            return done(next_state, CloseSplitTerminalEffect(session_id=session_id))
+                return finalize(next_state)
+            return finalize(next_state, CloseSplitTerminalEffect(session_id=session_id))
 
         session_id = state.next_request_id
         next_state = replace(
@@ -343,15 +343,15 @@ def handle_terminal_config_action(
                 session_id=session_id,
             ),
         )
-        return done(
+        return finalize(
             next_state,
             StartSplitTerminalEffect(session_id=session_id, cwd=state.current_path),
         )
 
     if isinstance(action, FocusSplitTerminal):
         if not state.split_terminal.visible or state.split_terminal.status != "running":
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 notification=None,
@@ -366,8 +366,8 @@ def handle_terminal_config_action(
             or state.split_terminal.status != "running"
             or session_id is None
         ):
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             state,
             WriteSplitTerminalInputEffect(session_id=session_id, data=action.data),
         )
@@ -379,8 +379,8 @@ def handle_terminal_config_action(
             or state.split_terminal.status != "running"
             or session_id is None
         ):
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             state,
             PasteFromClipboardEffect(session_id=session_id),
         )
@@ -388,11 +388,11 @@ def handle_terminal_config_action(
     if isinstance(action, ExternalLaunchCompleted):
         notification = notification_for_external_launch(action.request)
         if notification is None:
-            return done(state)
-        return done(replace(state, notification=notification))
+            return finalize(state)
+        return finalize(replace(state, notification=notification))
 
     if isinstance(action, ExternalLaunchFailed):
-        return done(
+        return finalize(
             replace(
                 state,
                 notification=NotificationState(level="error", message=action.message),
@@ -401,9 +401,9 @@ def handle_terminal_config_action(
 
     if isinstance(action, ShellCommandCompleted):
         if state.pending_shell_command_request_id != action.request_id:
-            return done(state)
+            return finalize(state)
         level, message = _notification_for_shell_command(action.result)
-        return done(
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -414,8 +414,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, ShellCommandFailed):
         if state.pending_shell_command_request_id != action.request_id:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 ui_mode="BROWSING",
@@ -426,8 +426,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, SplitTerminalStarted):
         if state.split_terminal.session_id != action.session_id:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 split_terminal=replace(
@@ -441,8 +441,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, SplitTerminalStartFailed):
         if state.split_terminal.session_id != action.session_id:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 split_terminal=SplitTerminalState(),
@@ -451,12 +451,12 @@ def handle_terminal_config_action(
         )
 
     if isinstance(action, SplitTerminalOutputReceived):
-        return done(state)
+        return finalize(state)
 
     if isinstance(action, SplitTerminalExited):
         if state.split_terminal.session_id != action.session_id:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 split_terminal=SplitTerminalState(),
@@ -469,7 +469,7 @@ def handle_terminal_config_action(
 
     if isinstance(action, ConfigSaveCompleted):
         if state.pending_config_save_request_id != action.request_id:
-            return done(state)
+            return finalize(state)
         next_config_editor = state.config_editor
         if next_config_editor is not None:
             next_config_editor = replace(
@@ -496,8 +496,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, ConfigSaveFailed):
         if state.pending_config_save_request_id != action.request_id:
-            return done(state)
-        return done(
+            return finalize(state)
+        return finalize(
             replace(
                 state,
                 pending_config_save_request_id=None,
@@ -510,8 +510,8 @@ def handle_terminal_config_action(
 
     if isinstance(action, SetTerminalHeight):
         if action.height == state.terminal_height:
-            return done(state)
-        return done(replace(state, terminal_height=action.height))
+            return finalize(state)
+        return finalize(replace(state, terminal_height=action.height))
 
     return None
 


### PR DESCRIPTION
## Summary

- Rename `done()` to `finalize()` in `reducer_common.py` for clearer semantics
- Add docstring to `finalize()` documenting its purpose and relationship to the reducer pipeline
- Fix import sort order in `reducer_palette.py`

`finalize` aligns with the existing `_finalize_reduce_result` naming convention in `reducer.py` and better describes the function's role of wrapping a state transition into a `ReduceResult`.

Note: Helper extraction for common state update patterns was investigated but deferred — handlers clear widely varying field sets (2–16 fields), making extraction prone to over-abstraction.

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run pytest` — 813 tests passed
- [x] `grep -r '\bdone\b' src/peneo/state/reducer*.py` — no remaining old references

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)