### PR TITLE
Add split terminal position config option (#569)

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -242,14 +242,23 @@ class zivoApp(App[None]):
         except NoMatches:
             return
 
+        is_right_and_terminal_visible = (
+            self._app_state.config.display.split_terminal_position == "right"
+            and self._app_state.split_terminal.visible
+        )
+
         if width >= self._PANE_VISIBILITY_MEDIUM_THRESHOLD:
             parent_pane.display = True
-            child_pane.display = True
         elif width >= self._PANE_VISIBILITY_NARROW_THRESHOLD:
             parent_pane.display = False
-            child_pane.display = True
         else:
             parent_pane.display = False
+
+        if is_right_and_terminal_visible:
+            child_pane.display = False
+        elif width >= self._PANE_VISIBILITY_NARROW_THRESHOLD:
+            child_pane.display = True
+        else:
             child_pane.display = False
 
     def _update_command_palette_geometry(self) -> None:
@@ -328,7 +337,10 @@ class zivoApp(App[None]):
         await self._dispatch_key_press(key)
 
     def _build_body(self, shell: ThreePaneShellData) -> Vertical:
-        return build_body(shell)
+        return build_body(
+            shell,
+            terminal_position=self._app_state.config.display.split_terminal_position,
+        )
 
     async def _dispatch_key_press(
         self,
@@ -355,11 +367,20 @@ class zivoApp(App[None]):
         sync_runtime_state(self, previous_state, self._app_state)
         next_theme = _active_app_theme(self._app_state)
         theme_changed = previous_theme != next_theme
+        layout_changed = (
+            previous_state.config.display.split_terminal_position
+            != self._app_state.config.display.split_terminal_position
+        )
         if theme_changed:
             self.theme = next_theme
         if previous_state.config != self._app_state.config:
             self._sync_external_launch_service()
-        if changed or theme_changed:
+        if layout_changed:
+            try:
+                await self.query_one("#body").remove()
+            except NoMatches:
+                pass
+        if changed or theme_changed or layout_changed:
             await self._refresh_shell(theme_changed=theme_changed)
         schedule_effects(self, effects)
 

--- a/src/zivo/app.tcss
+++ b/src/zivo/app.tcss
@@ -284,6 +284,24 @@ Screen {
     background: $boost;
 }
 
+#split-terminal.split-terminal-right {
+    display: none;
+    width: 2.2fr;
+    min-width: 20;
+    height: 1fr;
+    min-height: 6;
+    border: round $surface;
+    background: $surface;
+}
+
+#split-terminal.split-terminal-right.-visible {
+    display: block;
+}
+
+#split-terminal.split-terminal-right.-focused {
+    background: $boost;
+}
+
 /* File type component styles resolved via COMPONENT_CLASSES */
 .ft-executable {
     color: $success;

--- a/src/zivo/app_shell.py
+++ b/src/zivo/app_shell.py
@@ -25,35 +25,46 @@ from zivo.ui import (
 )
 
 
-def build_body(shell: ThreePaneShellData) -> Vertical:
-    return Vertical(
-        Horizontal(
-            SidePane(
-                "Parent Directory",
-                shell.parent_entries,
-                id="parent-pane",
-                classes="pane side-pane",
-            ),
-            MainPane(
-                "Current Directory",
-                shell.current_entries or (),
-                summary=shell.current_summary,
-                cursor_index=shell.current_cursor_index,
-                cursor_visible=shell.current_cursor_visible,
-                context_input=shell.current_context_input,
-                id="current-pane",
-                classes="pane main-pane",
-            ),
-            ChildPane(
-                shell.child_pane,
-                id="child-pane",
-                classes="pane side-pane",
-            ),
-            id="browser-row",
+def build_body(shell: ThreePaneShellData, *, terminal_position: str = "bottom") -> Vertical:
+    browser_row_children: list[Any] = [
+        SidePane(
+            "Parent Directory",
+            shell.parent_entries,
+            id="parent-pane",
+            classes="pane side-pane",
         ),
-        SplitTerminalPane(shell.split_terminal, id="split-terminal"),
-        id="body",
-    )
+        MainPane(
+            "Current Directory",
+            shell.current_entries or (),
+            summary=shell.current_summary,
+            cursor_index=shell.current_cursor_index,
+            cursor_visible=shell.current_cursor_visible,
+            context_input=shell.current_context_input,
+            id="current-pane",
+            classes="pane main-pane",
+        ),
+        ChildPane(
+            shell.child_pane,
+            id="child-pane",
+            classes="pane side-pane",
+        ),
+    ]
+    body_children: list[Any] = [
+        Horizontal(*browser_row_children, id="browser-row"),
+    ]
+    if terminal_position == "right":
+        browser_row_children.append(
+            SplitTerminalPane(
+                shell.split_terminal,
+                id="split-terminal",
+                classes="split-terminal-right",
+            )
+        )
+    else:
+        body_children.append(
+            SplitTerminalPane(shell.split_terminal, id="split-terminal")
+        )
+    return Vertical(*body_children, id="body")
 
 
 async def refresh_shell(
@@ -109,7 +120,8 @@ async def refresh_shell(
                 pass
         await app.mount(TabBar(shell.tab_bar, id="tab-bar"))
         await app.mount(CurrentPathBar(shell.current_path, id="current-path-bar"))
-        await app.mount(build_body(shell))
+        terminal_position = app_state.config.display.split_terminal_position
+        await app.mount(build_body(shell, terminal_position=terminal_position))
         await app.mount(
             Container(
                 CommandPalette(shell.command_palette, id="command-palette"),
@@ -166,6 +178,9 @@ async def refresh_shell(
     current_pane.set_context_input(shell.current_context_input)
     await parent_pane.set_entries(shell.parent_entries)
     await child_pane.set_state(shell.child_pane)
+    terminal_position = app_state.config.display.split_terminal_position
+    if terminal_position == "right":
+        child_pane.display = not app_state.split_terminal.visible
     if theme_changed:
         def _refresh_themed_panes() -> None:
             parent_pane.refresh_styles()

--- a/src/zivo/app_shell.py
+++ b/src/zivo/app_shell.py
@@ -49,9 +49,6 @@ def build_body(shell: ThreePaneShellData, *, terminal_position: str = "bottom") 
             classes="pane side-pane",
         ),
     ]
-    body_children: list[Any] = [
-        Horizontal(*browser_row_children, id="browser-row"),
-    ]
     if terminal_position == "right":
         browser_row_children.append(
             SplitTerminalPane(
@@ -60,7 +57,10 @@ def build_body(shell: ThreePaneShellData, *, terminal_position: str = "bottom") 
                 classes="split-terminal-right",
             )
         )
-    else:
+    body_children: list[Any] = [
+        Horizontal(*browser_row_children, id="browser-row"),
+    ]
+    if terminal_position != "right":
         body_children.append(
             SplitTerminalPane(shell.split_terminal, id="split-terminal")
         )

--- a/src/zivo/models/config.py
+++ b/src/zivo/models/config.py
@@ -6,6 +6,7 @@ from typing import Literal
 from zivo.theme_support import AUTO_PREVIEW_SYNTAX_THEME, DEFAULT_APP_THEME
 
 ConfigSortField = Literal["name", "modified", "size"]
+SplitTerminalPosition = Literal["bottom", "right"]
 ConfigTheme = str
 PreviewSyntaxTheme = str
 ConfigLogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
@@ -42,6 +43,7 @@ class DisplayConfig:
     default_sort_descending: bool = False
     directories_first: bool = True
     grep_preview_context_lines: int = 3
+    split_terminal_position: SplitTerminalPosition = "bottom"
 
 
 @dataclass(frozen=True)

--- a/src/zivo/services/config.py
+++ b/src/zivo/services/config.py
@@ -44,6 +44,7 @@ _VALID_THEMES = frozenset(SUPPORTED_APP_THEMES)
 _VALID_PREVIEW_SYNTAX_THEMES = frozenset(SUPPORTED_PREVIEW_SYNTAX_THEMES)
 _VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 _VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
+_VALID_SPLIT_TERMINAL_POSITIONS = frozenset({"bottom", "right"})
 _VALID_TERMINAL_EDITOR_NAMES = frozenset(
     {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
 )
@@ -258,6 +259,15 @@ def _load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
             default=config.default_sort_field,
             valid_values=_VALID_SORT_FIELDS,
             valid_display="name, modified, size",
+            section_name="display",
+            warnings=warnings,
+        ),
+        split_terminal_position=_read_enum(
+            validated,
+            key="split_terminal_position",
+            default=config.split_terminal_position,
+            valid_values=_VALID_SPLIT_TERMINAL_POSITIONS,
+            valid_display="bottom, right",
             section_name="display",
             warnings=warnings,
         ),
@@ -578,7 +588,8 @@ def _render_display_section(config: AppConfig) -> str:
         f'default_sort_field = "{config.display.default_sort_field}"\n'
         f"default_sort_descending = {_render_bool(config.display.default_sort_descending)}\n"
         f"directories_first = {_render_bool(config.display.directories_first)}\n"
-        f"grep_preview_context_lines = {config.display.grep_preview_context_lines}"
+        f"grep_preview_context_lines = {config.display.grep_preview_context_lines}\n"
+        f'split_terminal_position = "{config.display.split_terminal_position}"'
     )
 
 

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -58,6 +58,7 @@ ConfigFieldId = Literal[
     "display.default_sort_field",
     "display.default_sort_descending",
     "display.directories_first",
+    "display.split_terminal_position",
     "behavior.confirm_delete",
     "behavior.paste_conflict_action",
     "logging.level",

--- a/src/zivo/state/reducer_common.py
+++ b/src/zivo/state/reducer_common.py
@@ -58,6 +58,7 @@ CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
 CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
 CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
+CONFIG_SPLIT_TERMINAL_POSITIONS = ("bottom", "right")
 REGEX_FILE_SEARCH_PREFIX = "re:"
 REGEX_GREP_SEARCH_PREFIX = "re:"
 
@@ -753,6 +754,18 @@ def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) 
                 ),
             ),
         )
+    if field_id == "display.split_terminal_position":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                split_terminal_position=cycle_choice(
+                    CONFIG_SPLIT_TERMINAL_POSITIONS,
+                    config.display.split_terminal_position,
+                    delta,
+                ),
+            ),
+        )
     if field_id == "behavior.confirm_delete":
         return replace(
             config,
@@ -812,6 +825,7 @@ def config_editor_field_ids() -> tuple[str, ...]:
         "display.default_sort_descending",
         "display.directories_first",
         "display.grep_preview_context_lines",
+        "display.split_terminal_position",
         "behavior.confirm_delete",
         "behavior.paste_conflict_action",
         "logging.level",
@@ -831,6 +845,7 @@ def config_editor_labels() -> tuple[str, ...]:
         "Default sort descending",
         "Directories first",
         "Grep preview context lines",
+        "Split terminal position",
         "Confirm delete",
         "Paste conflict action",
         "Log level",
@@ -839,10 +854,10 @@ def config_editor_labels() -> tuple[str, ...]:
 
 CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
     ("External", (0,)),
-    ("Display", (2, 5, 1, 3, 4, 6, 10)),
+    ("Display", (2, 5, 1, 3, 4, 6, 10, 11)),
     ("Sorting", (7, 8, 9)),
-    ("Behavior", (11, 12)),
-    ("Logging", (13,)),
+    ("Behavior", (12, 13)),
+    ("Logging", (14,)),
 )
 
 

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -1231,6 +1231,8 @@ def _config_field_value(field_index: int, config: "AppConfig") -> str:  # type: 
         return _format_bool(config.display.directories_first)
     if field_id == "display.grep_preview_context_lines":
         return str(config.display.grep_preview_context_lines)
+    if field_id == "display.split_terminal_position":
+        return config.display.split_terminal_position
     if field_id == "behavior.confirm_delete":
         return _format_bool(config.behavior.confirm_delete)
     if field_id == "behavior.paste_conflict_action":

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -98,6 +98,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
     assert result.config.display.default_sort_descending is True
     assert result.config.display.directories_first is False
     assert result.config.display.grep_preview_context_lines == 5
+    assert result.config.display.split_terminal_position == "bottom"
     assert result.config.behavior.confirm_delete is False
     assert result.config.behavior.paste_conflict_action == "rename"
     assert result.config.logging.enabled is False
@@ -227,6 +228,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
     assert 'path = "/tmp/zivo-errors.log"' in written
     assert 'paths = ["/tmp/project", "/tmp/docs"]' in written
     assert "grep_preview_context_lines = 7" in written
+    assert 'split_terminal_position = "bottom"' in written
 
 
 def test_loader_accepts_all_supported_builtin_themes(tmp_path) -> None:
@@ -314,3 +316,36 @@ def test_loader_accepts_zero_grep_preview_context_lines(tmp_path) -> None:
 
     assert result.warnings == ()
     assert result.config.display.grep_preview_context_lines == 0
+
+
+def test_loader_reads_split_terminal_position(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [display]
+        split_terminal_position = "right"
+        """,
+        encoding="utf-8",
+    )
+
+    result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+    assert result.warnings == ()
+    assert result.config.display.split_terminal_position == "right"
+
+
+def test_loader_rejects_invalid_split_terminal_position(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [display]
+        split_terminal_position = "top"
+        """,
+        encoding="utf-8",
+    )
+
+    result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+    assert len(result.warnings) == 1
+    assert "split_terminal_position" in result.warnings[0]
+    assert result.config.display.split_terminal_position == "bottom"

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1409,7 +1409,7 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     next_state = _reduce_state(state, MoveConfigEditorCursor(delta=99))
 
     assert next_state.config_editor is not None
-    assert next_state.config_editor.cursor_index == 13
+    assert next_state.config_editor.cursor_index == 14
 
 
 def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:
@@ -1445,6 +1445,25 @@ def test_cycle_config_editor_value_updates_draft_and_dirty_state() -> None:
 
     assert next_state.config_editor is not None
     assert next_state.config_editor.draft.display.show_hidden_files is True
+    assert next_state.config_editor.dirty is True
+
+
+def test_cycle_config_editor_split_terminal_position_updates_draft() -> None:
+    original_state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
+    state = replace(
+        original_state,
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/zivo/config.toml",
+            draft=original_state.config,
+            cursor_index=11,
+        ),
+    )
+
+    next_state = _reduce_state(state, CycleConfigEditorValue(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.draft.display.split_terminal_position == "right"
     assert next_state.config_editor.dirty is True
 
 


### PR DESCRIPTION
## Summary
- `DisplayConfig` に `split_terminal_position: Literal["bottom", "right"]` を追加
- config画面でターミナル表示位置を「下（bottom）」「右（right）」に切り替え可能
- "right" の場合、child directoryの領域にターミナルを表示（左右分割）
- position変更時はDOM再構築でレイアウトを切り替え

## Test plan
- [x] `uv run ruff check .` — 通過
- [x] `uv run pytest` — 933 passed（3件テスト追加）
- [x] アプリ起動後、config画面でSplit terminal positionをrightに変更→保存→ターミナルを開いてchild pane領域に表示されることを確認
- [x] bottomに戻して従来の動作になることを確認

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)