### PR TITLE
Constrain ConfigDialog to Current Directory pane (#495)

### DIFF
--- a/src/peneo/app.py
+++ b/src/peneo/app.py
@@ -261,6 +261,23 @@ class PeneoApp(App[None]):
         command_palette_layer.styles.height = region.height
         command_palette_layer.styles.offset = (region.x, max(0, region.y - 1))
 
+    def _update_config_dialog_geometry(self) -> None:
+        """Constrain the config dialog overlay to the current pane."""
+
+        try:
+            config_dialog_layer = self.query_one("#config-dialog-layer", Container)
+            current_pane = self.query_one("#current-pane", MainPane)
+        except NoMatches:
+            return
+
+        region = current_pane.region
+        if region.width <= 0 or region.height <= 0:
+            return
+
+        config_dialog_layer.styles.width = region.width
+        config_dialog_layer.styles.height = region.height
+        config_dialog_layer.styles.offset = (region.x, max(0, region.y - 1))
+
     async def on_mount(self) -> None:
         """Load the initial directory snapshot after the UI mounts."""
 
@@ -421,6 +438,7 @@ class PeneoApp(App[None]):
 
         self._update_pane_visibility(self.size.width if width is None else width)
         self._update_command_palette_geometry()
+        self._update_config_dialog_geometry()
 
     def _resize_split_terminal_session(self) -> None:
         resize_split_terminal_session(

--- a/src/peneo/app.tcss
+++ b/src/peneo/app.tcss
@@ -153,6 +153,10 @@ Screen {
     align-horizontal: center;
 }
 
+#config-dialog-layer {
+    align-horizontal: center;
+}
+
 .dialog-layer {
     align: center middle;
 }


### PR DESCRIPTION
## Summary
Constrain ConfigDialog to Current Directory pane, allowing theme changes and other config modifications to be visible in real-time against the background directory display.

## Changes
- Add `_update_config_dialog_geometry()` method in `src/peneo/app.py`
- Update `_sync_overlay_layout()` to call the new geometry method
- Add `#config-dialog-layer` horizontal centering in `src/peneo/app.tcss`

## Test plan
- [x] Lint checks pass (ruff)
- [x] All 867 unit tests pass
- [x] All 53 config-related tests pass
- [ ] Manual verification: ConfigDialog displays within Current Directory pane
- [ ] Manual verification: Theme changes visible in real-time
- [ ] Manual verification: Resize handling works correctly
- [ ] Manual verification: Other dialogs (Conflict, Attribute, ShellCommand) remain full-screen overlays

Closes #495