### PR TITLE
Add configurable grep preview context lines

### DIFF
--- a/src/peneo/models/config.py
+++ b/src/peneo/models/config.py
@@ -41,6 +41,7 @@ class DisplayConfig:
     default_sort_field: ConfigSortField = "name"
     default_sort_descending: bool = False
     directories_first: bool = True
+    grep_preview_context_lines: int = 3
 
 
 @dataclass(frozen=True)

--- a/src/peneo/services/config.py
+++ b/src/peneo/services/config.py
@@ -223,6 +223,14 @@ def _load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
             warnings=warnings,
             section_name="display",
         ),
+        grep_preview_context_lines=_read_int(
+            validated,
+            key="grep_preview_context_lines",
+            default=config.grep_preview_context_lines,
+            minimum=0,
+            warnings=warnings,
+            section_name="display",
+        ),
     )
     config = replace(
         config,
@@ -480,6 +488,29 @@ def _read_bool(
     return default
 
 
+def _read_int(
+    section: dict[str, object],
+    *,
+    key: str,
+    default: int,
+    minimum: int = 0,
+    warnings: list[str],
+    section_name: str,
+) -> int:
+    value = section.get(key, default)
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value >= minimum:
+            return value
+        if key in section:
+            warnings.append(
+                f"{section_name}.{key} must be >= {minimum}; using default."
+            )
+        return default
+    if key in section:
+        warnings.append(f"{section_name}.{key} must be an integer; using default.")
+    return default
+
+
 def _read_enum(
     section: dict[str, object],
     *,
@@ -546,7 +577,8 @@ def _render_display_section(config: AppConfig) -> str:
         f'preview_syntax_theme = "{config.display.preview_syntax_theme}"\n'
         f'default_sort_field = "{config.display.default_sort_field}"\n'
         f"default_sort_descending = {_render_bool(config.display.default_sort_descending)}\n"
-        f"directories_first = {_render_bool(config.display.directories_first)}"
+        f"directories_first = {_render_bool(config.display.directories_first)}\n"
+        f"grep_preview_context_lines = {config.display.grep_preview_context_lines}"
     )
 
 

--- a/src/peneo/state/reducer_common.py
+++ b/src/peneo/state/reducer_common.py
@@ -739,6 +739,16 @@ def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) 
                 directories_first=not config.display.directories_first,
             ),
         )
+    if field_id == "display.grep_preview_context_lines":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                grep_preview_context_lines=max(
+                    0, config.display.grep_preview_context_lines + delta
+                ),
+            ),
+        )
     if field_id == "behavior.confirm_delete":
         return replace(
             config,
@@ -797,6 +807,7 @@ def config_editor_field_ids() -> tuple[str, ...]:
         "display.default_sort_field",
         "display.default_sort_descending",
         "display.directories_first",
+        "display.grep_preview_context_lines",
         "behavior.confirm_delete",
         "behavior.paste_conflict_action",
         "logging.level",
@@ -815,6 +826,7 @@ def config_editor_labels() -> tuple[str, ...]:
         "Default sort field",
         "Default sort descending",
         "Directories first",
+        "Grep preview context lines",
         "Confirm delete",
         "Paste conflict action",
         "Log level",
@@ -823,10 +835,10 @@ def config_editor_labels() -> tuple[str, ...]:
 
 CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
     ("External", (0,)),
-    ("Display", (2, 5, 1, 3, 4, 6)),
+    ("Display", (2, 5, 1, 3, 4, 6, 10)),
     ("Sorting", (7, 8, 9)),
-    ("Behavior", (10, 11)),
-    ("Logging", (12,)),
+    ("Behavior", (11, 12)),
+    ("Logging", (13,)),
 )
 
 

--- a/src/peneo/state/reducer_palette.py
+++ b/src/peneo/state/reducer_palette.py
@@ -87,7 +87,6 @@ from .reducer_common import (
 )
 from .selectors import select_target_paths, select_visible_current_entry_states
 
-GREP_PREVIEW_CONTEXT_LINES = 3
 _GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "include", "exclude")
 _EXTENSION_SEPARATOR_RE = re.compile(r"[\s,]+")
 _VALID_EXTENSION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]*")
@@ -1259,7 +1258,7 @@ def _sync_grep_preview(state: AppState) -> ReduceResult:
             current_path=state.current_path,
             cursor_path=selected_result.path,
             grep_result=selected_result,
-            grep_context_lines=GREP_PREVIEW_CONTEXT_LINES,
+            grep_context_lines=state.config.display.grep_preview_context_lines,
         ),
     )
 

--- a/src/peneo/state/selectors.py
+++ b/src/peneo/state/selectors.py
@@ -1224,6 +1224,8 @@ def _config_field_value(field_index: int, config: "AppConfig") -> str:  # type: 
         return _format_bool(config.display.default_sort_descending)
     if field_id == "display.directories_first":
         return _format_bool(config.display.directories_first)
+    if field_id == "display.grep_preview_context_lines":
+        return str(config.display.grep_preview_context_lines)
     if field_id == "behavior.confirm_delete":
         return _format_bool(config.behavior.confirm_delete)
     if field_id == "behavior.paste_conflict_action":

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -45,6 +45,7 @@ def test_loader_creates_default_config_when_missing(tmp_path) -> None:
     assert "enabled = true" in written
     assert 'path = ""' in written
     assert '# paths = ["/home/user/src", "/home/user/docs"]' in written
+    assert "grep_preview_context_lines = 3" in written
 
 
 def test_loader_reads_valid_config_values(tmp_path) -> None:
@@ -66,6 +67,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
         default_sort_field = "modified"
         default_sort_descending = true
         directories_first = false
+        grep_preview_context_lines = 5
 
         [behavior]
         confirm_delete = false
@@ -95,6 +97,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
     assert result.config.display.default_sort_field == "modified"
     assert result.config.display.default_sort_descending is True
     assert result.config.display.directories_first is False
+    assert result.config.display.grep_preview_context_lines == 5
     assert result.config.behavior.confirm_delete is False
     assert result.config.behavior.paste_conflict_action == "rename"
     assert result.config.logging.enabled is False
@@ -119,6 +122,7 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
         theme = "bad-theme"
         preview_syntax_theme = "bad-preview-style"
         default_sort_field = "invalid"
+        grep_preview_context_lines = -1
 
         [behavior]
         confirm_delete = "yes"
@@ -149,7 +153,7 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
     assert result.config.logging.enabled is True
     assert result.config.logging.path is None
     assert result.config.bookmarks.paths == ()
-    assert len(result.warnings) == 13
+    assert len(result.warnings) == 14
 
 
 def test_loader_warns_for_invalid_editor_command_syntax(tmp_path) -> None:
@@ -188,6 +192,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
                 default_sort_field="size",
                 default_sort_descending=True,
                 directories_first=False,
+                grep_preview_context_lines=7,
             ),
             behavior=BehaviorConfig(
                 confirm_delete=False,
@@ -218,6 +223,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
     assert "enabled = false" in written
     assert 'path = "/tmp/peneo-errors.log"' in written
     assert 'paths = ["/tmp/project", "/tmp/docs"]' in written
+    assert "grep_preview_context_lines = 7" in written
 
 
 def test_loader_accepts_all_supported_builtin_themes(tmp_path) -> None:
@@ -270,3 +276,38 @@ def test_loader_treats_blank_logging_path_as_default(tmp_path) -> None:
 
     assert result.config.logging.enabled is True
     assert result.config.logging.path is None
+
+
+def test_loader_rejects_non_integer_grep_preview_context_lines(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [display]
+        grep_preview_context_lines = "many"
+        """,
+        encoding="utf-8",
+    )
+
+    result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+    assert result.config.display.grep_preview_context_lines == 3
+    assert any(
+        "display.grep_preview_context_lines must be an integer" in w
+        for w in result.warnings
+    )
+
+
+def test_loader_accepts_zero_grep_preview_context_lines(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [display]
+        grep_preview_context_lines = 0
+        """,
+        encoding="utf-8",
+    )
+
+    result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+    assert result.warnings == ()
+    assert result.config.display.grep_preview_context_lines == 0

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1412,7 +1412,7 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     next_state = _reduce_state(state, MoveConfigEditorCursor(delta=99))
 
     assert next_state.config_editor is not None
-    assert next_state.config_editor.cursor_index == 12
+    assert next_state.config_editor.cursor_index == 13
 
 
 def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:


### PR DESCRIPTION
## Summary
- `DisplayConfig` に `grep_preview_context_lines: int = 3` を追加し、`config.toml` でgrepプレビューの前後行数を設定可能にした
- 整数バリデーションヘルパー `_read_int()` を追加（bool除外チェック付き）
- `reducer_palette.py` のハードコード定数を削除し、config値を参照するように変更

## Test plan
- [x] デフォルト値（3）が正しく反映される
- [x] 有効な値の読み込み・保存が正常に動作する
- [x] 負数・非整数値に対して警告が出てデフォルトにフォールバックする
- [x] ゼロ値（有効なエッジケース）が受け入れられる
- [x] `uv run ruff check .` lint通過
- [x] `uv run pytest` 871テスト全て通過

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)