### PR TITLE
Add macOS runner to CI workflow (#506)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -21,8 +25,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y ripgrep
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ripgrep
 
       - name: Install dependencies
         run: uv sync --dev


### PR DESCRIPTION
## Summary
- CI ワークフローに macOS runner を追加
- `strategy.matrix` で `ubuntu-latest` と `macos-latest` の両方で lint/test を実行
- OS ごとのシステム依存関係インストールに対応（Ubuntu: apt, macOS: brew）

## Test plan
- [ ] Ubuntu runner で CI がパスすること
- [ ] macOS runner で CI がパスすること
- [ ] ローカルで `uv run ruff check .` がパスすること（確認済み）
- [ ] ローカルで `uv run pytest` がパスすること（930 tests passed・確認済み）

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)