### PR TITLE
Add macOS to PyPI classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Environment :: Console",
   "Intended Audience :: End Users/Desktop",
   "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
- Add `Operating System :: MacOS` to the `classifiers` list in `pyproject.toml` to reflect official macOS support

## Context
- Closes #507
- README already documents macOS as a supported platform (addressed in a prior commit)

## Test plan
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pytest` — 930 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)