### PR TITLE
Align command palette y-position with browser row (#554)

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -258,16 +258,21 @@ class zivoApp(App[None]):
         try:
             command_palette_layer = self.query_one("#command-palette-layer", Container)
             current_pane = self.query_one("#current-pane", MainPane)
+            browser_row = self.query_one("#browser-row")
         except NoMatches:
             return
 
-        region = current_pane.region
-        if region.width <= 0 or region.height <= 0:
+        pane_region = current_pane.region
+        row_region = browser_row.region
+        if pane_region.width <= 0 or pane_region.height <= 0:
             return
 
-        command_palette_layer.styles.width = region.width
-        command_palette_layer.styles.height = region.height
-        command_palette_layer.styles.offset = (region.x, max(0, region.y - 1))
+        command_palette_layer.styles.width = pane_region.width
+        command_palette_layer.styles.height = pane_region.height
+        command_palette_layer.styles.offset = (
+            pane_region.x,
+            max(0, row_region.y - 1),
+        )
 
     def _update_config_dialog_geometry(self) -> None:
         """Constrain the config dialog overlay to the current pane."""
@@ -275,16 +280,21 @@ class zivoApp(App[None]):
         try:
             config_dialog_layer = self.query_one("#config-dialog-layer", Container)
             current_pane = self.query_one("#current-pane", MainPane)
+            browser_row = self.query_one("#browser-row")
         except NoMatches:
             return
 
-        region = current_pane.region
-        if region.width <= 0 or region.height <= 0:
+        pane_region = current_pane.region
+        row_region = browser_row.region
+        if pane_region.width <= 0 or pane_region.height <= 0:
             return
 
-        config_dialog_layer.styles.width = region.width
-        config_dialog_layer.styles.height = region.height
-        config_dialog_layer.styles.offset = (region.x, max(0, region.y - 1))
+        config_dialog_layer.styles.width = pane_region.width
+        config_dialog_layer.styles.height = pane_region.height
+        config_dialog_layer.styles.offset = (
+            pane_region.x,
+            max(0, row_region.y - 1),
+        )
 
     async def on_mount(self) -> None:
         """Load the initial directory snapshot after the UI mounts."""

--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -271,7 +271,7 @@ class zivoApp(App[None]):
         command_palette_layer.styles.height = pane_region.height
         command_palette_layer.styles.offset = (
             pane_region.x,
-            max(0, row_region.y - 1),
+            row_region.y,
         )
 
     def _update_config_dialog_geometry(self) -> None:
@@ -293,7 +293,7 @@ class zivoApp(App[None]):
         config_dialog_layer.styles.height = pane_region.height
         config_dialog_layer.styles.offset = (
             pane_region.x,
-            max(0, row_region.y - 1),
+            row_region.y,
         )
 
     async def on_mount(self) -> None:


### PR DESCRIPTION
## Summary
- コマンドパレットと config dialog のオーバーレイ y 座標計算を `#browser-row` の region に基づくよう変更
- Parent Directory / Child Directory ペインと同じ高さに配置されるようになり、バランスが改善

## Test plan
- [x] `uv run ruff check .` — lint 合格
- [x] `uv run pytest` — develop と同率のテスト結果（既存の107件の失敗は今回の変更と無関係）
- [ ] `uv run zivo` でコマンドパレット（`:`）の表示位置を目視確認
- [ ] ターミナルリサイズ時のオーバーレイ再配置を確認

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)