### PR TITLE
Group config editor settings by category for issue 491

### DIFF
--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -821,6 +821,34 @@ def config_editor_labels() -> tuple[str, ...]:
     )
 
 
+CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
+    ("External", (0,)),
+    ("Display", (2, 5, 1, 3, 4, 6)),
+    ("Sorting", (7, 8, 9)),
+    ("Behavior", (10, 11)),
+    ("Logging", (12,)),
+)
+
+
+def config_editor_visual_order() -> tuple[int, ...]:
+    """Return field indices in visual display order."""
+    result: list[int] = []
+    for _header, field_indices in CONFIG_EDITOR_CATEGORIES:
+        result.extend(field_indices)
+    return tuple(result)
+
+
+def move_config_cursor_visual(cursor_index: int, delta: int) -> int:
+    """Move cursor by *delta* steps in visual order, returning the new field index."""
+    order = config_editor_visual_order()
+    try:
+        pos = order.index(cursor_index)
+    except ValueError:
+        pos = 0
+    new_pos = max(0, min(len(order) - 1, pos + delta))
+    return order[new_pos]
+
+
 def apply_config_to_runtime_state(state: AppState, config: AppConfig) -> AppState:
     return replace(
         state,

--- a/src/peneo/state/reducer_terminal_config.py
+++ b/src/peneo/state/reducer_terminal_config.py
@@ -53,7 +53,7 @@ from .reducer_common import (
     apply_config_to_runtime_state,
     cycle_config_editor_value,
     finalize,
-    normalize_config_editor_cursor,
+    move_config_cursor_visual,
     notification_for_external_launch,
     run_external_launch_request,
     split_terminal_exit_message,
@@ -123,8 +123,8 @@ def handle_terminal_config_action(
                 state,
                 config_editor=replace(
                     state.config_editor,
-                    cursor_index=normalize_config_editor_cursor(
-                        state.config_editor.cursor_index + action.delta
+                    cursor_index=move_config_cursor_visual(
+                        state.config_editor.cursor_index, action.delta
                     ),
                 ),
             )

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -801,87 +801,42 @@ def select_config_dialog_state(state: AppState) -> ConfigDialogState | None:
     if state.ui_mode != "CONFIG" or state.config_editor is None:
         return None
 
+    from .reducer_common import CONFIG_EDITOR_CATEGORIES, config_editor_labels
+
     config = state.config_editor.draft
     selected_index = state.config_editor.cursor_index
-    lines = (
+    labels = config_editor_labels()
+    lines_list: list[str] = [
         f"Path: {state.config_editor.path}",
         "",
-        _format_config_line(
-            0, selected_index, "Editor command", _format_editor_command_value(config.editor.command)
-        ),
-        _format_config_line(
-            1,
-            selected_index,
-            "Show hidden files",
-            _format_bool(config.display.show_hidden_files),
-        ),
-        _format_config_line(
-            2,
-            selected_index,
-            "Theme",
-            config.display.theme,
-        ),
-        _format_config_line(
-            3,
-            selected_index,
-            "Show directory sizes",
-            _format_bool(config.display.show_directory_sizes),
-        ),
-        _format_config_line(
-            4,
-            selected_index,
-            "Show preview",
-            _format_bool(config.display.show_preview),
-        ),
-        _format_config_line(
-            5,
-            selected_index,
-            "Preview syntax theme",
-            config.display.preview_syntax_theme,
-        ),
-        _format_config_line(
-            6,
-            selected_index,
-            "Show help bar",
-            _format_bool(config.display.show_help_bar),
-        ),
-        _format_config_line(
-            7,
-            selected_index,
-            "Default sort field",
-            config.display.default_sort_field,
-        ),
-        _format_config_line(
-            8,
-            selected_index,
-            "Default sort descending",
-            _format_bool(config.display.default_sort_descending),
-        ),
-        _format_config_line(
-            9, selected_index, "Directories first", _format_bool(config.display.directories_first)
-        ),
-        _format_config_line(
-            10, selected_index, "Confirm delete", _format_bool(config.behavior.confirm_delete)
-        ),
-        _format_config_line(
-            11, selected_index, "Paste conflict action", config.behavior.paste_conflict_action
-        ),
-        _format_config_line(
-            12, selected_index, "Log level", config.logging.level
-        ),
+    ]
+
+    for header, field_indices in CONFIG_EDITOR_CATEGORIES:
+        lines_list.append(f"  ── {header} ──")
+        for field_idx in field_indices:
+            lines_list.append(
+                _format_config_line(
+                    is_selected=(field_idx == selected_index),
+                    label=labels[field_idx],
+                    value=_config_field_value(field_idx, config),
+                )
+            )
+
+    lines_list.extend([
         "",
         _format_custom_editor_hint(config.editor.command),
         "Terminal launch templates: edit config.toml with e",
         f"  Linux templates: {len(config.terminal.linux)}",
         f"  macOS templates: {len(config.terminal.macos)}",
         f"  Windows templates: {len(config.terminal.windows)}",
-    )
+    ])
+
     title = "Config Editor"
     if state.config_editor.dirty:
         title = "Config Editor*"
     return ConfigDialogState(
         title=title,
-        lines=lines,
+        lines=tuple(lines_list),
         options=(
             "↑↓/Ctrl+n/p choose",
             "←→/enter change",
@@ -1224,13 +1179,46 @@ def _filter_hidden_entries(
     return tuple(entry for entry in entries if not entry.hidden)
 
 
-def _format_config_line(index: int, selected_index: int, label: str, value: str) -> str:
-    prefix = ">" if index == selected_index else " "
+def _format_config_line(*, is_selected: bool, label: str, value: str) -> str:
+    prefix = ">" if is_selected else " "
     return f"{prefix} {label}: {value}"
 
 
 def _format_bool(value: bool) -> str:
     return "true" if value else "false"
+
+
+def _config_field_value(field_index: int, config: "AppConfig") -> str:  # type: ignore[name-defined]  # noqa: F821
+    from .reducer_common import config_editor_field_ids
+
+    field_id = config_editor_field_ids()[field_index]
+    if field_id == "editor.command":
+        return _format_editor_command_value(config.editor.command)
+    if field_id == "display.show_hidden_files":
+        return _format_bool(config.display.show_hidden_files)
+    if field_id == "display.theme":
+        return config.display.theme
+    if field_id == "display.show_directory_sizes":
+        return _format_bool(config.display.show_directory_sizes)
+    if field_id == "display.show_preview":
+        return _format_bool(config.display.show_preview)
+    if field_id == "display.preview_syntax_theme":
+        return config.display.preview_syntax_theme
+    if field_id == "display.show_help_bar":
+        return _format_bool(config.display.show_help_bar)
+    if field_id == "display.default_sort_field":
+        return config.display.default_sort_field
+    if field_id == "display.default_sort_descending":
+        return _format_bool(config.display.default_sort_descending)
+    if field_id == "display.directories_first":
+        return _format_bool(config.display.directories_first)
+    if field_id == "behavior.confirm_delete":
+        return _format_bool(config.behavior.confirm_delete)
+    if field_id == "behavior.paste_conflict_action":
+        return config.behavior.paste_conflict_action
+    if field_id == "logging.level":
+        return config.logging.level
+    return ""
 
 
 @lru_cache(maxsize=128)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3593,7 +3593,8 @@ async def test_app_command_palette_opens_config_dialog_and_saves_changes() -> No
         assert "Path: /tmp/peneo/config.toml" in str(lines.renderable)
         assert "> Editor command: system default" in str(lines.renderable)
 
-        await pilot.press("down")
+        for _ in range(3):
+            await pilot.press("down")
         await pilot.press("enter")
         await pilot.press("s")
         await _wait_for_notification_message(app, "Config saved: /tmp/peneo/config.toml")
@@ -3661,7 +3662,6 @@ async def test_app_config_dialog_save_updates_theme(monkeypatch) -> None:
 
         assert app.theme == "textual-dark"
 
-        await pilot.press("down")
         await pilot.press("down")
         await pilot.press("enter")
         await pilot.press("s")
@@ -3741,7 +3741,7 @@ async def test_app_config_dialog_save_updates_preview_syntax_theme() -> None:
         await pilot.press("enter")
         await _wait_for_config_dialog(app)
 
-        for _ in range(5):
+        for _ in range(2):
             await pilot.press("down")
         await pilot.press("enter")
         await pilot.press("s")

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1770,10 +1770,13 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     assert dialog is not None
     assert dialog.title == "Config Editor*"
     assert "Path: /tmp/peneo/config.toml" in dialog.lines
+    assert "  ── External ──" in dialog.lines
     assert "  Editor command: system default" in dialog.lines
+    assert "  ── Display ──" in dialog.lines
     assert "> Theme: textual-dark" in dialog.lines
-    assert "  Show preview: true" in dialog.lines
     assert "  Preview syntax theme: auto" in dialog.lines
+    assert "  Show preview: true" in dialog.lines
+    assert "  ── Sorting ──" in dialog.lines
     assert "  Default sort field: name" in dialog.lines
     assert "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw" in dialog.lines
     assert "Terminal launch templates: edit config.toml with e" in dialog.lines


### PR DESCRIPTION
## Summary
- Add section headers (External, Display, Sorting, Behavior, Logging) to the config editor for better visibility
- Navigate cursor in visual display order so arrow keys follow the grouped layout
- Refactor `_format_config_line` to use `is_selected: bool` and extract `_config_field_value` helper

## Test plan
- [x] `uv run pytest` — 386 tests passed
- [x] `uv run ruff check .` — all checks passed
- [ ] Visual verification: open config editor and confirm cursor follows grouped display order

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)