### PR TITLE
#508 macOS で Trash restore 機能を実装

### DIFF
--- a/src/zivo/services/trash_operations.py
+++ b/src/zivo/services/trash_operations.py
@@ -177,11 +177,81 @@ class MacOsTrashService:
         path: str,
         send_to_trash: Callable[[], None],
     ) -> TrashRestoreRecord | None:
+        # 1. 元のパス情報を収集
+        original_path = str(Path(path).expanduser().resolve())
+        original_name = Path(original_path).name
+
+        # 2. ゴミ箱内の既存アイテムを確認
+        trash_path = Path.home() / ".Trash"
+        before_trash: set[str] = set()
+        if trash_path.exists():
+            try:
+                before_trash = {item.name for item in trash_path.iterdir()}
+            except PermissionError:
+                pass
+
+        # 3. ゴミ箱に移動実行
         send_to_trash()
-        return None
+
+        # 4. ゴミ箱内の新規アイテムを検出
+        if not trash_path.exists():
+            return None
+
+        try:
+            after_trash = {item.name for item in trash_path.iterdir()}
+        except PermissionError:
+            return None
+
+        new_items = after_trash - before_trash
+
+        # 5. 元ファイル名と一致するアイテムを探す
+        candidates: list[Path] = []
+        for item_name in new_items:
+            if item_name == original_name or item_name.startswith(f"{original_name} "):
+                trashed_path = trash_path / item_name
+                if trashed_path.exists():
+                    candidates.append(trashed_path)
+
+        if not candidates:
+            return None
+
+        # 6. 最も新しいアイテムを選択（作成時間で判定）
+        trashed_path = max(candidates, key=lambda p: p.stat().st_mtime)
+
+        # 7. メタデータパスの生成（ダミーを使用）
+        metadata_path = str(trashed_path) + ".zivorestore"
+
+        return TrashRestoreRecord(
+            original_path=original_path,
+            trashed_path=str(trashed_path),
+            metadata_path=metadata_path,
+        )
 
     def restore(self, record: TrashRestoreRecord) -> str:
-        raise OSError("Trash restore is not supported on this platform")
+        trashed_path = Path(record.trashed_path)
+        original_path = Path(record.original_path)
+
+        if not trashed_path.exists():
+            raise OSError(f"Trashed entry not found: {trashed_path.name}")
+        if original_path.exists():
+            raise OSError(f"Restore destination already exists: {original_path.name}")
+
+        original_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            shutil.move(str(trashed_path), str(original_path))
+        except OSError as error:
+            raise OSError(str(error) or f"Failed to restore {original_path.name}") from error
+
+        # メタデータのクリーンアップ
+        metadata_path = Path(record.metadata_path)
+        if metadata_path.exists() and metadata_path.name.endswith(".zivorestore"):
+            try:
+                metadata_path.unlink()
+            except OSError:
+                pass
+
+        return str(original_path)
 
 
 @dataclass(frozen=True)

--- a/tests/test_services_trash_operations.py
+++ b/tests/test_services_trash_operations.py
@@ -1,5 +1,7 @@
+from pathlib import Path
+
 from zivo.models import TrashRestoreRecord
-from zivo.services.trash_operations import LinuxTrashService
+from zivo.services.trash_operations import LinuxTrashService, MacOsTrashService
 
 
 def test_linux_trash_service_captures_restorable_metadata(tmp_path, monkeypatch) -> None:
@@ -60,3 +62,47 @@ def test_linux_trash_service_restores_record(tmp_path, monkeypatch) -> None:
     assert destination.read_text(encoding="utf-8") == "restored\n"
     assert trashed_path.exists() is False
     assert metadata_path.exists() is False
+
+
+def test_macos_trash_service_captures_restorable_metadata(tmp_path, monkeypatch) -> None:
+    trash_path = tmp_path / ".Trash"
+    trash_path.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: trash_path.parent))
+
+    original_path = tmp_path / "docs"
+    original_path.write_text("original\n", encoding="utf-8")
+
+    def fake_send_to_trash() -> None:
+        (trash_path / "docs").write_text("trashed\n", encoding="utf-8")
+
+    service = MacOsTrashService()
+
+    record = service.capture_restorable_trash(str(original_path), fake_send_to_trash)
+
+    assert record == TrashRestoreRecord(
+        original_path=str(original_path),
+        trashed_path=str(trash_path / "docs"),
+        metadata_path=str(trash_path / "docs") + ".zivorestore",
+    )
+
+
+def test_macos_trash_service_restores_record(tmp_path, monkeypatch) -> None:
+    trash_path = tmp_path / ".Trash"
+    trash_path.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: trash_path.parent))
+
+    trashed_path = trash_path / "docs"
+    trashed_path.write_text("restored\n", encoding="utf-8")
+
+    destination = tmp_path / "restored" / "docs"
+    record = TrashRestoreRecord(
+        original_path=str(destination),
+        trashed_path=str(trashed_path),
+        metadata_path=str(trashed_path) + ".zivorestore",
+    )
+
+    restored_path = MacOsTrashService().restore(record)
+
+    assert restored_path == str(destination)
+    assert destination.read_text(encoding="utf-8") == "restored\n"
+    assert trashed_path.exists() is False


### PR DESCRIPTION
## 概要
Issue #508 の対応として、macOS でゴミ箱からの復元機能を実装しました。

## 変更内容

### MacOsTrashService.capture_restorable_trash() の実装
- ゴミ箱移動前後のディレクトリ内容を比較
- 元ファイル名と一致するアイテムを検出
- 最新のアイテムを選択（st_mtime で判定）
- TrashRestoreRecord を返す

### MacOsTrashService.restore() の実装
- TrashRestoreRecord を使ってファイルを元の場所に移動
- エラーハンドリングを追加
- メタデータファイルのクリーンアップ

### テスト追加
- test_macos_trash_service_captures_restorable_metadata
- test_macos_trash_service_restores_record

## 影響範囲
- **Undo 機能**: 自動的に有効になります
- **ファイル削除操作**: TrashRestoreRecord が記録されるようになります
- 既存の Linux 機能には影響ありません

## テスト結果
- ✅ ゴミ箱機能関連のテストすべて成功
- ✅ Lint チェック通過
- ℹ️ test_app_loads_directory_sizes_when_enabled は既存の問題で失敗（develop ブランチでも同じ結果）

## 関連 Issue
- #508

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>