### PR TITLE
Add .gz and .bz2 single-file compression as supported archive formats

### DIFF
--- a/src/zivo/archive_utils.py
+++ b/src/zivo/archive_utils.py
@@ -3,13 +3,15 @@
 from pathlib import Path
 from typing import Literal
 
-ArchiveFormat = Literal["zip", "tar", "tar.gz", "tar.bz2"]
+ArchiveFormat = Literal["zip", "tar", "tar.gz", "tar.bz2", "gz", "bz2"]
 
 SUPPORTED_ARCHIVE_SUFFIXES: tuple[tuple[str, ArchiveFormat], ...] = (
     (".tar.gz", "tar.gz"),
     (".tar.bz2", "tar.bz2"),
     (".zip", "zip"),
     (".tar", "tar"),
+    (".gz", "gz"),
+    (".bz2", "bz2"),
 )
 
 
@@ -43,6 +45,9 @@ def default_extract_destination(source_path: str | Path) -> str:
     """Return the default destination path for an archive extraction."""
 
     source = Path(source_path).expanduser().resolve()
+    archive_format = detect_archive_format(source)
+    if archive_format in ("gz", "bz2"):
+        return str(source.parent)
     return str(source.parent / strip_archive_suffix(source.name))
 
 

--- a/src/zivo/models/file_operations.py
+++ b/src/zivo/models/file_operations.py
@@ -8,7 +8,7 @@ ConflictResolution = Literal["overwrite", "skip", "rename"]
 CreateKind = Literal["file", "dir"]
 DeleteMode = Literal["trash", "permanent"]
 MutationResultLevel = Literal["info", "warning", "error"]
-ArchiveFormat = Literal["zip", "tar", "tar.gz", "tar.bz2"]
+ArchiveFormat = Literal["zip", "tar", "tar.gz", "tar.bz2", "gz", "bz2"]
 FileMutationOperation = Literal["rename", "create", "delete"]
 UndoOperationKind = Literal["rename", "paste_copy", "paste_cut", "trash_delete"]
 

--- a/src/zivo/services/archive_extract.py
+++ b/src/zivo/services/archive_extract.py
@@ -1,5 +1,7 @@
 """Archive inspection and extraction services."""
 
+import bz2
+import gzip
 import os
 import shutil
 import tarfile
@@ -67,6 +69,18 @@ class LiveArchiveExtractService:
 
         if archive_format == "zip":
             extracted_entries = _extract_zip_archive(
+                source_path,
+                destination_path,
+                progress_callback=progress_callback,
+            )
+        elif archive_format == "gz":
+            extracted_entries = _extract_gz_archive(
+                source_path,
+                destination_path,
+                progress_callback=progress_callback,
+            )
+        elif archive_format == "bz2":
+            extracted_entries = _extract_bz2_archive(
                 source_path,
                 destination_path,
                 progress_callback=progress_callback,
@@ -168,6 +182,16 @@ def _scan_archive_entries(
                 if (parts := _normalize_archive_member_path(info.filename)) is not None
             )
 
+    if archive_format in ("gz", "bz2"):
+        entry_name = _get_decompressed_entry_name(source_path)
+        return (
+            _ArchiveEntry(
+                archive_path=entry_name,
+                destination_parts=(entry_name,),
+                is_dir=False,
+            ),
+        )
+
     with tarfile.open(source_path, mode="r:*") as archive:
         return tuple(
             _ArchiveEntry(
@@ -212,6 +236,17 @@ def _normalize_archive_member_path(name: str) -> tuple[str, ...] | None:
     if any(part == ".." for part in parts):
         raise OSError(f"Archive entry escapes the destination directory: {name}")
     return parts
+
+
+def _get_decompressed_entry_name(source_path: Path) -> str:
+    """Derive the decompressed filename by stripping the compression suffix."""
+    name = source_path.name
+    lower = name.casefold()
+    if lower.endswith(".bz2") and len(name) > 4:
+        return name[:-4]
+    if lower.endswith(".gz") and len(name) > 3:
+        return name[:-3]
+    return name
 
 
 def _extract_zip_archive(
@@ -276,6 +311,36 @@ def _extract_tar_archive(
             _report_progress(progress_callback, extracted_entries, total_entries, str(target_path))
 
     return extracted_entries
+
+
+def _extract_gz_archive(
+    source_path: Path,
+    destination_path: Path,
+    *,
+    progress_callback: ProgressCallback | None,
+) -> int:
+    entry_name = _get_decompressed_entry_name(source_path)
+    target_path = destination_path / entry_name
+    _prepare_file_target(target_path)
+    with gzip.open(source_path, "rb") as source_file, target_path.open("wb") as destination_file:
+        shutil.copyfileobj(source_file, destination_file)
+    _report_progress(progress_callback, 1, 1, str(target_path))
+    return 1
+
+
+def _extract_bz2_archive(
+    source_path: Path,
+    destination_path: Path,
+    *,
+    progress_callback: ProgressCallback | None,
+) -> int:
+    entry_name = _get_decompressed_entry_name(source_path)
+    target_path = destination_path / entry_name
+    _prepare_file_target(target_path)
+    with bz2.open(source_path, "rb") as source_file, target_path.open("wb") as destination_file:
+        shutil.copyfileobj(source_file, destination_file)
+    _report_progress(progress_callback, 1, 1, str(target_path))
+    return 1
 
 
 def _prepare_directory_target(target_path: Path) -> None:

--- a/src/zivo/services/archive_list.py
+++ b/src/zivo/services/archive_list.py
@@ -1,6 +1,7 @@
 """Archive inspection service for listing archive contents."""
 
 import os
+import struct
 import tarfile
 import zipfile
 from dataclasses import dataclass
@@ -80,6 +81,20 @@ def _scan_archive_entries(
                 if _normalize_archive_member_path(info.filename) is not None
             )
 
+    if archive_format in ("gz", "bz2"):
+        entry_name = _get_decompressed_entry_name(source_path)
+        size_bytes: int | None = None
+        if archive_format == "gz":
+            size_bytes = _read_gz_decompressed_size(source_path)
+        return (
+            _ArchiveEntry(
+                archive_path=entry_name,
+                display_name=entry_name,
+                is_dir=False,
+                size_bytes=size_bytes,
+            ),
+        )
+
     with tarfile.open(source_path, mode="r:*") as archive:
         return tuple(
             _ArchiveEntry(
@@ -113,6 +128,27 @@ def _get_display_name(archive_path: str) -> str:
     if parts is None:
         return archive_path
     return parts[-1]
+
+
+def _get_decompressed_entry_name(source_path: Path) -> str:
+    """Derive the decompressed filename by stripping the compression suffix."""
+    name = source_path.name
+    lower = name.casefold()
+    if lower.endswith(".bz2") and len(name) > 4:
+        return name[:-4]
+    if lower.endswith(".gz") and len(name) > 3:
+        return name[:-3]
+    return name
+
+
+def _read_gz_decompressed_size(path: Path) -> int | None:
+    """Read the uncompressed size from the gzip file trailer (last 4 bytes)."""
+    try:
+        with path.open("rb") as f:
+            f.seek(-4, 2)
+            return struct.unpack("<I", f.read(4))[0]
+    except (OSError, struct.error):
+        return None
 
 
 def _build_virtual_path(archive_path: Path, entry: _ArchiveEntry) -> str:

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,0 +1,87 @@
+from zivo.archive_utils import (
+    default_extract_destination,
+    detect_archive_format,
+    is_supported_archive_path,
+    strip_archive_suffix,
+)
+
+
+class TestDetectArchiveFormat:
+    def test_gz(self):
+        assert detect_archive_format("file.log.gz") == "gz"
+
+    def test_bz2(self):
+        assert detect_archive_format("file.log.bz2") == "bz2"
+
+    def test_tar_gz_not_matched_as_gz(self):
+        assert detect_archive_format("archive.tar.gz") == "tar.gz"
+
+    def test_tar_bz2_not_matched_as_bz2(self):
+        assert detect_archive_format("archive.tar.bz2") == "tar.bz2"
+
+    def test_zip(self):
+        assert detect_archive_format("archive.zip") == "zip"
+
+    def test_tar(self):
+        assert detect_archive_format("archive.tar") == "tar"
+
+    def test_unsupported(self):
+        assert detect_archive_format("file.rar") is None
+
+    def test_case_insensitive(self):
+        assert detect_archive_format("FILE.LOG.GZ") == "gz"
+
+
+class TestIsSupportedArchivePath:
+    def test_gz_is_supported(self):
+        assert is_supported_archive_path("dmesg.1.gz") is True
+
+    def test_bz2_is_supported(self):
+        assert is_supported_archive_path("dmesg.1.bz2") is True
+
+    def test_unsupported_not_supported(self):
+        assert is_supported_archive_path("file.rar") is False
+
+
+class TestStripArchiveSuffix:
+    def test_gz(self):
+        assert strip_archive_suffix("dmesg.1.gz") == "dmesg.1"
+
+    def test_bz2(self):
+        assert strip_archive_suffix("dmesg.1.bz2") == "dmesg.1"
+
+    def test_tar_gz(self):
+        assert strip_archive_suffix("archive.tar.gz") == "archive"
+
+    def test_zip(self):
+        assert strip_archive_suffix("archive.zip") == "archive"
+
+
+class TestDefaultExtractDestination:
+    def test_gz_returns_parent_directory(self, tmp_path):
+        archive_path = tmp_path / "dmesg.1.gz"
+        archive_path.write_text("")
+
+        result = default_extract_destination(str(archive_path))
+        assert result == str(tmp_path)
+
+    def test_bz2_returns_parent_directory(self, tmp_path):
+        archive_path = tmp_path / "dmesg.1.bz2"
+        archive_path.write_text("")
+
+        result = default_extract_destination(str(archive_path))
+        assert result == str(tmp_path)
+
+    def test_tar_gz_returns_subdirectory(self, tmp_path):
+        archive_path = tmp_path / "archive.tar.gz"
+        archive_path.write_text("")
+
+        result = default_extract_destination(str(archive_path))
+        assert result == str(tmp_path / "archive")
+
+    def test_zip_returns_subdirectory(self, tmp_path):
+        archive_path = tmp_path / "archive.zip"
+        archive_path.write_text("")
+
+        result = default_extract_destination(str(archive_path))
+        assert result == str(tmp_path / "archive")

--- a/tests/test_services_archive_extract.py
+++ b/tests/test_services_archive_extract.py
@@ -1,3 +1,5 @@
+import bz2
+import gzip
 import tarfile
 import zipfile
 from io import BytesIO
@@ -23,6 +25,16 @@ def _create_tar_archive(path, mode: str) -> None:
             info = tarfile.TarInfo(name=name)
             info.size = len(body)
             archive.addfile(info, BytesIO(body))
+
+
+def _create_gz_archive(path) -> None:
+    with gzip.open(path, "wb") as f:
+        f.write(b"hello from gzip\n")
+
+
+def _create_bz2_archive(path) -> None:
+    with bz2.open(path, "wb") as f:
+        f.write(b"hello from bz2\n")
 
 
 @pytest.mark.parametrize(
@@ -55,6 +67,37 @@ def test_archive_extract_service_extracts_supported_formats(
     assert (destination_path / "notes.txt").read_text(encoding="utf-8") == "notes\n"
     assert result.destination_path == str(destination_path)
     assert result.extracted_entries == 2
+
+
+@pytest.mark.parametrize(
+    ("archive_name", "builder", "expected_entry_name", "expected_content"),
+    (
+        ("sample.log.gz", _create_gz_archive, "sample.log", "hello from gzip\n"),
+        ("sample.log.bz2", _create_bz2_archive, "sample.log", "hello from bz2\n"),
+    ),
+)
+def test_archive_extract_service_extracts_single_file_compressed(
+    tmp_path,
+    archive_name,
+    builder,
+    expected_entry_name,
+    expected_content,
+) -> None:
+    archive_path = tmp_path / archive_name
+    builder(archive_path)
+    destination_path = tmp_path / "output"
+
+    service = LiveArchiveExtractService()
+    result = service.execute(
+        ExtractArchiveRequest(
+            source_path=str(archive_path),
+            destination_path=str(destination_path),
+        )
+    )
+
+    extracted_file = destination_path / expected_entry_name
+    assert extracted_file.read_text(encoding="utf-8") == expected_content
+    assert result.extracted_entries == 1
 
 
 def test_archive_extract_service_prepare_detects_conflicts(tmp_path) -> None:

--- a/tests/test_services_archive_list.py
+++ b/tests/test_services_archive_list.py
@@ -1,3 +1,5 @@
+import bz2
+import gzip
 import tarfile
 import zipfile
 from io import BytesIO
@@ -28,6 +30,16 @@ def _create_tar_archive(path, mode: str) -> None:
             archive.addfile(info, BytesIO(body))
 
 
+def _create_gz_archive(path) -> None:
+    with gzip.open(path, "wb") as f:
+        f.write(b"hello from gzip\n")
+
+
+def _create_bz2_archive(path) -> None:
+    with bz2.open(path, "wb") as f:
+        f.write(b"hello from bz2\n")
+
+
 @pytest.mark.parametrize(
     ("archive_name", "builder"),
     (
@@ -54,6 +66,30 @@ def test_archive_list_service_lists_supported_formats(
     assert "notes.txt" in entry_names
     assert "executable.sh" in entry_names
     assert "src" in entry_names
+
+
+@pytest.mark.parametrize(
+    ("archive_name", "builder", "expected_entry_name"),
+    (
+        ("sample.log.gz", _create_gz_archive, "sample.log"),
+        ("sample.log.bz2", _create_bz2_archive, "sample.log"),
+    ),
+)
+def test_archive_list_service_lists_single_file_compressed_formats(
+    tmp_path,
+    archive_name,
+    builder,
+    expected_entry_name,
+) -> None:
+    archive_path = tmp_path / archive_name
+    builder(archive_path)
+
+    service = LiveArchiveListService()
+    entries = service.list_archive_entries(str(archive_path))
+
+    assert len(entries) == 1
+    assert entries[0].name == expected_entry_name
+    assert entries[0].kind == "file"
 
 
 def test_archive_list_service_sorts_directories_first(tmp_path) -> None:
@@ -172,3 +208,37 @@ def test_archive_list_service_creates_virtual_paths(tmp_path) -> None:
     assert internal_dir.kind == "dir"
     assert str(archive_path) in internal_dir.path
     assert "/internal" in internal_dir.path
+
+
+def test_archive_list_service_gz_shows_decompressed_size(tmp_path) -> None:
+    archive_path = tmp_path / "sample.log.gz"
+    _create_gz_archive(archive_path)
+
+    service = LiveArchiveListService()
+    entries = service.list_archive_entries(str(archive_path))
+
+    assert len(entries) == 1
+    assert entries[0].size_bytes == len(b"hello from gzip\n")
+
+
+def test_archive_list_service_bz2_shows_none_size(tmp_path) -> None:
+    archive_path = tmp_path / "sample.log.bz2"
+    _create_bz2_archive(archive_path)
+
+    service = LiveArchiveListService()
+    entries = service.list_archive_entries(str(archive_path))
+
+    assert len(entries) == 1
+    assert entries[0].size_bytes is None
+
+
+def test_archive_list_service_tar_gz_not_matched_as_gz(tmp_path) -> None:
+    """Verify .tar.gz is matched as tar.gz format, not plain gz."""
+    archive_path = tmp_path / "sample.tar.gz"
+    _create_tar_archive(archive_path, "w:gz")
+
+    service = LiveArchiveListService()
+    entries = service.list_archive_entries(str(archive_path))
+
+    # tar.gz should list multiple entries, not a single synthesized one
+    assert len(entries) == 4


### PR DESCRIPTION
## Summary
- Closes #545
- `.gz` / `.bz2`（単一ファイル圧縮形式）をアーカイブとして認識し、エントリ一覧を表示できるようにしました
- `ArchiveFormat` 型と `SUPPORTED_ARCHIVE_SUFFIXES` に `"gz"` / `"bz2"` を追加
- `archive_list.py` に gz/bz2 エントリ一覧を実装（単一エントリを合成、gz は展開後サイズを表示）
- `archive_extract.py` に gz/bz2 展開を実装
- `default_extract_destination` を更新（gz/bz2 の展開先は親ディレクトリ）
- テスト追加: `test_archive_utils.py`（新規）、`test_services_archive_list.py`、`test_services_archive_extract.py`

## Test plan
- [x] `uv run pytest` — 907 テスト全て合格
- [x] `uv run ruff check .` — リント合格
- [ ] `.tar.gz` が `.gz` として誤認識されないことを確認するテスト含む
- [ ] CI がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)