### PR TITLE
CI改善: リリースワークフローのトリガー変更と自動タグ付与

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,68 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  tag-and-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      version_changed: ${{ steps.check-version.outputs.changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version changed in pyproject.toml
+        id: check-version
+        run: |
+          BEFORE=$(git show HEAD~1:pyproject.toml | python3 -c "import sys,tomllib; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
+          AFTER=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Version changed: $BEFORE -> $AFTER"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No version change detected ($AFTER)"
+          fi
+
+      - name: Extract version from pyproject.toml
+        if: steps.check-version.outputs.changed == 'true'
+        id: version
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check if tag already exists
+        if: steps.check-version.outputs.changed == 'true'
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git tag -l "$TAG" | grep -q .; then
+            echo "Error: Tag $TAG already exists"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        if: steps.check-version.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
   build-distributions:
+    needs: tag-and-release
+    if: needs.tag-and-release.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -31,27 +84,12 @@ jobs:
       - name: Prepare temp directory
         run: mkdir -p "$RUNNER_TEMP/zivo-tmp"
 
-      - name: Extract version from tag
+      - name: Extract version from pyproject.toml
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
-
-      - name: Verify version consistency
-        run: |
-          TAG_VERSION=${{ steps.version.outputs.version }}
-          PY_VERSION=$(python3 - <<'PY'
-          import tomllib
-
-          with open("pyproject.toml", "rb") as f:
-              print(tomllib.load(f)["project"]["version"])
-          PY
-          )
-          if [ "$TAG_VERSION" != "$PY_VERSION" ]; then
-            echo "Error: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PY_VERSION)"
-            exit 1
-          fi
 
       - name: Run tests
         run: TMPDIR="$RUNNER_TEMP/zivo-tmp" uv run pytest
@@ -149,8 +187,6 @@ jobs:
     needs:
       - build-distributions
       - publish-pypi
-    permissions:
-      contents: write
 
     steps:
       - name: Download distribution artifacts
@@ -162,7 +198,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: v${{ needs.build-distributions.outputs.version }}
           name: zivo ${{ needs.build-distributions.outputs.version }}
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Summary

- リリースワークフローのトリガーをタグ push から「main への PR マージ + pyproject.toml バージョン変更」に変更
- マージ後に自動で `v{version}` タグを作成・push する `tag-and-release` ジョブを追加
- バージョン抽出をタグ参照から pyproject.toml 直読みに変更

Closes #557

## Test plan

- [ ] リリースPR（バージョン更新あり）を main にマージし、ワークフローが発火することを確認
- [ ] タグが自動作成されることを確認
- [ ] TestPyPI → PyPI → GitHub Release の全パイプラインが通ることを確認
- [ ] バージョン変更なしのPRマージではワークフローがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)