### PR TITLE
Handle macOS filesystem case-insensitivity and colon validation

### DIFF
--- a/src/zivo/adapters/file_operations.py
+++ b/src/zivo/adapters/file_operations.py
@@ -39,7 +39,14 @@ class LocalFileOperationAdapter:
         return os.path.lexists(self._entry_path(path))
 
     def paths_are_same(self, source: str, destination: str) -> bool:
-        return self._entry_path(source) == self._entry_path(destination)
+        source_path = self._entry_path(source)
+        destination_path = self._entry_path(destination)
+        if source_path == destination_path:
+            return True
+        try:
+            return os.path.samefile(str(source_path), str(destination_path))
+        except OSError:
+            return False
 
     def remove_path(self, path: str) -> None:
         target = self._entry_path(path)
@@ -53,6 +60,9 @@ class LocalFileOperationAdapter:
         destination_path = self._entry_path(destination)
         if source_path == destination_path:
             raise OSError("Source and destination are the same path")
+        if source_path.exists() and destination_path.exists():
+            if os.path.samefile(str(source_path), str(destination_path)):
+                raise OSError("Source and destination are the same path")
         if source_path.is_symlink():
             destination_path.symlink_to(os.readlink(source_path))
             return

--- a/src/zivo/state/reducer_common.py
+++ b/src/zivo/state/reducer_common.py
@@ -1,6 +1,7 @@
 """Shared helpers for reducer action handlers."""
 
 import os
+import platform as _platform_module
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
@@ -69,6 +70,9 @@ def finalize(next_state: AppState, *effects: Effect) -> ReduceResult:
     reducer.py (viewport adjustment, tab sync, transient delta clearing).
     """
     return ReduceResult(state=next_state, effects=effects)
+
+
+_is_macos = _platform_module.system() == "Darwin"
 
 
 def current_entry_paths(state: AppState) -> set[str]:
@@ -923,15 +927,24 @@ def validate_pending_input(state: AppState) -> str | None:
         return "'.' and '..' are not valid names"
     if "/" in name or "\\" in name:
         return "Names cannot include path separators"
+    if _is_macos and ":" in name:
+        return "Names cannot include colons"
 
     parent_path, current_target_path = pending_input_parent_and_target(state)
     if parent_path is None:
         return "Unable to resolve target directory"
 
-    candidate_path = str(Path(parent_path) / name)
     existing_paths = current_entry_paths(state)
-    if candidate_path in existing_paths and candidate_path != current_target_path:
-        return f"An entry named '{name}' already exists"
+    if _is_macos:
+        name_cf = name.casefold()
+        for existing_path in existing_paths:
+            existing_name_cf = Path(existing_path).name.casefold()
+            if existing_name_cf == name_cf and existing_path != current_target_path:
+                return f"An entry named '{name}' already exists"
+    else:
+        candidate_path = str(Path(parent_path) / name)
+        if candidate_path in existing_paths and candidate_path != current_target_path:
+            return f"An entry named '{name}' already exists"
     return None
 
 

--- a/tests/test_adapters_file_operations.py
+++ b/tests/test_adapters_file_operations.py
@@ -225,3 +225,39 @@ def test_local_file_operation_adapter_send_to_trash_converts_oserror(
 
     with pytest.raises(OSError, match="permission denied"):
         adapter.send_to_trash(str(target))
+
+
+def test_local_file_operation_adapter_paths_are_same_returns_false_for_nonexistent_paths() -> None:
+    adapter = LocalFileOperationAdapter()
+
+    assert adapter.paths_are_same("/nonexistent/a", "/nonexistent/b") is False
+
+
+def test_local_file_operation_adapter_paths_are_same_detects_same_file(tmp_path) -> None:
+    file_path = tmp_path / "README.md"
+    file_path.write_text("content\n", encoding="utf-8")
+
+    adapter = LocalFileOperationAdapter()
+
+    assert adapter.paths_are_same(str(file_path), str(file_path)) is True
+
+
+def test_local_file_operation_adapter_paths_are_same_detects_different_files(tmp_path) -> None:
+    file_a = tmp_path / "a.txt"
+    file_b = tmp_path / "b.txt"
+    file_a.write_text("a\n", encoding="utf-8")
+    file_b.write_text("b\n", encoding="utf-8")
+
+    adapter = LocalFileOperationAdapter()
+
+    assert adapter.paths_are_same(str(file_a), str(file_b)) is False
+
+
+def test_local_file_operation_adapter_copy_path_rejects_same_path_via_samefile(tmp_path) -> None:
+    source = tmp_path / "README.md"
+    source.write_text("plain\n", encoding="utf-8")
+
+    adapter = LocalFileOperationAdapter()
+
+    with pytest.raises(OSError, match="Source and destination are the same path"):
+        adapter.copy_path(str(source), str(source))

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -5973,3 +5973,115 @@ def test_confirm_empty_trash_shows_notification_on_success(monkeypatch) -> None:
     assert next_state.empty_trash_confirmation is None
     assert next_state.notification is not None
     assert next_state.notification.level == "info"
+
+
+def test_submit_pending_input_case_only_rename_emits_mutation() -> None:
+    """Case-only rename (docs -> Docs) should proceed, not show 'Name unchanged'."""
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="RENAME",
+        pending_input=PendingInputState(
+            prompt="Rename: ",
+            value="Docs",
+            target_path="/home/tadashi/develop/zivo/docs",
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitPendingInput())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.effects == (
+        RunFileMutationEffect(
+            request_id=1,
+            request=RenameRequest(
+                source_path="/home/tadashi/develop/zivo/docs",
+                new_name="Docs",
+            ),
+        ),
+    )
+
+
+def test_submit_pending_input_case_insensitive_conflict_on_macos(monkeypatch) -> None:
+    """On macOS, renaming to a case-different existing name should conflict."""
+    import zivo.state.reducer_common as rc
+
+    monkeypatch.setattr(rc, "_is_macos", True)
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="RENAME",
+        pending_input=PendingInputState(
+            prompt="Rename: ",
+            value="Src",
+            target_path="/home/tadashi/develop/zivo/docs",
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitPendingInput())
+
+    assert result.state.ui_mode == "CONFIRM"
+    assert result.state.name_conflict == NameConflictState(kind="rename", name="Src")
+
+
+def test_submit_pending_input_case_sensitive_no_conflict_on_linux(monkeypatch) -> None:
+    """On Linux, renaming to a case-different existing name should NOT conflict."""
+    import zivo.state.reducer_common as rc
+
+    monkeypatch.setattr(rc, "_is_macos", False)
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="RENAME",
+        pending_input=PendingInputState(
+            prompt="Rename: ",
+            value="Src",
+            target_path="/home/tadashi/develop/zivo/docs",
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitPendingInput())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.effects != ()
+
+
+def test_submit_pending_input_rejects_colon_in_name_on_macos(monkeypatch) -> None:
+    """On macOS, names containing ':' should be rejected."""
+    import zivo.state.reducer_common as rc
+
+    monkeypatch.setattr(rc, "_is_macos", True)
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="CREATE",
+        pending_input=PendingInputState(
+            prompt="New file: ",
+            value="file:name.txt",
+            create_kind="file",
+        ),
+    )
+
+    next_state = _reduce_state(state, SubmitPendingInput())
+
+    assert next_state.notification is not None
+    assert next_state.notification.level == "error"
+    assert "colons" in next_state.notification.message
+
+
+def test_submit_pending_input_allows_colon_in_name_on_linux(monkeypatch) -> None:
+    """On Linux, names containing ':' should not be rejected."""
+    import zivo.state.reducer_common as rc
+
+    monkeypatch.setattr(rc, "_is_macos", False)
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="CREATE",
+        pending_input=PendingInputState(
+            prompt="New file: ",
+            value="file:name.txt",
+            create_kind="file",
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitPendingInput())
+
+    # Should proceed to emit a create effect (not blocked by colon validation)
+    assert result.state.ui_mode == "BUSY"
+    assert result.effects != ()


### PR DESCRIPTION
## Summary

- macOS APFS (デフォルト) は大文字小文字を区別しないため、ファイル名衝突検出・パス比較を修正
- `validate_pending_input` で macOS の場合に case-insensitive な名前比較を追加 (`.casefold()`)
- `paths_are_same` / `copy_path` で `os.path.samefile()` を使用して正確な同一ファイル判定
- macOS でファイル名に `:` が含まれる場合を拒否 (APFS 制限)
- `move_path` の同一パスチェックは変更なし (ケースのみのリネーム `Foo` → `foo` を許可)

Closes #511

## Test plan

- [x] 新規テスト 9 件追加 (ケースのみリネーム、case-insensitive 衝突、コロン検証、paths_are_same)
- [x] `uv run ruff check .` — 全チェック通過
- [x] `uv run pytest` — 新規テスト全通過 (既存の macOS 固有失敗 15 件は変更前から存在)