### PR TITLE
Implement macOS trash restore (#508)

### DIFF
--- a/src/zivo/services/trash_operations.py
+++ b/src/zivo/services/trash_operations.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import unquote
 
@@ -152,7 +153,8 @@ class MacOsTrashService:
         if not trash_dir.exists():
             return 0, ""
 
-        items = [item for item in trash_dir.iterdir() if item.name != ".DS_Store"]
+        _excluded = {".DS_Store", ".zivo-restore"}
+        items = [item for item in trash_dir.iterdir() if item.name not in _excluded]
         if not items:
             return 0, ""
 
@@ -174,11 +176,59 @@ class MacOsTrashService:
         path: str,
         send_to_trash: Callable[[], None],
     ) -> TrashRestoreRecord | None:
+        trash_dir = Path.home() / ".Trash"
+        resolved_original = str(Path(path).expanduser().resolve(strict=False))
+
+        before = _snapshot_trash_dir(trash_dir)
+
         send_to_trash()
-        return None
+
+        after = _snapshot_trash_dir(trash_dir)
+        new_names = sorted(after - before)
+
+        if not new_names:
+            return None
+
+        candidates = [
+            trash_dir / name for name in new_names if (trash_dir / name).exists()
+        ]
+        if not candidates:
+            return None
+
+        trashed_path = max(candidates, key=lambda p: p.stat().st_mtime)
+        metadata_dir = _metadata_dir()
+        metadata_path = _write_restore_metadata(
+            metadata_dir, resolved_original, str(trashed_path),
+        )
+
+        return TrashRestoreRecord(
+            original_path=resolved_original,
+            trashed_path=str(trashed_path),
+            metadata_path=str(metadata_path),
+        )
 
     def restore(self, record: TrashRestoreRecord) -> str:
-        raise OSError("Trash restore is not supported on this platform")
+        trashed_path = Path(record.trashed_path)
+        metadata_path = Path(record.metadata_path)
+        original_path = Path(record.original_path)
+
+        if not trashed_path.exists():
+            raise OSError(f"Trashed entry not found: {trashed_path.name}")
+        if original_path.exists():
+            raise OSError(f"Restore destination already exists: {original_path.name}")
+
+        original_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.move(str(trashed_path), str(original_path))
+        except OSError as error:
+            raise OSError(str(error) or f"Failed to restore {original_path.name}") from error
+
+        try:
+            if metadata_path.exists():
+                metadata_path.unlink()
+        except OSError as error:
+            raise OSError(str(error) or f"Failed to remove trash metadata for {original_path.name}")
+        return str(original_path)
 
 
 @dataclass(frozen=True)
@@ -222,6 +272,41 @@ def _parse_trashinfo_original_path(info_path: Path) -> str | None:
     if encoded_path is None:
         return None
     return str(Path(unquote(encoded_path)).expanduser().resolve(strict=False))
+
+
+def _snapshot_trash_dir(trash_dir: Path) -> set[str]:
+    """Return item names in the macOS trash directory, excluding system entries."""
+    if not trash_dir.exists():
+        return set()
+    excluded = {".DS_Store", ".zivo-restore"}
+    return {item.name for item in trash_dir.iterdir() if item.name not in excluded}
+
+
+def _metadata_dir() -> Path:
+    """Return (and create if needed) the macOS restore metadata directory."""
+    metadata_dir = Path.home() / ".Trash" / ".zivo-restore"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    return metadata_dir
+
+
+def _write_restore_metadata(
+    metadata_dir: Path,
+    original_path: str,
+    trashed_path: str,
+) -> Path:
+    """Write a restore metadata file and return its path."""
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    safe_name = original_path.replace("/", "_").lstrip("_")
+    metadata_path = metadata_dir / f"{timestamp}_{safe_name}.restoreinfo"
+
+    content = (
+        "[Zivo Restore Info]\n"
+        f"OriginalPath={original_path}\n"
+        f"TrashedPath={trashed_path}\n"
+        f"DeletionDate={datetime.now().isoformat()}\n"
+    )
+    metadata_path.write_text(content, encoding="utf-8")
+    return metadata_path
 
 
 def resolve_trash_service(

--- a/tests/test_services_trash_operations.py
+++ b/tests/test_services_trash_operations.py
@@ -1,4 +1,7 @@
+from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from zivo.models import TrashRestoreRecord
 from zivo.services.trash_operations import LinuxTrashService, MacOsTrashService
@@ -141,3 +144,131 @@ def test_macos_empty_trash_returns_error_on_osascript_failure(tmp_path, monkeypa
 
     assert count == 0
     assert "Full Disk Access" in error
+
+
+def test_macos_capture_restorable_trash_creates_record(tmp_path, monkeypatch) -> None:
+    trash_dir = tmp_path / ".Trash"
+    trash_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    original_path = tmp_path / "docs"
+    original_path.write_text("hello", encoding="utf-8")
+
+    def fake_send_to_trash() -> None:
+        original_path.rename(trash_dir / "docs")
+
+    service = MacOsTrashService()
+    record = service.capture_restorable_trash(str(original_path), fake_send_to_trash)
+
+    assert record is not None
+    assert record.original_path == str(original_path)
+    assert record.trashed_path == str(trash_dir / "docs")
+    assert Path(record.metadata_path).exists()
+    content = Path(record.metadata_path).read_text(encoding="utf-8")
+    assert "[Zivo Restore Info]" in content
+    assert f"OriginalPath={original_path}" in content
+
+
+def test_macos_capture_restorable_trash_handles_name_collision(tmp_path, monkeypatch) -> None:
+    trash_dir = tmp_path / ".Trash"
+    trash_dir.mkdir()
+    (trash_dir / "docs").write_text("existing", encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    original_path = tmp_path / "docs"
+    original_path.write_text("hello", encoding="utf-8")
+
+    def fake_send_to_trash() -> None:
+        original_path.rename(trash_dir / "docs 1")
+
+    service = MacOsTrashService()
+    record = service.capture_restorable_trash(str(original_path), fake_send_to_trash)
+
+    assert record is not None
+    assert record.trashed_path == str(trash_dir / "docs 1")
+
+
+def test_macos_restore_moves_file_back(tmp_path, monkeypatch) -> None:
+    trash_dir = tmp_path / ".Trash"
+    trash_dir.mkdir()
+    metadata_dir = trash_dir / ".zivo-restore"
+    metadata_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    trashed_path = trash_dir / "docs"
+    trashed_path.write_text("restored\n", encoding="utf-8")
+    metadata_path = metadata_dir / "20260416T120000_docs.restoreinfo"
+    metadata_path.write_text(
+        "[Zivo Restore Info]\nOriginalPath=/tmp/project/docs\n"
+        "TrashedPath=docs\nDeletionDate=2026-04-16T12:00:00\n",
+        encoding="utf-8",
+    )
+
+    destination = tmp_path / "restored" / "docs"
+    record = TrashRestoreRecord(
+        original_path=str(destination),
+        trashed_path=str(trashed_path),
+        metadata_path=str(metadata_path),
+    )
+
+    restored_path = MacOsTrashService().restore(record)
+
+    assert restored_path == str(destination)
+    assert destination.read_text(encoding="utf-8") == "restored\n"
+    assert not trashed_path.exists()
+    assert not metadata_path.exists()
+
+
+def test_macos_restore_raises_when_trashed_missing(tmp_path, monkeypatch) -> None:
+    trash_dir = tmp_path / ".Trash"
+    trash_dir.mkdir()
+    metadata_dir = trash_dir / ".zivo-restore"
+    metadata_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    record = TrashRestoreRecord(
+        original_path=str(tmp_path / "dest"),
+        trashed_path=str(trash_dir / "missing"),
+        metadata_path=str(metadata_dir / "meta.restoreinfo"),
+    )
+
+    with pytest.raises(OSError, match="Trashed entry not found"):
+        MacOsTrashService().restore(record)
+
+
+def test_macos_restore_raises_when_destination_exists(tmp_path, monkeypatch) -> None:
+    trash_dir = tmp_path / ".Trash"
+    trash_dir.mkdir()
+    metadata_dir = trash_dir / ".zivo-restore"
+    metadata_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    trashed_path = trash_dir / "docs"
+    trashed_path.write_text("data", encoding="utf-8")
+    destination = tmp_path / "docs"
+    destination.write_text("already here", encoding="utf-8")
+
+    record = TrashRestoreRecord(
+        original_path=str(destination),
+        trashed_path=str(trashed_path),
+        metadata_path=str(metadata_dir / "meta.restoreinfo"),
+    )
+
+    with pytest.raises(OSError, match="Restore destination already exists"):
+        MacOsTrashService().restore(record)
+
+
+def test_macos_capture_returns_none_when_no_new_entry(
+    tmp_path, monkeypatch,
+) -> None:
+    trash_dir = tmp_path / ".Trash"
+    trash_dir.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    original_path = tmp_path / "docs"
+    original_path.write_text("hello", encoding="utf-8")
+
+    service = MacOsTrashService()
+    record = service.capture_restorable_trash(str(original_path), lambda: None)
+
+    assert record is None


### PR DESCRIPTION
## Summary
- `MacOsTrashService` に `capture_restorable_trash()` と `restore()` を実装し、macOS でゴミ箱からの復元（Undo）を可能にした
- `~/.Trash/.zivo-restore/` に INI 形式のメタデータファイルを保存し、復元時に利用する
- `empty_trash()` で `.zivo-restore` ディレクトリをカウント対象から除外
- テスト 6 件追加（正常系・名前衝突・エラー系）

## Test plan
- [x] `uv run ruff check .` — 通過
- [x] `uv run pytest tests/test_services_trash_operations.py` — 13 件全て通過
- [ ] 手動確認: アプリ起動 → ファイル削除（ゴミ箱） → Undo で復元

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)