### PR TITLE
[#488] テーマ連携でペインのファイル種別スタイルを統合

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -317,12 +317,15 @@ class PeneoApp(App[None]):
         previous_state = self._app_state
         changed, effects = self._apply_actions(actions)
         sync_runtime_state(self, previous_state, self._app_state)
-        if previous_state.config.display.theme != self._app_state.config.display.theme:
+        theme_changed = (
+            previous_state.config.display.theme != self._app_state.config.display.theme
+        )
+        if theme_changed:
             self.theme = self._app_state.config.display.theme
         if previous_state.config != self._app_state.config:
             self._sync_external_launch_service()
-        if changed:
-            await self._refresh_shell()
+        if changed or theme_changed:
+            await self._refresh_shell(theme_changed=theme_changed)
         schedule_effects(self, effects)
 
     def _build_external_launch_service(self, app_config: AppConfig) -> LiveExternalLaunchService:
@@ -400,13 +403,14 @@ class PeneoApp(App[None]):
             return
         self.call_after_refresh(self._resize_split_terminal_session)
 
-    async def _refresh_shell(self) -> None:
+    async def _refresh_shell(self, *, theme_changed: bool = False) -> None:
         try:
             await refresh_shell(
                 self,
                 self._app_state,
                 select_shell_data(self._app_state),
                 self._split_terminal_session,
+                theme_changed=theme_changed,
             )
             self.call_after_refresh(self._sync_overlay_layout)
         except ScreenStackError:

--- a/src/peneo/app.tcss
+++ b/src/peneo/app.tcss
@@ -279,3 +279,69 @@ Screen {
 #split-terminal.-focused {
     background: $boost;
 }
+
+/* File type component styles resolved via COMPONENT_CLASSES */
+.ft-executable {
+    color: $success;
+    text-style: bold;
+}
+
+.ft-executable-sel {
+    color: $success;
+    text-style: bold;
+}
+
+.ft-executable-cut {
+    color: $success;
+    text-style: bold dim;
+}
+
+.ft-directory {
+    color: $accent;
+    text-style: bold;
+}
+
+.ft-directory-sel {
+    color: $accent;
+    text-style: bold underline;
+}
+
+.ft-directory-sel-table {
+    color: $accent;
+    text-style: bold;
+}
+
+.ft-directory-cut {
+    color: $accent;
+    text-style: bold dim;
+}
+
+.ft-symlink {
+    color: $secondary;
+    text-style: bold;
+}
+
+.ft-symlink-sel {
+    color: $secondary;
+    text-style: bold;
+}
+
+.ft-symlink-cut {
+    color: $secondary;
+    text-style: bold dim;
+}
+
+.ft-selected {
+    color: $success;
+    text-style: bold;
+}
+
+.ft-cut {
+    color: $text-muted;
+    text-style: dim;
+}
+
+.ft-selected-cut {
+    color: $text-muted;
+    text-style: bold;
+}

--- a/src/peneo/app_shell.py
+++ b/src/peneo/app_shell.py
@@ -61,6 +61,8 @@ async def refresh_shell(
     app_state: AppState,
     shell: ThreePaneShellData,
     split_terminal_session: SplitTerminalSession | None,
+    *,
+    theme_changed: bool = False,
 ) -> None:
     try:
         tab_bar = app.query_one("#tab-bar", TabBar)
@@ -164,6 +166,10 @@ async def refresh_shell(
     current_pane.set_context_input(shell.current_context_input)
     await parent_pane.set_entries(shell.parent_entries)
     await child_pane.set_state(shell.child_pane)
+    if theme_changed:
+        parent_pane.refresh_styles()
+        current_pane.refresh_styles()
+        child_pane.refresh_styles()
     split_terminal.set_state(shell.split_terminal)
     resize_split_terminal_session(app, app_state, split_terminal_session)
     command_palette_layer.display = shell.command_palette is not None

--- a/src/peneo/ui/panes.py
+++ b/src/peneo/ui/panes.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 
 from rich.cells import cell_len
+from rich.style import Style
 from rich.syntax import Syntax
 from rich.text import Text
 from textual import events
@@ -24,6 +25,23 @@ from .input_bar import InputBar
 from .summary_bar import SummaryBar
 
 ELLIPSIS = "~"
+FILE_TYPE_COMPONENT_CLASSES = frozenset(
+    {
+        "ft-cut",
+        "ft-directory",
+        "ft-directory-cut",
+        "ft-directory-sel",
+        "ft-directory-sel-table",
+        "ft-executable",
+        "ft-executable-cut",
+        "ft-executable-sel",
+        "ft-selected",
+        "ft-selected-cut",
+        "ft-symlink",
+        "ft-symlink-cut",
+        "ft-symlink-sel",
+    }
+)
 
 
 def build_entry_label(entry: PaneEntry) -> str:
@@ -97,20 +115,150 @@ def _take_suffix_cells(text: str, width: int) -> str:
     return "".join(reversed(collected))
 
 
+def _resolve_component_styles(widget: object) -> dict[str, Style]:
+    """Resolve all file-type component styles from the widget's CSS."""
+
+    return {
+        name: widget.get_component_rich_style(name)  # type: ignore[union-attr]
+        for name in FILE_TYPE_COMPONENT_CLASSES
+    }
+
+
+def _style_without_background(style: Style | None) -> Style | None:
+    """Drop background color so table cell text doesn't paint its own block."""
+
+    if style is None or style.bgcolor is None:
+        return style
+    return Style(
+        color=style.color,
+        bold=style.bold,
+        dim=style.dim,
+        italic=style.italic,
+        underline=style.underline,
+        blink=style.blink,
+        blink2=style.blink2,
+        reverse=style.reverse,
+        conceal=style.conceal,
+        strike=style.strike,
+        underline2=style.underline2,
+        frame=style.frame,
+        encircle=style.encircle,
+        overline=style.overline,
+        link=style.link,
+        meta=style.meta,
+    )
+
+
+def _ft_style_name(
+    entry: PaneEntry,
+    *,
+    selected_directory_style: str,
+    selected_cut_style: str,
+) -> str | None:
+    """Return the component class name that should style the entry."""
+
+    if entry.cut:
+        if entry.symlink:
+            return "ft-symlink-cut"
+        if entry.kind == "dir":
+            return "ft-directory-cut"
+        if entry.executable:
+            return "ft-executable-cut"
+        if entry.selected:
+            return selected_cut_style
+        return "ft-cut"
+    if entry.symlink:
+        if entry.selected:
+            return "ft-symlink-sel"
+        return "ft-symlink"
+    if entry.kind == "dir":
+        if entry.selected:
+            return selected_directory_style
+        return "ft-directory"
+    if entry.executable:
+        if entry.selected:
+            return "ft-executable-sel"
+        return "ft-executable"
+    if entry.selected:
+        return "ft-selected"
+    return None
+
+
+def _ft_resolve_style(
+    entry: PaneEntry,
+    styles: dict[str, Style],
+    *,
+    selected_directory_style: str,
+    selected_cut_style: str,
+) -> Style | None:
+    """Resolve the file-type Rich style for an entry."""
+
+    style_name = _ft_style_name(
+        entry,
+        selected_directory_style=selected_directory_style,
+        selected_cut_style=selected_cut_style,
+    )
+    if style_name is None:
+        return None
+    return styles.get(style_name)
+
+
+def _render_file_label(
+    entry: PaneEntry,
+    render_width: int,
+    styles: dict[str, Style],
+    *,
+    selected_directory_style: str,
+    selected_cut_style: str,
+) -> Text:
+    """Render a single file entry label with resolved theme styles."""
+
+    label = build_entry_label(entry)
+    if render_width > 0:
+        label = truncate_middle(label, render_width)
+    style = _ft_resolve_style(
+        entry,
+        styles,
+        selected_directory_style=selected_directory_style,
+        selected_cut_style=selected_cut_style,
+    )
+    style = _style_without_background(style)
+    return Text(label) if style is None else Text(label, style=style)
+
+
+def _render_file_entries(
+    entries: Sequence[PaneEntry],
+    render_width: int,
+    styles: dict[str, Style],
+    *,
+    selected_directory_style: str,
+    selected_cut_style: str,
+) -> Text:
+    """Render a sequence of file entries as a single Rich Text block."""
+
+    if not entries:
+        return Text()
+    return Text("\n").join(
+        [
+            _render_file_label(
+                entry,
+                render_width,
+                styles,
+                selected_directory_style=selected_directory_style,
+                selected_cut_style=selected_cut_style,
+            )
+            for entry in entries
+        ]
+    )
+
+
 class SidePane(Vertical):
     """Lightweight pane used for parent and child directory listings."""
 
-    CUT_STYLE = "bright_black dim"
-    EXECUTABLE_STYLE = "bold #55FF55"
-    EXECUTABLE_SELECTED_STYLE = "bold #55FF55"
-    EXECUTABLE_CUT_STYLE = "bold #55FF55 dim"
-    DIRECTORY_STYLE = "bold #5555FF"
-    DIRECTORY_SELECTED_STYLE = "bold white on #5555FF"
-    DIRECTORY_CUT_STYLE = "bold #5555FF dim"
-    SYMLINK_STYLE = "bold #55FFFF"
-    SYMLINK_SELECTED_STYLE = "bold #55FFFF"
-    SYMLINK_CUT_STYLE = "bold #55FFFF dim"
+    COMPONENT_CLASSES = FILE_TYPE_COMPONENT_CLASSES
     ENTRY_HORIZONTAL_PADDING = 2
+    SELECTED_DIRECTORY_STYLE = "ft-directory-sel"
+    SELECTED_CUT_STYLE = "ft-cut"
 
     def __init__(
         self,
@@ -123,6 +271,7 @@ class SidePane(Vertical):
         super().__init__(id=id, classes=classes)
         self._title = title
         self._entries = tuple(entries)
+        self._ft_styles: dict[str, Style] = {}
         self._last_render_width = 0
 
     @property
@@ -133,7 +282,13 @@ class SidePane(Vertical):
     def compose(self) -> ComposeResult:
         yield Label(self._title, classes="pane-title")
         content = Static(
-            self._render_entries(self._entries, 0),
+            _render_file_entries(
+                self._entries,
+                0,
+                {},
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+            ),
             id=self.list_view_id,
             classes="pane-list",
         )
@@ -141,6 +296,7 @@ class SidePane(Vertical):
         yield content
 
     def on_mount(self) -> None:
+        self._ft_styles = _resolve_component_styles(self)
         self.call_after_refresh(self._refresh_rendered_labels)
 
     def on_resize(self, _event: events.Resize) -> None:
@@ -155,7 +311,15 @@ class SidePane(Vertical):
 
         content = self._content_widget()
         render_width = self._entry_width(content)
-        content.update(self._render_entries(next_entries, render_width))
+        content.update(
+            _render_file_entries(
+                next_entries,
+                render_width,
+                self._ft_styles,
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+            )
+        )
         self._entries = next_entries
         self._last_render_width = render_width
 
@@ -164,68 +328,38 @@ class SidePane(Vertical):
         render_width = self._entry_width(content)
         if render_width <= 0 or render_width == self._last_render_width:
             return
-        content.update(self._render_entries(self._entries, render_width))
+        content.update(
+            _render_file_entries(
+                self._entries,
+                render_width,
+                self._ft_styles,
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+            )
+        )
         self._last_render_width = render_width
 
     def _content_widget(self) -> Static:
         return self.query_one(f"#{self.list_view_id}", Static)
 
-    @classmethod
-    def _render_entries(cls, entries: Sequence[PaneEntry], render_width: int) -> Text:
-        if not entries:
-            return Text()
-        return Text("\n").join(
-            [cls._render_label(entry, render_width) for entry in entries]
-        )
-
-    @classmethod
-    def _render_label(cls, entry: PaneEntry, render_width: int = 0) -> Text:
-        label = build_entry_label(entry)
-        if render_width > 0:
-            label = truncate_middle(label, render_width)
-
-        # カット状態が最優先
-        if entry.cut:
-            if entry.symlink:
-                return Text(label, style=cls.SYMLINK_CUT_STYLE)
-            if entry.kind == "dir":
-                return Text(label, style=cls.DIRECTORY_CUT_STYLE)
-            if entry.executable:
-                return Text(label, style=cls.EXECUTABLE_CUT_STYLE)
-            return Text(label, style=cls.CUT_STYLE)
-
-        # シンボリックリンク
-        if entry.symlink:
-            if entry.selected:
-                return Text(label, style=cls.SYMLINK_SELECTED_STYLE)
-            return Text(label, style=cls.SYMLINK_STYLE)
-
-        # ディレクトリ（実行権限に関わらずディレクトリ色を優先）
-        if entry.kind == "dir":
-            if entry.selected:
-                return Text(label, style=cls.DIRECTORY_SELECTED_STYLE)
-            return Text(label, style=cls.DIRECTORY_STYLE)
-
-        # 実行権限付きファイル
-        if entry.executable:
-            if entry.selected:
-                return Text(label, style=cls.EXECUTABLE_SELECTED_STYLE)
-            return Text(label, style=cls.EXECUTABLE_STYLE)
-
-        # 選択状態
-        if entry.selected:
-            return Text(label, style="bold #55FF55")
-
-        return Text(label)
-
     def _entry_width(self, content: Static) -> int:
         return max(0, content.size.width - self.ENTRY_HORIZONTAL_PADDING)
+
+    def refresh_styles(self) -> None:
+        """Re-resolve component styles after a theme change."""
+
+        self._ft_styles = _resolve_component_styles(self)
+        self._last_render_width = 0
+        self._refresh_rendered_labels()
 
 
 class ChildPane(Vertical):
     """Right-side pane that switches between entries and text preview."""
 
+    COMPONENT_CLASSES = FILE_TYPE_COMPONENT_CLASSES
     PREVIEW_HORIZONTAL_PADDING = 2
+    SELECTED_DIRECTORY_STYLE = "ft-directory-sel"
+    SELECTED_CUT_STYLE = "ft-cut"
 
     def __init__(
         self,
@@ -236,6 +370,7 @@ class ChildPane(Vertical):
     ) -> None:
         super().__init__(id=id, classes=classes)
         self._state = state
+        self._ft_styles: dict[str, Style] = {}
         self._last_render_width = 0
 
     @property
@@ -253,7 +388,13 @@ class ChildPane(Vertical):
     def compose(self) -> ComposeResult:
         yield Label(self._state.title, classes="pane-title")
         list_content = Static(
-            SidePane._render_entries(self._state.entries, 0),
+            _render_file_entries(
+                self._state.entries,
+                0,
+                {},
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+            ),
             id=self.list_view_id,
             classes="pane-list",
         )
@@ -277,6 +418,7 @@ class ChildPane(Vertical):
         yield permissions
 
     def on_mount(self) -> None:
+        self._ft_styles = _resolve_component_styles(self)
         self.call_after_refresh(self._refresh_rendered_content)
 
     def on_resize(self, _event: events.Resize) -> None:
@@ -311,7 +453,15 @@ class ChildPane(Vertical):
         render_width = max(0, widget.size.width - SidePane.ENTRY_HORIZONTAL_PADDING)
         if render_width <= 0 or render_width == self._last_render_width:
             return
-        widget.update(SidePane._render_entries(self._state.entries, render_width))
+        widget.update(
+            _render_file_entries(
+                self._state.entries,
+                render_width,
+                self._ft_styles,
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+            )
+        )
         self._last_render_width = render_width
 
     def _list_widget(self) -> Static:
@@ -353,24 +503,20 @@ class ChildPane(Vertical):
             code_width=max(1, render_width),
         )
 
+    def refresh_styles(self) -> None:
+        """Re-resolve component styles after a theme change."""
+
+        self._ft_styles = _resolve_component_styles(self)
+        self._last_render_width = 0
+        self._refresh_rendered_content()
+
 
 class MainPane(Vertical):
     """Center pane with detailed columns for the current directory."""
 
     COLUMN_LABELS = ("Sel", "Name", "Size", "Modified")
     COLUMN_KEYS = ("sel", "name", "size", "modified")
-    SELECTED_STYLE = "bold #55FF55"
-    CUT_STYLE = "bright_black dim"
-    SELECTED_CUT_STYLE = "bold bright_black"
-    EXECUTABLE_STYLE = "bold #55FF55"
-    EXECUTABLE_SELECTED_STYLE = "bold #55FF55"
-    EXECUTABLE_CUT_STYLE = "bold #55FF55 dim"
-    DIRECTORY_STYLE = "bold #5555FF"
-    DIRECTORY_SELECTED_STYLE = "bold #5555FF"
-    DIRECTORY_CUT_STYLE = "bold #5555FF dim"
-    SYMLINK_STYLE = "bold #55FFFF"
-    SYMLINK_SELECTED_STYLE = "bold #55FFFF"
-    SYMLINK_CUT_STYLE = "bold #55FFFF dim"
+    COMPONENT_CLASSES = FILE_TYPE_COMPONENT_CLASSES
     NAME_MIN_WIDTH = 3
     FIXED_COLUMN_PREFERRED_WIDTHS = {
         "sel": 1,
@@ -403,6 +549,7 @@ class MainPane(Vertical):
         self._cursor_index = cursor_index
         self._cursor_visible = cursor_visible
         self._context_input = context_input
+        self._ft_styles: dict[str, Style] = {}
         self._last_table_width = 0
 
     @property
@@ -430,6 +577,7 @@ class MainPane(Vertical):
 
     def on_mount(self) -> None:
         """Populate the table after the widget is attached to an app."""
+        self._ft_styles = _resolve_component_styles(self)
         table = self.query_one(DataTable)
         table.cursor_type = "row"
         table.show_cursor = self._cursor_visible
@@ -665,20 +813,19 @@ class MainPane(Vertical):
     def _row_key(entry: PaneEntry, index: int) -> str:
         return entry.path or f"__row__:{index}"
 
-    @classmethod
     def _build_row_cells(
-        cls,
+        self,
         entry: PaneEntry,
         column_widths: dict[str, int],
     ) -> tuple[Text, Text, Text, Text]:
         return (
-            cls._render_cell(entry.selection_marker, entry),
-            cls._render_cell(
+            self._render_cell(entry.selection_marker, entry),
+            self._render_cell(
                 truncate_middle(build_entry_label(entry), column_widths["name"]),
                 entry,
             ),
-            cls._render_cell(entry.size_label, entry),
-            cls._render_cell(entry.modified_label, entry),
+            self._render_cell(entry.size_label, entry),
+            self._render_cell(entry.modified_label, entry),
         )
 
     # -- Column layout ----------------------------------------------------------
@@ -719,35 +866,22 @@ class MainPane(Vertical):
 
     # -- Style / rendering ------------------------------------------------------
 
-    @classmethod
-    def _entry_style(cls, entry: PaneEntry) -> str | None:
-        if entry.cut:
-            if entry.symlink:
-                return cls.SYMLINK_CUT_STYLE
-            if entry.kind == "dir":
-                return cls.DIRECTORY_CUT_STYLE
-            if entry.executable:
-                return cls.EXECUTABLE_CUT_STYLE
-            if entry.selected:
-                return cls.SELECTED_CUT_STYLE
-            return cls.CUT_STYLE
-        if entry.symlink:
-            if entry.selected:
-                return cls.SYMLINK_SELECTED_STYLE
-            return cls.SYMLINK_STYLE
-        if entry.kind == "dir":
-            if entry.selected:
-                return cls.DIRECTORY_SELECTED_STYLE
-            return cls.DIRECTORY_STYLE
-        if entry.executable:
-            if entry.selected:
-                return cls.EXECUTABLE_SELECTED_STYLE
-            return cls.EXECUTABLE_STYLE
-        if entry.selected:
-            return cls.SELECTED_STYLE
-        return None
+    def _entry_style(self, entry: PaneEntry) -> Style | None:
+        return _style_without_background(
+            _ft_resolve_style(
+                entry,
+                self._ft_styles,
+                selected_directory_style="ft-directory-sel-table",
+                selected_cut_style="ft-selected-cut",
+            )
+        )
 
-    @classmethod
-    def _render_cell(cls, value: str, entry: PaneEntry) -> Text:
-        style = cls._entry_style(entry)
+    def _render_cell(self, value: str, entry: PaneEntry) -> Text:
+        style = self._entry_style(entry)
         return Text(value) if style is None else Text(value, style=style)
+
+    def refresh_styles(self) -> None:
+        """Re-resolve component styles after a theme change."""
+
+        self._ft_styles = _resolve_component_styles(self)
+        self._rebuild_table(self.query_one(DataTable))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from rich.style import Style
 from rich.text import Text
 from textual.css.query import NoMatches
 from textual.widgets import DataTable, Label, Static
@@ -57,6 +58,7 @@ from peneo.state import (
 from peneo.state.selectors import compute_current_pane_visible_window, select_command_palette_state
 from peneo.ui import (
     AttributeDialog,
+    ChildPane,
     CommandPalette,
     ConfigDialog,
     ConflictDialog,
@@ -64,6 +66,7 @@ from peneo.ui import (
     HelpBar,
     InputBar,
     ShellCommandDialog,
+    SidePane,
     SplitTerminalPane,
     StatusBar,
     SummaryBar,
@@ -102,6 +105,43 @@ def _build_snapshot(
             entries=child_entries,
         ),
     )
+
+
+def _normalize_rich_style(style: str | Style | None) -> Style | None:
+    if style is None:
+        return None
+    if isinstance(style, Style):
+        return style
+    return Style.parse(style)
+
+
+def _style_without_background(style: Style) -> Style:
+    return Style(
+        color=style.color,
+        bold=style.bold,
+        dim=style.dim,
+        italic=style.italic,
+        underline=style.underline,
+        blink=style.blink,
+        blink2=style.blink2,
+        reverse=style.reverse,
+        conceal=style.conceal,
+        strike=style.strike,
+        underline2=style.underline2,
+        frame=style.frame,
+        encircle=style.encircle,
+        overline=style.overline,
+        link=style.link,
+        meta=style.meta,
+    )
+
+
+def _text_has_style(renderable: Text, expected_style: Style) -> bool:
+    return any(_normalize_rich_style(span.style) == expected_style for span in renderable.spans)
+
+
+def _text_style_matches(text: Text, expected_style: Style) -> bool:
+    return _normalize_rich_style(text.style) == expected_style
 
 
 async def _wait_for_status_bar(app, timeout: float = 0.5) -> StatusBar:
@@ -840,13 +880,17 @@ async def test_app_live_snapshot_highlights_current_directory_in_parent_pane(tmp
         await _wait_for_snapshot_loaded(app, str(tmp_path))
         await _wait_for_row_count(app, 2)
 
+        parent_pane = app.query_one("#parent-pane", SidePane)
         parent_list = app.query_one("#parent-pane-list", Static)
         parent_renderable = parent_list.renderable
 
         assert app.app_state.parent_pane.cursor_path == str(tmp_path)
         assert isinstance(parent_renderable, Text)
         assert tmp_path.name in parent_renderable.plain.splitlines()
-        assert any(span.style == "bold white on #5555FF" for span in parent_renderable.spans)
+        assert _text_has_style(
+            parent_renderable,
+            _style_without_background(parent_pane.get_component_rich_style("ft-directory-sel")),
+        )
 
 
 @pytest.mark.asyncio
@@ -875,6 +919,7 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
         await _wait_for_parent_entries(app, ["peneo-app", "sibling"])
         await _wait_for_child_entries(app, ["spec.md"])
 
+        parent_pane = app.query_one("#parent-pane", SidePane)
         parent_list = app.query_one("#parent-pane-list", Static)
         current_table = app.query_one("#current-pane-table", DataTable)
         child_list = app.query_one("#child-pane-list", Static)
@@ -894,7 +939,10 @@ async def test_app_renders_loaded_three_pane_shell() -> None:
         assert parent_entries == ["peneo-app", "sibling"]
         parent_renderable = parent_list.renderable
         assert isinstance(parent_renderable, Text)
-        assert any(span.style == "bold white on #5555FF" for span in parent_renderable.spans)
+        assert _text_has_style(
+            parent_renderable,
+            _style_without_background(parent_pane.get_component_rich_style("ft-directory-sel")),
+        )
         assert headers == ["Sel", "Name", "Size", "Modified"]
         assert current_table.row_count == 2
         assert child_entries == ["spec.md"]
@@ -1403,11 +1451,17 @@ async def test_app_keyboard_input_updates_selection_and_child_pane() -> None:
         assert str(status_bar.renderable) == ""
 
         current_table = app.query_one("#current-pane-table", DataTable)
+        current_pane = app.query_one("#current-pane", MainPane)
         first_row = current_table.get_row_at(0)
 
         assert isinstance(first_row[0], Text)
         assert first_row[0].plain == "*"
-        assert first_row[0].style == "bold #5555FF"
+        assert _text_style_matches(
+            first_row[0],
+            _style_without_background(
+                current_pane.get_component_rich_style("ft-directory-sel-table")
+            ),
+        )
         assert first_row[1].plain == "docs"
         await _wait_for_child_pane_runtime_idle(app, timeout=1.0)
 
@@ -1574,13 +1628,17 @@ async def test_app_cut_marks_row_with_dimmed_style() -> None:
         await asyncio.sleep(0.05)
 
         current_table = app.query_one("#current-pane-table", DataTable)
+        current_pane = app.query_one("#current-pane", MainPane)
         first_row = current_table.get_row_at(0)
 
         assert app.app_state.clipboard.mode == "cut"
         assert app.app_state.clipboard.paths == (f"{path}/docs",)
         assert isinstance(first_row[1], Text)
         assert first_row[1].plain == "docs"
-        assert first_row[1].style == "bold #5555FF dim"
+        assert _text_style_matches(
+            first_row[1],
+            _style_without_background(current_pane.get_component_rich_style("ft-directory-cut")),
+        )
 
 
 @pytest.mark.asyncio
@@ -3543,7 +3601,7 @@ async def test_app_command_palette_opens_config_dialog_and_saves_changes() -> No
 
 
 @pytest.mark.asyncio
-async def test_app_config_dialog_save_updates_theme() -> None:
+async def test_app_config_dialog_save_updates_theme(monkeypatch) -> None:
     path = "/tmp/peneo-command-palette-theme"
     loader = FakeBrowserSnapshotLoader(
         snapshots={
@@ -3567,6 +3625,30 @@ async def test_app_config_dialog_save_updates_theme() -> None:
 
     async with app.run_test() as pilot:
         await _wait_for_snapshot_loaded(app, path)
+        parent_pane = app.query_one("#parent-pane", SidePane)
+        child_pane = app.query_one("#child-pane", ChildPane)
+        current_pane = app.query_one("#current-pane", MainPane)
+        refresh_calls = {"parent": 0, "current": 0, "child": 0}
+
+        original_parent_refresh = parent_pane.refresh_styles
+        original_current_refresh = current_pane.refresh_styles
+        original_child_refresh = child_pane.refresh_styles
+
+        def track_parent_refresh() -> None:
+            refresh_calls["parent"] += 1
+            original_parent_refresh()
+
+        def track_current_refresh() -> None:
+            refresh_calls["current"] += 1
+            original_current_refresh()
+
+        def track_child_refresh() -> None:
+            refresh_calls["child"] += 1
+            original_child_refresh()
+
+        monkeypatch.setattr(parent_pane, "refresh_styles", track_parent_refresh)
+        monkeypatch.setattr(current_pane, "refresh_styles", track_current_refresh)
+        monkeypatch.setattr(child_pane, "refresh_styles", track_child_refresh)
         await pilot.press(":")
         await pilot.press("c", "o", "n", "f", "i", "g")
         await pilot.press("enter")
@@ -3584,6 +3666,19 @@ async def test_app_config_dialog_save_updates_theme() -> None:
         _saved_path, saved_config = config_save_service.saved_requests[0]
         assert saved_config.display.theme == "textual-light"
         assert app.theme == "textual-light"
+
+        parent_list = app.query_one("#parent-pane-list", Static)
+        parent_renderable = parent_list.renderable
+        current_table = app.query_one("#current-pane-table", DataTable)
+        updated_parent_style = parent_pane.get_component_rich_style("ft-directory-sel")
+        updated_table_style = current_pane.get_component_rich_style("ft-directory-sel-table")
+        first_row = current_table.get_row_at(0)
+
+        assert refresh_calls == {"parent": 1, "current": 1, "child": 1}
+        assert isinstance(parent_renderable, Text)
+        assert _text_has_style(parent_renderable, _style_without_background(updated_parent_style))
+        assert isinstance(first_row[0], Text)
+        assert _text_style_matches(first_row[0], _style_without_background(updated_table_style))
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -1,5 +1,32 @@
+from rich.style import Style
+
 from peneo.models import PaneEntry
-from peneo.ui.panes import MainPane, SidePane, build_entry_label, truncate_middle
+from peneo.ui.panes import (
+    MainPane,
+    _ft_resolve_style,
+    _render_file_label,
+    _style_without_background,
+    build_entry_label,
+    truncate_middle,
+)
+
+
+def _style_map() -> dict[str, Style]:
+    return {
+        "ft-cut": Style.parse("dim"),
+        "ft-directory": Style.parse("bold blue"),
+        "ft-directory-cut": Style.parse("bold blue dim"),
+        "ft-directory-sel": Style.parse("bold underline blue"),
+        "ft-directory-sel-table": Style.parse("bold blue"),
+        "ft-executable": Style.parse("bold green"),
+        "ft-executable-cut": Style.parse("bold green dim"),
+        "ft-executable-sel": Style.parse("bold green"),
+        "ft-selected": Style.parse("bold green"),
+        "ft-selected-cut": Style.parse("bold bright_black"),
+        "ft-symlink": Style.parse("bold cyan"),
+        "ft-symlink-cut": Style.parse("bold cyan dim"),
+        "ft-symlink-sel": Style.parse("bold cyan"),
+    }
 
 
 def test_truncate_middle_keeps_text_when_width_is_sufficient() -> None:
@@ -46,97 +73,246 @@ def test_pane_entry_defaults_executable_to_false() -> None:
     assert entry.executable is False
 
 
-def test_side_pane_selected_directory_uses_background_highlight() -> None:
+def test_side_pane_selected_directory_uses_text_only_highlight() -> None:
+    styles = _style_map()
     entry = PaneEntry("docs", "dir", selected=True)
 
-    rendered = SidePane._render_label(entry)
+    rendered = _render_file_label(
+        entry,
+        0,
+        styles,
+        selected_directory_style="ft-directory-sel",
+        selected_cut_style="ft-cut",
+    )
 
-    assert rendered.style == "bold white on #5555FF"
+    assert rendered.style == styles["ft-directory-sel"]
 
 
-# -- MainPane._entry_style ------------------------------------------------------
+# -- File type style resolution -------------------------------------------------
 
 
 def test_entry_style_cut_symlink() -> None:
+    styles = _style_map()
     entry = PaneEntry("link", "file", cut=True, symlink=True)
-    assert MainPane._entry_style(entry) == MainPane.SYMLINK_CUT_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-symlink-cut"]
+    )
 
 
 def test_entry_style_cut_directory() -> None:
+    styles = _style_map()
     entry = PaneEntry("dir", "dir", cut=True)
-    assert MainPane._entry_style(entry) == MainPane.DIRECTORY_CUT_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-directory-cut"]
+    )
 
 
 def test_entry_style_cut_executable() -> None:
+    styles = _style_map()
     entry = PaneEntry("script.sh", "file", cut=True, executable=True)
-    assert MainPane._entry_style(entry) == MainPane.EXECUTABLE_CUT_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-executable-cut"]
+    )
 
 
 def test_entry_style_cut_selected() -> None:
+    styles = _style_map()
     entry = PaneEntry("file.txt", "file", cut=True, selected=True)
-    assert MainPane._entry_style(entry) == MainPane.SELECTED_CUT_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-selected-cut"]
+    )
 
 
 def test_entry_style_cut_plain() -> None:
+    styles = _style_map()
     entry = PaneEntry("file.txt", "file", cut=True)
-    assert MainPane._entry_style(entry) == MainPane.CUT_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-cut"]
+    )
 
 
 def test_entry_style_symlink_selected() -> None:
+    styles = _style_map()
     entry = PaneEntry("link", "file", symlink=True, selected=True)
-    assert MainPane._entry_style(entry) == MainPane.SYMLINK_SELECTED_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-symlink-sel"]
+    )
 
 
 def test_entry_style_symlink() -> None:
+    styles = _style_map()
     entry = PaneEntry("link", "file", symlink=True)
-    assert MainPane._entry_style(entry) == MainPane.SYMLINK_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-symlink"]
+    )
 
 
 def test_entry_style_directory_selected() -> None:
+    styles = _style_map()
     entry = PaneEntry("docs", "dir", selected=True)
-    assert MainPane._entry_style(entry) == MainPane.DIRECTORY_SELECTED_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-directory-sel-table"]
+    )
 
 
 def test_entry_style_directory() -> None:
+    styles = _style_map()
     entry = PaneEntry("docs", "dir")
-    assert MainPane._entry_style(entry) == MainPane.DIRECTORY_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-directory"]
+    )
 
 
 def test_entry_style_executable_selected() -> None:
+    styles = _style_map()
     entry = PaneEntry("run.sh", "file", executable=True, selected=True)
-    assert MainPane._entry_style(entry) == MainPane.EXECUTABLE_SELECTED_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-executable-sel"]
+    )
 
 
 def test_entry_style_executable() -> None:
+    styles = _style_map()
     entry = PaneEntry("run.sh", "file", executable=True)
-    assert MainPane._entry_style(entry) == MainPane.EXECUTABLE_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-executable"]
+    )
 
 
 def test_entry_style_selected() -> None:
+    styles = _style_map()
     entry = PaneEntry("file.txt", "file", selected=True)
-    assert MainPane._entry_style(entry) == MainPane.SELECTED_STYLE
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        == styles["ft-selected"]
+    )
 
 
 def test_entry_style_plain() -> None:
+    styles = _style_map()
     entry = PaneEntry("file.txt", "file")
-    assert MainPane._entry_style(entry) is None
+    assert (
+        _ft_resolve_style(
+            entry,
+            styles,
+            selected_directory_style="ft-directory-sel-table",
+            selected_cut_style="ft-selected-cut",
+        )
+        is None
+    )
 
 
-# -- MainPane._render_cell ------------------------------------------------------
+# -- Label rendering ------------------------------------------------------------
 
 
 def test_render_cell_plain_entry() -> None:
+    styles = _style_map()
     entry = PaneEntry("file.txt", "file")
-    result = MainPane._render_cell("file.txt", entry)
+    result = _render_file_label(
+        entry,
+        0,
+        styles,
+        selected_directory_style="ft-directory-sel-table",
+        selected_cut_style="ft-selected-cut",
+    )
     assert result.plain == "file.txt"
     assert not result.style
 
 
 def test_render_cell_selected_entry() -> None:
+    styles = _style_map()
     entry = PaneEntry("file.txt", "file", selected=True)
-    result = MainPane._render_cell("file.txt", entry)
+    result = _render_file_label(
+        entry,
+        0,
+        styles,
+        selected_directory_style="ft-directory-sel-table",
+        selected_cut_style="ft-selected-cut",
+    )
     assert result.plain == "file.txt"
-    assert result.style == MainPane.SELECTED_STYLE
+    assert result.style == styles["ft-selected"]
+
+
+def test_style_without_background_keeps_foreground_and_text_attributes() -> None:
+    style = Style.parse("bold blue on black")
+
+    stripped = _style_without_background(style)
+
+    assert stripped is not None
+    assert stripped.color == style.color
+    assert stripped.bgcolor is None
+    assert stripped.bold is True
 
 
 # -- MainPane._shrink_fixed_columns ---------------------------------------------


### PR DESCRIPTION
## Summary
- ペインのファイル種別スタイルを `app.tcss` の component class に集約
- `SidePane` / `ChildPane` / `MainPane` の style 解決を共通化
- テーマ変更時に各ペインが style を再解決して再描画するよう更新
- directory 表示の背景塗りを除去し、Parent/Child/Current の見え方を揃える

## Testing
- `uv run ruff check src/peneo/app.py src/peneo/app_shell.py src/peneo/ui/panes.py tests/test_app.py tests/test_ui_panes.py`
- `uv run pytest tests/test_ui_panes.py`
- `uv run pytest tests/test_app.py`

Refs #488
