### PR TITLE
Issue #533: 依存ライセンスの情報を明記する

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,20 @@
+ Name               Version  License                                        URL                                                
+ Pygments           2.19.2   BSD License                                    https://pygments.org                               
+ Send2Trash         2.1.0    BSD-3-Clause                                   https://github.com/arsenetar/send2trash            
+ iniconfig          2.3.0    MIT                                            https://github.com/pytest-dev/iniconfig            
+ linkify-it-py      2.1.0    MIT License                                    https://github.com/tsutsu3/linkify-it-py           
+ markdown-it-py     4.0.0    MIT License                                    https://github.com/executablebooks/markdown-it-py  
+ mdit-py-plugins    0.5.0    MIT License                                    https://github.com/executablebooks/mdit-py-plugins 
+ mdurl              0.1.2    MIT License                                    https://github.com/executablebooks/mdurl           
+ packaging          26.0     Apache-2.0 OR BSD-2-Clause                     https://github.com/pypa/packaging                  
+ platformdirs       4.9.4    MIT                                            https://github.com/tox-dev/platformdirs            
+ pluggy             1.6.0    MIT License                                    UNKNOWN                                            
+ pyte               0.8.2    GNU Lesser General Public License v3 (LGPLv3)  https://github.com/selectel/pyte                   
+ pytest             9.0.2    MIT                                            https://docs.pytest.org/en/latest/                 
+ pytest-asyncio     1.3.0    Apache-2.0                                     https://github.com/pytest-dev/pytest-asyncio       
+ rich               14.3.3   MIT License                                    https://github.com/Textualize/rich                 
+ ruff               0.15.7   MIT                                            https://docs.astral.sh/ruff                        
+ textual            0.89.1   MIT License                                    https://github.com/Textualize/textual              
+ typing_extensions  4.15.0   PSF-2.0                                        https://github.com/python/typing_extensions        
+ uc-micro-py        2.0.0    MIT License                                    https://github.com/tsutsu3/uc.micro-py             
+ zivo               0.12.0   MIT License                                    https://github.com/devgamesan/zivo                 

--- a/README.ja.md
+++ b/README.ja.md
@@ -440,6 +440,20 @@ paths = ["/home/user/src", "/home/user/docs"]
 - 実装構造: [docs/architecture.md](docs/architecture.md)
 - 性能確認メモ: [docs/performance.md](docs/performance.md)
 
+## ライセンス
+
+zivo は MIT ライセンスで提供されています。詳細は [LICENSE](LICENSE) を確認してください。
+
+### サードパーティーライセンス
+
+zivo はサードパーティーパッケージに依存しています。依存パッケージとそのライセンスの一覧は [NOTICE.txt](NOTICE.txt) を確認してください。
+
+依存関係を更新した後に NOTICE.txt を更新するには:
+
+```bash
+uv run pip-licenses --format=plain --from=mixed --with-urls --output-file NOTICE.txt
+```
+
 ## 開発者向け
 
 開発環境を作る場合は次を実行します。

--- a/README.md
+++ b/README.md
@@ -443,6 +443,20 @@ The accepted `display.preview_syntax_theme` values are `auto` plus the Pygments 
 - Implementation structure: [docs/architecture.en.md](docs/architecture.en.md)
 - Performance notes: [docs/performance.en.md](docs/performance.en.md)
 
+## License
+
+zivo is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+### Third-Party Licenses
+
+zivo depends on third-party packages. For a complete list of dependencies and their licenses, see [NOTICE.txt](NOTICE.txt).
+
+To update NOTICE.txt after dependency changes:
+
+```bash
+uv run pip-licenses --format=plain --from=mixed --with-urls --output-file NOTICE.txt
+```
+
 ## Development
 
 To prepare the development environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ zivo = "zivo.__main__:main"
 
 [dependency-groups]
 dev = [
+  "pip-licenses>=4.0",
   "pytest>=8.0",
   "pytest-asyncio>=0.23",
   "ruff>=0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -83,6 +83,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pip-licenses"
+version = "5.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prettytable" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/18/ddd93af610a04f56a51a27095ddfe55238e1ec236f6758730a0d2c0b49f2/pip_licenses-5.5.5.tar.gz", hash = "sha256:60750c006adf7a0910347b726e8ee9fee3bc8d2e7c8307a5c4ec0776c8e2a276", size = 54955, upload-time = "2026-03-28T22:12:56.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9a/6acfdb8d463eac7cdae7534d35d72237eca63f5fbafe797289d8a5fae447/pip_licenses-5.5.5-py3-none-any.whl", hash = "sha256:f4c4c6d9e6a03612cf59f29f19dc8ab54904d82e055b8e191498f2279a224e14", size = 23247, upload-time = "2026-03-28T22:12:54.89Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -98,6 +110,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -241,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "zivo"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },
@@ -251,6 +275,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pip-licenses" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -265,6 +290,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pip-licenses", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.6" },


### PR DESCRIPTION
## Summary
- pip-licenses を dev 依存に追加
- NOTICE.txt を生成してライセンス情報を記載
- README.md と README.ja.md にライセンスセクションを追加
- NOTICE.txt の更新手順をドキュメント化

## Changes
- pyproject.toml: pip-licenses>=4.0 を dev 依存に追加
- NOTICE.txt: 依存パッケージのライセンス情報を生成
- README.md/README.ja.md: ライセンスセクションと更新手順を追加

## Test plan
- [x] Lint: `uv run ruff check .` - All checks passed
- [x] Test: `uv run pytest` - 869 tests passed
- [x] NOTICE.txt 生成コマンドが正常に動作することを確認

## Related
Resolves #533

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)