### PR TITLE
#450 Add Textual builtin theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The supported settings are:
 | `display` | `show_preview` | `true` / `false` | Shows the text-file preview in the right pane. Defaults to `true`. Directory and archive child panes are unaffected. grep result context preview follows the same setting. |
 | `display` | `show_help_bar` | `true` / `false` | Shows the help bar at the bottom of the screen. Defaults to `true`. The help bar is always shown when the command palette or split terminal is open, regardless of this setting. |
 | `display` | `theme` | Any built-in Textual theme, for example `textual-dark`, `textual-light`, `dracula`, or `tokyo-night` | Default UI theme applied on startup and after saving from the settings editor. |
+| `display` | `preview_syntax_theme` | `auto` or a supported Pygments style, for example `one-dark`, `xcode`, `nord`, or `gruvbox-dark` | Syntax-highlighting colors used by the right-pane text preview. `auto` keeps the current light/dark-based default selection. |
 | `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. |
 | `display` | `default_sort_descending` | `true` / `false` | Starts the main-pane sort in descending order when enabled. |
 | `display` | `directories_first` | `true` / `false` | Keeps directories grouped before files in the main pane. |
@@ -345,6 +346,7 @@ show_directory_sizes = true
 show_preview = true
 show_help_bar = true
 theme = "textual-dark"
+preview_syntax_theme = "auto"
 default_sort_field = "name"
 default_sort_descending = false
 directories_first = true
@@ -365,6 +367,7 @@ paths = ["/home/user/src", "/home/user/docs"]
 Invalid config values do not stop startup. Peneo falls back to built-in defaults and shows a warning after the initial directory load.
 When logging is enabled, startup failures and unhandled exceptions are appended to the configured log file for later investigation.
 The accepted `display.theme` values come from the built-in themes shipped with the installed Textual version.
+The accepted `display.preview_syntax_theme` values are `auto` plus the Pygments styles available in the installed environment.
 
 ## Command Palette
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The supported settings are:
 | `display` | `show_directory_sizes` | `true` / `false` | Shows recursive directory sizes in the current pane. Defaults to `true`. Large directories can be expensive to scan. Peneo also calculates sizes automatically while the main pane is sorted by `size`. |
 | `display` | `show_preview` | `true` / `false` | Shows the text-file preview in the right pane. Defaults to `true`. Directory and archive child panes are unaffected. grep result context preview follows the same setting. |
 | `display` | `show_help_bar` | `true` / `false` | Shows the help bar at the bottom of the screen. Defaults to `true`. The help bar is always shown when the command palette or split terminal is open, regardless of this setting. |
-| `display` | `theme` | `textual-dark` / `textual-light` | Default UI theme applied on startup and after saving from the settings editor. |
+| `display` | `theme` | Any built-in Textual theme, for example `textual-dark`, `textual-light`, `dracula`, or `tokyo-night` | Default UI theme applied on startup and after saving from the settings editor. |
 | `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. |
 | `display` | `default_sort_descending` | `true` / `false` | Starts the main-pane sort in descending order when enabled. |
 | `display` | `directories_first` | `true` / `false` | Keeps directories grouped before files in the main pane. |
@@ -364,6 +364,7 @@ paths = ["/home/user/src", "/home/user/docs"]
 
 Invalid config values do not stop startup. Peneo falls back to built-in defaults and shows a warning after the initial directory load.
 When logging is enabled, startup failures and unhandled exceptions are appended to the configured log file for later investigation.
+The accepted `display.theme` values come from the built-in themes shipped with the installed Textual version.
 
 ## Command Palette
 

--- a/src/peneo/models/__init__.py
+++ b/src/peneo/models/__init__.py
@@ -13,6 +13,7 @@ from .config import (
     HelpBarConfig,
     LoggingConfig,
     PasteConflictAction,
+    PreviewSyntaxTheme,
     TerminalConfig,
 )
 from .external_launch import ExternalLaunchKind, ExternalLaunchRequest
@@ -122,6 +123,7 @@ __all__ = [
     "MutationResultLevel",
     "PaneEntry",
     "PasteConflictAction",
+    "PreviewSyntaxTheme",
     "SplitTerminalViewState",
     "PasteConflict",
     "PasteConflictPrompt",

--- a/src/peneo/models/config.py
+++ b/src/peneo/models/config.py
@@ -3,8 +3,10 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
+from peneo.theme_support import DEFAULT_APP_THEME
+
 ConfigSortField = Literal["name", "modified", "size"]
-ConfigTheme = Literal["textual-dark", "textual-light"]
+ConfigTheme = str
 ConfigLogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 PasteConflictAction = Literal["overwrite", "skip", "rename", "prompt"]
 
@@ -33,7 +35,7 @@ class DisplayConfig:
     show_directory_sizes: bool = True
     show_preview: bool = True
     show_help_bar: bool = True
-    theme: ConfigTheme = "textual-dark"
+    theme: ConfigTheme = DEFAULT_APP_THEME
     default_sort_field: ConfigSortField = "name"
     default_sort_descending: bool = False
     directories_first: bool = True

--- a/src/peneo/models/config.py
+++ b/src/peneo/models/config.py
@@ -3,10 +3,11 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from peneo.theme_support import DEFAULT_APP_THEME
+from peneo.theme_support import AUTO_PREVIEW_SYNTAX_THEME, DEFAULT_APP_THEME
 
 ConfigSortField = Literal["name", "modified", "size"]
 ConfigTheme = str
+PreviewSyntaxTheme = str
 ConfigLogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 PasteConflictAction = Literal["overwrite", "skip", "rename", "prompt"]
 
@@ -36,6 +37,7 @@ class DisplayConfig:
     show_preview: bool = True
     show_help_bar: bool = True
     theme: ConfigTheme = DEFAULT_APP_THEME
+    preview_syntax_theme: PreviewSyntaxTheme = AUTO_PREVIEW_SYNTAX_THEME
     default_sort_field: ConfigSortField = "name"
     default_sort_descending: bool = False
     directories_first: bool = True

--- a/src/peneo/services/config.py
+++ b/src/peneo/services/config.py
@@ -21,7 +21,12 @@ from peneo.models import (
     TerminalConfig,
 )
 from peneo.models.config import BehaviorConfig
-from peneo.theme_support import SUPPORTED_APP_THEME_DISPLAY, SUPPORTED_APP_THEMES
+from peneo.theme_support import (
+    SUPPORTED_APP_THEME_DISPLAY,
+    SUPPORTED_APP_THEMES,
+    SUPPORTED_PREVIEW_SYNTAX_THEME_DISPLAY,
+    SUPPORTED_PREVIEW_SYNTAX_THEMES,
+)
 
 SystemNameResolver = Callable[[], str]
 EnvironmentVariableReader = Callable[[str], str | None]
@@ -36,6 +41,7 @@ class ConfigSaveService(Protocol):
 
 _VALID_SORT_FIELDS = frozenset({"name", "modified", "size"})
 _VALID_THEMES = frozenset(SUPPORTED_APP_THEMES)
+_VALID_PREVIEW_SYNTAX_THEMES = frozenset(SUPPORTED_PREVIEW_SYNTAX_THEMES)
 _VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 _VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
 _VALID_TERMINAL_EDITOR_NAMES = frozenset(
@@ -226,6 +232,15 @@ def _load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
             default=config.theme,
             valid_values=_VALID_THEMES,
             valid_display=SUPPORTED_APP_THEME_DISPLAY,
+            section_name="display",
+            warnings=warnings,
+        ),
+        preview_syntax_theme=_read_enum(
+            validated,
+            key="preview_syntax_theme",
+            default=config.preview_syntax_theme,
+            valid_values=_VALID_PREVIEW_SYNTAX_THEMES,
+            valid_display=SUPPORTED_PREVIEW_SYNTAX_THEME_DISPLAY,
             section_name="display",
             warnings=warnings,
         ),
@@ -528,6 +543,7 @@ def _render_display_section(config: AppConfig) -> str:
         f"show_directory_sizes = {_render_bool(config.display.show_directory_sizes)}\n"
         f"show_preview = {_render_bool(config.display.show_preview)}\n"
         f'theme = "{config.display.theme}"\n'
+        f'preview_syntax_theme = "{config.display.preview_syntax_theme}"\n'
         f'default_sort_field = "{config.display.default_sort_field}"\n'
         f"default_sort_descending = {_render_bool(config.display.default_sort_descending)}\n"
         f"directories_first = {_render_bool(config.display.directories_first)}"

--- a/src/peneo/services/config.py
+++ b/src/peneo/services/config.py
@@ -21,6 +21,7 @@ from peneo.models import (
     TerminalConfig,
 )
 from peneo.models.config import BehaviorConfig
+from peneo.theme_support import SUPPORTED_APP_THEME_DISPLAY, SUPPORTED_APP_THEMES
 
 SystemNameResolver = Callable[[], str]
 EnvironmentVariableReader = Callable[[str], str | None]
@@ -34,7 +35,7 @@ class ConfigSaveService(Protocol):
     def save(self, *, path: str, config: AppConfig) -> str: ...
 
 _VALID_SORT_FIELDS = frozenset({"name", "modified", "size"})
-_VALID_THEMES = frozenset({"textual-dark", "textual-light"})
+_VALID_THEMES = frozenset(SUPPORTED_APP_THEMES)
 _VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 _VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
 _VALID_TERMINAL_EDITOR_NAMES = frozenset(
@@ -224,7 +225,7 @@ def _load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
             key="theme",
             default=config.theme,
             valid_values=_VALID_THEMES,
-            valid_display="textual-dark, textual-light",
+            valid_display=SUPPORTED_APP_THEME_DISPLAY,
             section_name="display",
             warnings=warnings,
         ),

--- a/src/peneo/state/models.py
+++ b/src/peneo/state/models.py
@@ -54,11 +54,13 @@ ConfigFieldId = Literal[
     "display.show_directory_sizes",
     "display.show_preview",
     "display.theme",
+    "display.preview_syntax_theme",
     "display.default_sort_field",
     "display.default_sort_descending",
     "display.directories_first",
     "behavior.confirm_delete",
     "behavior.paste_conflict_action",
+    "logging.level",
 ]
 
 

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -19,7 +19,7 @@ from peneo.models import (
     RenameRequest,
     UndoEntry,
 )
-from peneo.theme_support import SUPPORTED_APP_THEMES
+from peneo.theme_support import SUPPORTED_APP_THEMES, SUPPORTED_PREVIEW_SYNTAX_THEMES
 
 from .actions import Action, RequestDirectorySizes
 from .effects import (
@@ -53,6 +53,7 @@ ReducerFn = Callable[[AppState, Action], ReduceResult]
 
 CONFIG_SORT_FIELDS = ("name", "modified", "size")
 CONFIG_THEMES = SUPPORTED_APP_THEMES
+CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
 CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
 CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
@@ -698,6 +699,18 @@ def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) 
                 ),
             ),
         )
+    if field_id == "display.preview_syntax_theme":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                preview_syntax_theme=cycle_choice(
+                    CONFIG_PREVIEW_SYNTAX_THEMES,
+                    config.display.preview_syntax_theme,
+                    delta,
+                ),
+            ),
+        )
     if field_id == "display.default_sort_field":
         return replace(
             config,
@@ -779,6 +792,7 @@ def config_editor_field_ids() -> tuple[str, ...]:
         "display.theme",
         "display.show_directory_sizes",
         "display.show_preview",
+        "display.preview_syntax_theme",
         "display.show_help_bar",
         "display.default_sort_field",
         "display.default_sort_descending",
@@ -796,6 +810,7 @@ def config_editor_labels() -> tuple[str, ...]:
         "Theme",
         "Show directory sizes",
         "Show preview",
+        "Preview syntax theme",
         "Show help bar",
         "Default sort field",
         "Default sort descending",

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -19,6 +19,7 @@ from peneo.models import (
     RenameRequest,
     UndoEntry,
 )
+from peneo.theme_support import SUPPORTED_APP_THEMES
 
 from .actions import Action, RequestDirectorySizes
 from .effects import (
@@ -51,7 +52,7 @@ from .selectors import select_target_paths, select_visible_current_entry_states
 ReducerFn = Callable[[AppState, Action], ReduceResult]
 
 CONFIG_SORT_FIELDS = ("name", "modified", "size")
-CONFIG_THEMES = ("textual-dark", "textual-light")
+CONFIG_THEMES = SUPPORTED_APP_THEMES
 CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
 CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -188,7 +188,10 @@ def _select_child_pane_for_cursor(
     state: AppState,
     cursor_entry: DirectoryEntryState | None,
 ) -> ChildPaneViewState:
-    syntax_theme = _select_child_syntax_theme(state.config.display.theme)
+    syntax_theme = _select_child_syntax_theme(
+        state.config.display.theme,
+        state.config.display.preview_syntax_theme,
+    )
     permissions_label = (
         _format_permissions_detail_label(cursor_entry)
         if cursor_entry
@@ -833,32 +836,38 @@ def select_config_dialog_state(state: AppState) -> ConfigDialogState | None:
         _format_config_line(
             5,
             selected_index,
+            "Preview syntax theme",
+            config.display.preview_syntax_theme,
+        ),
+        _format_config_line(
+            6,
+            selected_index,
             "Show help bar",
             _format_bool(config.display.show_help_bar),
         ),
         _format_config_line(
-            6,
+            7,
             selected_index,
             "Default sort field",
             config.display.default_sort_field,
         ),
         _format_config_line(
-            7,
+            8,
             selected_index,
             "Default sort descending",
             _format_bool(config.display.default_sort_descending),
         ),
         _format_config_line(
-            8, selected_index, "Directories first", _format_bool(config.display.directories_first)
+            9, selected_index, "Directories first", _format_bool(config.display.directories_first)
         ),
         _format_config_line(
-            9, selected_index, "Confirm delete", _format_bool(config.behavior.confirm_delete)
+            10, selected_index, "Confirm delete", _format_bool(config.behavior.confirm_delete)
         ),
         _format_config_line(
-            10, selected_index, "Paste conflict action", config.behavior.paste_conflict_action
+            11, selected_index, "Paste conflict action", config.behavior.paste_conflict_action
         ),
         _format_config_line(
-            11, selected_index, "Log level", config.logging.level
+            12, selected_index, "Log level", config.logging.level
         ),
         "",
         _format_custom_editor_hint(config.editor.command),
@@ -1224,9 +1233,9 @@ def _format_bool(value: bool) -> str:
     return "true" if value else "false"
 
 
-@lru_cache(maxsize=32)
-def _select_child_syntax_theme(app_theme: str) -> str:
-    return preview_syntax_theme_for_app_theme(app_theme)
+@lru_cache(maxsize=128)
+def _select_child_syntax_theme(app_theme: str, preview_syntax_theme: str) -> str:
+    return preview_syntax_theme_for_app_theme(app_theme, preview_syntax_theme)
 
 
 @lru_cache(maxsize=256)

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -29,6 +29,7 @@ from peneo.models import (
     TabItemState,
     ThreePaneShellData,
 )
+from peneo.theme_support import preview_syntax_theme_for_app_theme
 
 from .command_palette import (
     CommandPaletteItem,
@@ -1225,7 +1226,7 @@ def _format_bool(value: bool) -> str:
 
 @lru_cache(maxsize=32)
 def _select_child_syntax_theme(app_theme: str) -> str:
-    return "friendly" if app_theme == "textual-light" else "monokai"
+    return preview_syntax_theme_for_app_theme(app_theme)
 
 
 @lru_cache(maxsize=256)

--- a/src/peneo/theme_support.py
+++ b/src/peneo/theme_support.py
@@ -1,0 +1,17 @@
+"""Theme helpers shared across configuration, reducers, and selectors."""
+
+from textual.theme import BUILTIN_THEMES
+
+DEFAULT_APP_THEME = "textual-dark"
+SUPPORTED_APP_THEMES = tuple(sorted(BUILTIN_THEMES))
+SUPPORTED_APP_THEME_DISPLAY = ", ".join(SUPPORTED_APP_THEMES)
+
+_LIGHT_PREVIEW_SYNTAX_THEME = "friendly"
+_DARK_PREVIEW_SYNTAX_THEME = "monokai"
+
+
+def preview_syntax_theme_for_app_theme(app_theme: str) -> str:
+    """Return the preview syntax theme that matches the active Textual theme."""
+
+    theme = BUILTIN_THEMES.get(app_theme, BUILTIN_THEMES[DEFAULT_APP_THEME])
+    return _DARK_PREVIEW_SYNTAX_THEME if theme.dark else _LIGHT_PREVIEW_SYNTAX_THEME

--- a/src/peneo/theme_support.py
+++ b/src/peneo/theme_support.py
@@ -1,17 +1,34 @@
 """Theme helpers shared across configuration, reducers, and selectors."""
 
+from pygments.styles import get_all_styles
 from textual.theme import BUILTIN_THEMES
 
 DEFAULT_APP_THEME = "textual-dark"
 SUPPORTED_APP_THEMES = tuple(sorted(BUILTIN_THEMES))
 SUPPORTED_APP_THEME_DISPLAY = ", ".join(SUPPORTED_APP_THEMES)
+AUTO_PREVIEW_SYNTAX_THEME = "auto"
+SUPPORTED_PREVIEW_SYNTAX_STYLES = tuple(sorted(get_all_styles()))
+SUPPORTED_PREVIEW_SYNTAX_THEMES = (
+    AUTO_PREVIEW_SYNTAX_THEME,
+    *SUPPORTED_PREVIEW_SYNTAX_STYLES,
+)
+SUPPORTED_PREVIEW_SYNTAX_THEME_DISPLAY = (
+    "auto or a supported Pygments style "
+    "(for example: one-dark, xcode, nord, gruvbox-dark)"
+)
 
 _LIGHT_PREVIEW_SYNTAX_THEME = "friendly"
 _DARK_PREVIEW_SYNTAX_THEME = "monokai"
 
 
-def preview_syntax_theme_for_app_theme(app_theme: str) -> str:
-    """Return the preview syntax theme that matches the active Textual theme."""
+def preview_syntax_theme_for_app_theme(app_theme: str, configured_style: str) -> str:
+    """Return the preview syntax theme for the active Textual theme and config."""
+
+    if (
+        configured_style != AUTO_PREVIEW_SYNTAX_THEME
+        and configured_style in SUPPORTED_PREVIEW_SYNTAX_STYLES
+    ):
+        return configured_style
 
     theme = BUILTIN_THEMES.get(app_theme, BUILTIN_THEMES[DEFAULT_APP_THEME])
     return _DARK_PREVIEW_SYNTAX_THEME if theme.dark else _LIGHT_PREVIEW_SYNTAX_THEME

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,7 +55,12 @@ from peneo.state import (
     PaneState,
     SetTerminalHeight,
 )
-from peneo.state.selectors import compute_current_pane_visible_window, select_command_palette_state
+from peneo.state.selectors import (
+    compute_current_pane_visible_window,
+    select_command_palette_state,
+    select_shell_data,
+)
+from peneo.theme_support import SUPPORTED_PREVIEW_SYNTAX_THEMES
 from peneo.ui import (
     AttributeDialog,
     ChildPane,
@@ -3679,6 +3684,89 @@ async def test_app_config_dialog_save_updates_theme(monkeypatch) -> None:
         assert _text_has_style(parent_renderable, _style_without_background(updated_parent_style))
         assert isinstance(first_row[0], Text)
         assert _text_style_matches(first_row[0], _style_without_background(updated_table_style))
+
+
+@pytest.mark.asyncio
+async def test_app_config_dialog_save_updates_preview_syntax_theme() -> None:
+    path = "/tmp/peneo-command-palette-preview-theme"
+    preview_path = f"{path}/README.md"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(
+                        DirectoryEntryState(path, Path(path).name, "dir"),
+                    ),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(
+                        DirectoryEntryState(
+                            preview_path,
+                            "README.md",
+                            "file",
+                            size_bytes=120,
+                        ),
+                    ),
+                    cursor_path=preview_path,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=preview_path,
+                    preview_title="Preview: README.md",
+                    preview_content="# heading\nbody\n",
+                ),
+            )
+        }
+    )
+    config_save_service = FakeConfigSaveService()
+    app = create_app(
+        snapshot_loader=loader,
+        config_save_service=config_save_service,
+        config_path="/tmp/peneo/config.toml",
+        initial_path=path,
+    )
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        assert select_shell_data(app.app_state).child_pane.syntax_theme == "monokai"
+
+        await pilot.press(":")
+        await pilot.press("c", "o", "n", "f", "i", "g")
+        await pilot.press("enter")
+        await _wait_for_config_dialog(app)
+
+        for _ in range(5):
+            await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.press("s")
+        deadline = asyncio.get_running_loop().time() + 1.5
+        while True:
+            if (
+                len(config_save_service.saved_requests) == 1
+                and app.app_state.pending_config_save_request_id is None
+            ):
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError("config save did not complete")
+            await asyncio.sleep(0.01)
+
+        assert len(config_save_service.saved_requests) == 1
+        _saved_path, saved_config = config_save_service.saved_requests[0]
+        assert saved_config.display.preview_syntax_theme == SUPPORTED_PREVIEW_SYNTAX_THEMES[1]
+        assert (
+            app.app_state.config.display.preview_syntax_theme
+            == SUPPORTED_PREVIEW_SYNTAX_THEMES[1]
+        )
+        assert (
+            select_shell_data(app.app_state).child_pane.syntax_theme
+            == SUPPORTED_PREVIEW_SYNTAX_THEMES[1]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -660,7 +660,7 @@ def test_create_app_applies_configured_startup_state() -> None:
             terminal=TerminalConfig(),
             display=DisplayConfig(
                 show_hidden_files=True,
-                theme="textual-light",
+                theme="dracula",
                 default_sort_field="modified",
                 default_sort_descending=True,
                 directories_first=False,
@@ -673,7 +673,7 @@ def test_create_app_applies_configured_startup_state() -> None:
     )
 
     assert app.app_state.show_hidden is True
-    assert app.theme == "textual-light"
+    assert app.theme == "dracula"
     assert app.app_state.sort.field == "modified"
     assert app.app_state.sort.descending is True
     assert app.app_state.sort.directories_first is False

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -10,6 +10,7 @@ from peneo.models import (
     TerminalConfig,
 )
 from peneo.services.config import AppConfigLoader, LiveConfigSaveService, resolve_config_path
+from peneo.theme_support import SUPPORTED_APP_THEMES
 
 
 def test_resolve_config_path_uses_xdg_directory(tmp_path) -> None:
@@ -59,7 +60,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
         show_hidden_files = true
         show_directory_sizes = true
         show_preview = false
-        theme = "textual-light"
+        theme = "dracula"
         default_sort_field = "modified"
         default_sort_descending = true
         directories_first = false
@@ -87,7 +88,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
     assert result.config.display.show_hidden_files is True
     assert result.config.display.show_directory_sizes is True
     assert result.config.display.show_preview is False
-    assert result.config.display.theme == "textual-light"
+    assert result.config.display.theme == "dracula"
     assert result.config.display.default_sort_field == "modified"
     assert result.config.display.default_sort_descending is True
     assert result.config.display.directories_first is False
@@ -177,7 +178,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
                 show_hidden_files=True,
                 show_directory_sizes=True,
                 show_preview=False,
-                theme="textual-light",
+                theme="tokyo-night",
                 default_sort_field="size",
                 default_sort_descending=True,
                 directories_first=False,
@@ -203,13 +204,31 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
     assert "show_hidden_files = true" in written
     assert "show_directory_sizes = true" in written
     assert "show_preview = false" in written
-    assert 'theme = "textual-light"' in written
+    assert 'theme = "tokyo-night"' in written
     assert 'default_sort_field = "size"' in written
     assert "confirm_delete = false" in written
     assert 'paste_conflict_action = "rename"' in written
     assert "enabled = false" in written
     assert 'path = "/tmp/peneo-errors.log"' in written
     assert 'paths = ["/tmp/project", "/tmp/docs"]' in written
+
+
+def test_loader_accepts_all_supported_builtin_themes(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+
+    for theme_name in SUPPORTED_APP_THEMES:
+        config_path.write_text(
+            f"""
+            [display]
+            theme = "{theme_name}"
+            """,
+            encoding="utf-8",
+        )
+
+        result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+        assert result.warnings == ()
+        assert result.config.display.theme == theme_name
 
 
 def test_loader_treats_blank_logging_path_as_default(tmp_path) -> None:

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -10,7 +10,7 @@ from peneo.models import (
     TerminalConfig,
 )
 from peneo.services.config import AppConfigLoader, LiveConfigSaveService, resolve_config_path
-from peneo.theme_support import SUPPORTED_APP_THEMES
+from peneo.theme_support import SUPPORTED_APP_THEMES, SUPPORTED_PREVIEW_SYNTAX_THEMES
 
 
 def test_resolve_config_path_uses_xdg_directory(tmp_path) -> None:
@@ -37,6 +37,7 @@ def test_loader_creates_default_config_when_missing(tmp_path) -> None:
     assert '#   "gnome-terminal --working-directory={path}",' in written
     assert '# command = "nvim -u NONE"' in written
     assert 'theme = "textual-dark"' in written
+    assert 'preview_syntax_theme = "auto"' in written
     assert "show_directory_sizes = true" in written
     assert "show_preview = true" in written
     assert 'default_sort_field = "name"' in written
@@ -61,6 +62,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
         show_directory_sizes = true
         show_preview = false
         theme = "dracula"
+        preview_syntax_theme = "one-dark"
         default_sort_field = "modified"
         default_sort_descending = true
         directories_first = false
@@ -89,6 +91,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
     assert result.config.display.show_directory_sizes is True
     assert result.config.display.show_preview is False
     assert result.config.display.theme == "dracula"
+    assert result.config.display.preview_syntax_theme == "one-dark"
     assert result.config.display.default_sort_field == "modified"
     assert result.config.display.default_sort_descending is True
     assert result.config.display.directories_first is False
@@ -114,6 +117,7 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
         show_directory_sizes = "yes"
         show_preview = "yes"
         theme = "bad-theme"
+        preview_syntax_theme = "bad-preview-style"
         default_sort_field = "invalid"
 
         [behavior]
@@ -138,13 +142,14 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
     assert result.config.display.show_directory_sizes is True
     assert result.config.display.show_preview is True
     assert result.config.display.theme == "textual-dark"
+    assert result.config.display.preview_syntax_theme == "auto"
     assert result.config.display.default_sort_field == "name"
     assert result.config.behavior.confirm_delete is True
     assert result.config.behavior.paste_conflict_action == "prompt"
     assert result.config.logging.enabled is True
     assert result.config.logging.path is None
     assert result.config.bookmarks.paths == ()
-    assert len(result.warnings) == 12
+    assert len(result.warnings) == 13
 
 
 def test_loader_warns_for_invalid_editor_command_syntax(tmp_path) -> None:
@@ -179,6 +184,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
                 show_directory_sizes=True,
                 show_preview=False,
                 theme="tokyo-night",
+                preview_syntax_theme="one-dark",
                 default_sort_field="size",
                 default_sort_descending=True,
                 directories_first=False,
@@ -205,6 +211,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
     assert "show_directory_sizes = true" in written
     assert "show_preview = false" in written
     assert 'theme = "tokyo-night"' in written
+    assert 'preview_syntax_theme = "one-dark"' in written
     assert 'default_sort_field = "size"' in written
     assert "confirm_delete = false" in written
     assert 'paste_conflict_action = "rename"' in written
@@ -229,6 +236,24 @@ def test_loader_accepts_all_supported_builtin_themes(tmp_path) -> None:
 
         assert result.warnings == ()
         assert result.config.display.theme == theme_name
+
+
+def test_loader_accepts_all_supported_preview_syntax_themes(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+
+    for theme_name in SUPPORTED_PREVIEW_SYNTAX_THEMES:
+        config_path.write_text(
+            f"""
+            [display]
+            preview_syntax_theme = "{theme_name}"
+            """,
+            encoding="utf-8",
+        )
+
+        result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+        assert result.warnings == ()
+        assert result.config.display.preview_syntax_theme == theme_name
 
 
 def test_loader_treats_blank_logging_path_as_default(tmp_path) -> None:

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1469,6 +1469,29 @@ def test_cycle_config_editor_theme_updates_draft_and_dirty_state() -> None:
     assert next_state.config_editor.dirty is True
 
 
+def test_cycle_config_editor_theme_supports_all_builtin_themes() -> None:
+    base_state = build_initial_app_state()
+    themed_config = replace(
+        base_state.config,
+        display=replace(base_state.config.display, theme="solarized-light"),
+    )
+    state = replace(
+        base_state,
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/peneo/config.toml",
+            draft=themed_config,
+            cursor_index=2,
+        ),
+    )
+
+    next_state = _reduce_state(state, CycleConfigEditorValue(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.draft.display.theme == "textual-ansi"
+    assert next_state.config_editor.dirty is True
+
+
 def test_cycle_config_editor_directory_size_visibility_updates_draft_and_dirty_state() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/peneo/config.toml"),

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1412,7 +1412,7 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     next_state = _reduce_state(state, MoveConfigEditorCursor(delta=99))
 
     assert next_state.config_editor is not None
-    assert next_state.config_editor.cursor_index == 11
+    assert next_state.config_editor.cursor_index == 12
 
 
 def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:
@@ -1525,6 +1525,24 @@ def test_cycle_config_editor_preview_visibility_updates_draft_and_dirty_state() 
 
     assert next_state.config_editor is not None
     assert next_state.config_editor.draft.display.show_preview is False
+    assert next_state.config_editor.dirty is True
+
+
+def test_cycle_config_editor_preview_syntax_theme_updates_draft_and_dirty_state() -> None:
+    state = replace(
+        build_initial_app_state(config_path="/tmp/peneo/config.toml"),
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/peneo/config.toml",
+            draft=build_initial_app_state().config,
+            cursor_index=5,
+        ),
+    )
+
+    next_state = _reduce_state(state, CycleConfigEditorValue(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.draft.display.preview_syntax_theme == "abap"
     assert next_state.config_editor.dirty is True
 
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1773,6 +1773,7 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     assert "  Editor command: system default" in dialog.lines
     assert "> Theme: textual-dark" in dialog.lines
     assert "  Show preview: true" in dialog.lines
+    assert "  Preview syntax theme: auto" in dialog.lines
     assert "  Default sort field: name" in dialog.lines
     assert "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw" in dialog.lines
     assert "Terminal launch templates: edit config.toml with e" in dialog.lines
@@ -1787,8 +1788,13 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
 
 
 def test_select_child_syntax_theme_tracks_builtin_theme_brightness() -> None:
-    assert selectors_module._select_child_syntax_theme("solarized-light") == "friendly"
-    assert selectors_module._select_child_syntax_theme("dracula") == "monokai"
+    assert selectors_module._select_child_syntax_theme("solarized-light", "auto") == "friendly"
+    assert selectors_module._select_child_syntax_theme("dracula", "auto") == "monokai"
+
+
+def test_select_child_syntax_theme_prefers_explicit_preview_style() -> None:
+    assert selectors_module._select_child_syntax_theme("solarized-light", "xcode") == "xcode"
+    assert selectors_module._select_child_syntax_theme("dracula", "one-dark") == "one-dark"
 
 
 def test_select_config_dialog_state_shows_custom_editor_command_hint() -> None:

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1786,6 +1786,11 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     )
 
 
+def test_select_child_syntax_theme_tracks_builtin_theme_brightness() -> None:
+    assert selectors_module._select_child_syntax_theme("solarized-light") == "friendly"
+    assert selectors_module._select_child_syntax_theme("dracula") == "monokai"
+
+
 def test_select_config_dialog_state_shows_custom_editor_command_hint() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/peneo/config.toml"),


### PR DESCRIPTION
## Summary
- support every built-in Textual theme in config loading and the config editor
- derive preview syntax highlighting from the selected theme brightness instead of hard-coding two theme names
- update README and tests for the expanded theme support

## Testing
- uv run ruff check .
- uv run pytest tests/test_services_config.py tests/test_state_reducer.py tests/test_state_selectors.py tests/test_app.py

Closes #450
