### PR TITLE
Show Permission denied in child pane for denied directories

### DIFF
--- a/src/zivo/services/__init__.py
+++ b/src/zivo/services/__init__.py
@@ -20,6 +20,7 @@ from .archive_list import (
     LiveArchiveListService,
 )
 from .browser_snapshot import (
+    PREVIEW_PERMISSION_DENIED_MESSAGE,
     BrowserSnapshotLoader,
     FakeBrowserSnapshotLoader,
     LiveBrowserSnapshotLoader,
@@ -135,6 +136,7 @@ __all__ = [
     "LiveDirectorySizeService",
     "LiveClipboardOperationService",
     "LiveBrowserSnapshotLoader",
+    "PREVIEW_PERMISSION_DENIED_MESSAGE",
     "LiveConfigSaveService",
     "LiveShellCommandService",
     "LiveSplitTerminalService",

--- a/src/zivo/services/browser_snapshot.py
+++ b/src/zivo/services/browser_snapshot.py
@@ -281,8 +281,18 @@ class LiveBrowserSnapshotLoader:
 
         child_path = Path(cursor_path).expanduser().resolve()
         if child_path.is_dir():
-            child_entries = self._list_directory(str(child_path))
-            return PaneState(directory_path=str(child_path), entries=child_entries)
+            try:
+                child_entries = self._list_directory(str(child_path))
+                return PaneState(directory_path=str(child_path), entries=child_entries)
+            except OSError as error:
+                if _is_permission_denied_error(error):
+                    return PaneState(
+                        directory_path=str(child_path),
+                        entries=(),
+                        mode="preview",
+                        preview_message=PREVIEW_PERMISSION_DENIED_MESSAGE,
+                    )
+                raise
 
         if is_supported_archive_path(child_path):
             try:
@@ -384,6 +394,10 @@ class LiveBrowserSnapshotLoader:
             raise OSError(f"Not a directory: {path}") from error
         except OSError as error:
             raise OSError(str(error) or f"Failed to load directory: {path}") from error
+
+
+def _is_permission_denied_error(error: OSError) -> bool:
+	return str(error).startswith("Permission denied:")
 
 
 @dataclass(frozen=True)

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -219,6 +219,11 @@ def _select_child_pane_for_cursor(
     is_archive = cursor_entry.kind == "file" and is_supported_archive_path(cursor_entry.path)
     if cursor_entry.kind == "dir" or is_archive:
         if (
+            state.child_pane.mode == "preview"
+            and state.child_pane.preview_message is not None
+        ):
+            pass
+        elif (
             state.child_pane.mode != "entries"
             or cursor_entry.path != state.child_pane.directory_path
         ):

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import pytest
 
 from zivo.adapters import LocalFilesystemAdapter
-from zivo.services import FakeBrowserSnapshotLoader, LiveBrowserSnapshotLoader
+from zivo.services import (
+    PREVIEW_PERMISSION_DENIED_MESSAGE,
+    FakeBrowserSnapshotLoader,
+    LiveBrowserSnapshotLoader,
+)
 from zivo.state import BrowserSnapshot, DirectoryEntryState, GrepSearchResultState, PaneState
 
 
@@ -512,3 +516,45 @@ def test_live_browser_snapshot_loader_grep_preview_with_unknown_extension(tmp_pa
     assert "line 3" in preview.preview_content
     assert preview.preview_start_line == 1
     assert preview.preview_highlight_line == 2
+
+
+def test_live_browser_snapshot_loader_returns_permission_denied_for_denied_directory(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    secret = project / "secret"
+    secret.mkdir()
+
+    loader = LiveBrowserSnapshotLoader(
+        filesystem=StubFilesystemAdapter(
+            entries_by_path={str(project): ()},
+            errors_by_path={str(secret): PermissionError("blocked")},
+        )
+    )
+
+    pane = loader.load_child_pane_snapshot(str(project), str(secret))
+
+    assert pane.mode == "preview"
+    assert pane.preview_message == PREVIEW_PERMISSION_DENIED_MESSAGE
+    assert pane.entries == ()
+    assert pane.directory_path == str(secret)
+
+
+def test_live_browser_snapshot_loader_propagates_non_permission_os_error_for_directory(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    inaccessible = project / "inaccessible"
+    inaccessible.mkdir()
+
+    loader = LiveBrowserSnapshotLoader(
+        filesystem=StubFilesystemAdapter(
+            entries_by_path={str(project): ()},
+            errors_by_path={str(inaccessible): FileNotFoundError("gone")},
+        )
+    )
+
+    with pytest.raises(OSError, match="Not found:"):
+        loader.load_child_pane_snapshot(str(project), str(inaccessible))

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -812,6 +812,35 @@ def test_select_shell_data_builds_child_preview_message_for_unavailable_file() -
     assert shell.child_pane.preview_message == "Preview unavailable for this file type"
 
 
+def test_select_shell_data_builds_child_preview_for_permission_denied_directory() -> None:
+    from zivo.services import PREVIEW_PERMISSION_DENIED_MESSAGE
+
+    initial_state = build_initial_app_state()
+    path = "/home/tadashi/develop/zivo/.Trash"
+    state = replace(
+        initial_state,
+        current_pane=replace(
+            initial_state.current_pane,
+            entries=initial_state.current_pane.entries
+            + (DirectoryEntryState(path, ".Trash", "dir"),),
+            cursor_path=path,
+        ),
+        child_pane=PaneState(
+            directory_path=path,
+            entries=(),
+            mode="preview",
+            preview_message=PREVIEW_PERMISSION_DENIED_MESSAGE,
+        ),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is True
+    assert shell.child_pane.preview_path == path
+    assert shell.child_pane.preview_content is None
+    assert shell.child_pane.preview_message == PREVIEW_PERMISSION_DENIED_MESSAGE
+
+
 def test_select_shell_data_builds_grep_preview_for_palette_selection() -> None:
     initial_state = build_initial_app_state()
     path = "/home/tadashi/develop/zivo/README.md"


### PR DESCRIPTION
## Summary
- ディレクトリのパーミッション拒否時（例: macOS `.Trash`）に、子ディレクトリ表示領域に "Permission denied" メッセージを目立つように表示するようにしました
- `load_child_pane_snapshot` でパーミッションエラーのみをキャッチし、`PaneState(mode="preview", preview_message)` を返すように変更
- `_select_child_pane_for_cursor` のガード条件を修正し、ディレクトリ + `preview_message` の場合にプレビュー描画へフォールスルー

Closes #540

## Test plan
- [x] `uv run pytest` — 910 tests passed
- [x] `uv run ruff check .` — All checks passed
- [ ] 手動確認: 権限のないディレクトリにカーソルを合わせて子ペインにメッセージが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)