### PR TITLE
ソート機能が正常動作しない問題を修正 (#543)

### DIFF
--- a/src/zivo/ui/panes.py
+++ b/src/zivo/ui/panes.py
@@ -756,8 +756,8 @@ class MainPane(Vertical):
             return True
         if len(previous_entries) != len(next_entries):
             return True
-        previous_paths = {entry.path for entry in previous_entries}
-        next_paths = {entry.path for entry in next_entries}
+        previous_paths = tuple(entry.path for entry in previous_entries)
+        next_paths = tuple(entry.path for entry in next_entries)
         return previous_paths != next_paths
 
     def _update_changed_rows(

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -389,7 +389,7 @@ def test_should_rebuild_rows_with_path_changes() -> None:
 
 
 def test_should_rebuild_rows_with_sort() -> None:
-    """ソート時（同じパス集合）、差分更新のみ行うこと"""
+    """ソート時（同じパス集合でも順序が異なる）は全再構築が必要なこと"""
     summary = CurrentSummaryState(item_count=3, selected_count=0, sort_label="Name")
     pane = MainPane(title="Test", entries=[], summary=summary)
     table = Mock(spec=DataTable)
@@ -409,7 +409,7 @@ def test_should_rebuild_rows_with_sort() -> None:
 
     result = pane._should_rebuild_rows(table, previous_entries, next_entries)
 
-    assert result is False, "ソート時は差分更新のみ"
+    assert result is True, "ソート時は全再構築が必要"
 
 
 def test_should_rebuild_rows_with_width_change() -> None:


### PR DESCRIPTION
## Summary
- `_should_rebuild_rows` のパス比較を `set` → `tuple` に変更し、ソート順の変更を正しく検出するように修正
- 対応するテストのアサーションを修正

## Changes
- `src/zivo/ui/panes.py`: パス比較を集合（set）から順序付きタプル（tuple）に変更
- `tests/test_ui_panes.py`: `test_should_rebuild_rows_with_sort` の期待値を修正

## Test plan
- [x] Lint: `uv run ruff check .` - All checks passed
- [x] Test: `uv run pytest tests/test_ui_panes.py` - 32 tests passed

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)