### PR TITLE
Performance: lazy-load imports for non-TUI commands (#280)

### DIFF
--- a/scripts/benchmark_startup_imports.py
+++ b/scripts/benchmark_startup_imports.py
@@ -1,0 +1,41 @@
+"""Benchmark non-TUI command startup time.
+
+Measures wall-clock time for init and help commands
+to verify lazy import improvements.
+
+Usage:
+    uv run python scripts/benchmark_startup_imports.py
+"""
+
+import subprocess
+import sys
+import time
+
+
+def measure(command: list[str], runs: int = 20) -> float:
+    """Return mean wall-clock time in ms for the given command."""
+    times: list[float] = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        subprocess.run(command, capture_output=True)
+        t1 = time.perf_counter()
+        times.append((t1 - t0) * 1000)
+    return sum(times) / len(times)
+
+
+def main() -> None:
+    python = sys.executable
+
+    init_cmd = [python, "-c", "from zivo.__main__ import main; main(['init', 'bash'])"]
+    import_cmd = [python, "-c", "import zivo; zivo.create_app"]
+
+    init_time = measure(init_cmd)
+    import_time = measure(import_cmd)
+
+    print(f"zivo init bash:            {init_time:.0f}ms (avg of 20 runs)")
+    print(f"zivo create_app (TUI):     {import_time:.0f}ms (avg of 20 runs)")
+    print(f"estimated savings:         {import_time - init_time:.0f}ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zivo/__init__.py
+++ b/src/zivo/__init__.py
@@ -2,5 +2,10 @@
 
 __all__ = ["create_app"]
 
-from .app import create_app
 
+def __getattr__(name: str) -> object:
+    if name == "create_app":
+        from .app import create_app
+
+        return create_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/zivo/__main__.py
+++ b/src/zivo/__main__.py
@@ -8,11 +8,10 @@ import sys
 from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import IO, Iterator
+from typing import IO, TYPE_CHECKING, Iterator
 
-from .app import create_app
-from .services import configure_file_logging, load_app_config
-from .state import NotificationState
+if TYPE_CHECKING:
+    from .state import NotificationState
 
 
 @dataclass(frozen=True)
@@ -65,6 +64,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stdout.write(render_shell_init(args.shell))
         return 0
 
+    from .app import create_app
+    from .services import configure_file_logging, load_app_config
+
     config_result = load_app_config()
     logging_result = configure_file_logging(
         config=config_result.config.logging,
@@ -99,6 +101,8 @@ def _startup_notification(
     config_warnings: tuple[str, ...],
     logging_warning: str = "",
 ) -> NotificationState | None:
+    from .state import NotificationState
+
     messages = list(config_warnings)
     if logging_warning:
         messages.append(logging_warning)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,13 +45,15 @@ def test_render_shell_init_outputs_zivo_cd_function() -> None:
 
 def test_main_print_last_dir_outputs_return_value(capsys, monkeypatch) -> None:
     app = DummyApp(return_value="/tmp/zivo-last-dir")
-    monkeypatch.setattr(cli, "load_app_config", lambda: ConfigLoadResult(config=AppConfig()))
     monkeypatch.setattr(
-        cli,
-        "configure_file_logging",
+        "zivo.services.load_app_config",
+        lambda: ConfigLoadResult(config=AppConfig()),
+    )
+    monkeypatch.setattr(
+        "zivo.services.configure_file_logging",
         lambda **_kwargs: LoggingSetupResult(enabled=True, path="/tmp/zivo.log"),
     )
-    monkeypatch.setattr(cli, "create_app", lambda **_kwargs: app)
+    monkeypatch.setattr("zivo.app.create_app", lambda **_kwargs: app)
 
     return_code = cli.main(["--print-last-dir"])
 
@@ -62,13 +64,15 @@ def test_main_print_last_dir_outputs_return_value(capsys, monkeypatch) -> None:
 
 def test_main_print_last_dir_falls_back_to_current_path(capsys, monkeypatch) -> None:
     app = DummyApp(return_value=None, current_path="/tmp/zivo-fallback")
-    monkeypatch.setattr(cli, "load_app_config", lambda: ConfigLoadResult(config=AppConfig()))
     monkeypatch.setattr(
-        cli,
-        "configure_file_logging",
+        "zivo.services.load_app_config",
+        lambda: ConfigLoadResult(config=AppConfig()),
+    )
+    monkeypatch.setattr(
+        "zivo.services.configure_file_logging",
         lambda **_kwargs: LoggingSetupResult(enabled=True, path="/tmp/zivo.log"),
     )
-    monkeypatch.setattr(cli, "create_app", lambda **_kwargs: app)
+    monkeypatch.setattr("zivo.app.create_app", lambda **_kwargs: app)
 
     return_code = cli.main(["--print-last-dir"])
 
@@ -168,13 +172,15 @@ def test_main_print_last_dir_runs_app_with_tty_streams_when_stdout_is_captured(
     monkeypatch.setattr(sys, "__stdin__", original_stdin, raising=False)
     monkeypatch.setattr(sys, "__stdout__", original_stdout, raising=False)
     monkeypatch.setattr(sys, "__stderr__", original_stderr, raising=False)
-    monkeypatch.setattr(cli, "load_app_config", lambda: ConfigLoadResult(config=AppConfig()))
     monkeypatch.setattr(
-        cli,
-        "configure_file_logging",
+        "zivo.services.load_app_config",
+        lambda: ConfigLoadResult(config=AppConfig()),
+    )
+    monkeypatch.setattr(
+        "zivo.services.configure_file_logging",
         lambda **_kwargs: LoggingSetupResult(enabled=True, path="/tmp/zivo.log"),
     )
-    monkeypatch.setattr(cli, "create_app", lambda **_kwargs: app)
+    monkeypatch.setattr("zivo.app.create_app", lambda **_kwargs: app)
     monkeypatch.setattr(
         cli,
         "_open_tty_streams",
@@ -204,8 +210,7 @@ def test_main_passes_loaded_config_and_warnings_to_create_app(monkeypatch) -> No
     captured_logging_kwargs: dict[str, object] = {}
 
     monkeypatch.setattr(
-        cli,
-        "load_app_config",
+        "zivo.services.load_app_config",
         lambda: ConfigLoadResult(
             config=loaded_config,
             warnings=("using test config",),
@@ -216,13 +221,16 @@ def test_main_passes_loaded_config_and_warnings_to_create_app(monkeypatch) -> No
         captured_logging_kwargs.update(kwargs)
         return LoggingSetupResult(enabled=True, path="/tmp/custom-zivo.log")
 
-    monkeypatch.setattr(cli, "configure_file_logging", fake_configure_file_logging)
+    monkeypatch.setattr(
+        "zivo.services.configure_file_logging",
+        fake_configure_file_logging,
+    )
 
     def fake_create_app(**kwargs):
         captured_kwargs.update(kwargs)
         return app
 
-    monkeypatch.setattr(cli, "create_app", fake_create_app)
+    monkeypatch.setattr("zivo.app.create_app", fake_create_app)
 
     return_code = cli.main([])
 
@@ -252,13 +260,15 @@ def test_main_logs_and_reraises_runtime_exception(monkeypatch) -> None:
         raise RuntimeError("boom")
 
     app.run = lambda **_kwargs: raise_in_run()  # type: ignore[method-assign]
-    monkeypatch.setattr(cli, "load_app_config", lambda: ConfigLoadResult(config=AppConfig()))
     monkeypatch.setattr(
-        cli,
-        "configure_file_logging",
+        "zivo.services.load_app_config",
+        lambda: ConfigLoadResult(config=AppConfig()),
+    )
+    monkeypatch.setattr(
+        "zivo.services.configure_file_logging",
         lambda **_kwargs: LoggingSetupResult(enabled=True, path="/tmp/zivo.log"),
     )
-    monkeypatch.setattr(cli, "create_app", lambda **_kwargs: app)
+    monkeypatch.setattr("zivo.app.create_app", lambda **_kwargs: app)
 
     captured: list[str] = []
 

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -1,0 +1,27 @@
+"""Verify non-TUI commands avoid heavy imports."""
+
+import subprocess
+import sys
+
+
+def test_init_command_does_not_import_textual() -> None:
+    """zivo init bash should not import textual or pygments."""
+    script = (
+        "import sys; "
+        "from zivo.__main__ import main; "
+        "main(['init', 'bash']); "
+        "assert 'textual' not in sys.modules, "
+        "'textual was imported during init command'; "
+        "assert 'pygments' not in sys.modules, "
+        "'pygments was imported during init command'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"init command failed or imported heavy deps.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "zivo-cd()" in result.stdout

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -4,7 +4,7 @@ from zivo.__main__ import main
 
 
 def test_main_runs_app() -> None:
-    with patch("zivo.__main__.create_app") as create_app:
+    with patch("zivo.app.create_app") as create_app:
         app = create_app.return_value
 
         main([])


### PR DESCRIPTION
## Summary
- Defer heavy imports (textual, pygments, services, state) past the `init` command early return in `main()`
- Add PEP 562 lazy `__getattr__` in `__init__.py` so `import zivo` alone doesn't trigger textual
- Add test verifying `zivo init bash` does not import textual or pygments
- Add benchmark script to measure startup time improvement

## Test plan
- [x] `uv run pytest` — 942/943 passed (1 pre-existing flaky test unrelated to changes)
- [x] `uv run ruff check .` — all checks passed
- [x] New test `test_init_command_does_not_import_textual` passes
- [x] `uv run python scripts/benchmark_startup_imports.py` shows measurable improvement

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)