### PR TITLE
Remove backspace key binding for parent directory navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Peneo is a TUI file manager you can use without memorizing keybindings. Common a
 | `PageUp` / `PageDown` | Move cursor by page |
 | `k` / `↑` | Move up |
 | `Home` / `End` | Jump to first/last visible entry |
-| `h` / `←` / `Backspace` | Go to parent directory |
+| `h` / `←` | Go to parent directory |
 | `l` / `→` | Enter directory |
 | `Shift+↑` / `Shift+↓` | Extend selection |
 | `Enter` | Open file/enter directory |

--- a/src/peneo/state/input.py
+++ b/src/peneo/state/input.py
@@ -125,7 +125,6 @@ BROWSING_KEYMAP = {
     "escape": "clear_selection",
     "/": "begin_filter",
     "left": "go_to_parent",
-    "backspace": "go_to_parent",
     "h": "go_to_parent",
     "R": "reload_directory",
     "q": "exit_current_path",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1627,7 +1627,7 @@ async def test_app_cut_uses_targeted_row_updates(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_app_right_enters_directory_and_backspace_returns_to_parent() -> None:
+async def test_app_right_enters_directory_and_left_returns_to_parent() -> None:
     root = "/tmp/peneo-nav"
     docs = f"{root}/docs"
     root_entries = (
@@ -1674,7 +1674,7 @@ async def test_app_right_enters_directory_and_backspace_returns_to_parent() -> N
         assert app.app_state.current_path == docs
         assert current_table.cursor_row == 0
 
-        await pilot.press("backspace")
+        await pilot.press("left")
         await _wait_for_path(app, root)
         assert str(current_path_bar.renderable) == f"Current Path: {root}"
 
@@ -1684,7 +1684,7 @@ async def test_app_right_enters_directory_and_backspace_returns_to_parent() -> N
 
 
 @pytest.mark.asyncio
-async def test_app_backspace_can_move_above_initial_directory() -> None:
+async def test_app_left_can_move_above_initial_directory() -> None:
     initial_path = "/tmp/peneo-nav/deeper"
     parent_path = "/tmp/peneo-nav"
     grandparent_path = "/tmp"
@@ -1746,7 +1746,7 @@ async def test_app_backspace_can_move_above_initial_directory() -> None:
 
     async with app.run_test() as pilot:
         await _wait_for_snapshot_loaded(app, initial_path)
-        await pilot.press("backspace")
+        await pilot.press("left")
         await _wait_for_path(app, parent_path)
         await pilot.press("left")
         await _wait_for_path(app, grandparent_path)
@@ -4908,7 +4908,7 @@ async def test_app_main_flow_round_trip_on_live_filesystem(tmp_path) -> None:
         assert (docs_dir / "notes.txt").is_file()
         assert str(status_bar.renderable) == "info: Copied 1 item(s)"
 
-        await pilot.press("backspace")
+        await pilot.press("left")
         await _wait_for_path(app, str(tmp_path))
         await _wait_for_row_count(app, 4)
 

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -543,14 +543,6 @@ def test_browsing_e_on_directory_warns() -> None:
     )
 
 
-def test_browsing_backspace_goes_to_parent_directory() -> None:
-    state = build_initial_app_state()
-
-    actions = dispatch_key_input(state, key="backspace")
-
-    assert actions == (SetNotification(None), GoToParentDirectory())
-
-
 def test_browsing_capital_R_reloads_current_directory() -> None:
     state = build_initial_app_state()
 


### PR DESCRIPTION
## Summary
- Remove `"backspace": "go_to_parent"` from `BROWSING_KEYMAP` in `input.py`
- Update tests to use `left` arrow key instead of `backspace` for parent directory navigation
- Remove `test_browsing_backspace_goes_to_parent_directory` dispatch test

## Test plan
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run pytest` — 839 tests passed

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)