### PR TITLE
Change delete keybindings to d/D keys (#588)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -217,6 +217,8 @@ zivo-cd
 | `r` | 選択項目をリネーム |
 | `n` | 新規ファイル作成 |
 | `N` | 新規ディレクトリ作成 |
+| `d` | 選択項目をゴミ箱へ移動 |
+| `D` | 選択項目を完全に削除 |
 | `Delete` | 選択項目をゴミ箱へ移動（macOS では fn + Delete） |
 | `Shift+Delete` | 選択項目を完全に削除（macOS では fn + Shift + Delete） |
 | `i` | ファイル属性を表示 |
@@ -232,7 +234,6 @@ zivo-cd
 | `~` | ホームディレクトリに移動 |
 | `.` | 隠しファイル表示を切り替え |
 | `s` | ソート順を循環切り替え |
-| `d` | ディレクトリ優先表示を切り替え |
 | `R` | ディレクトリを再読み込み |
 | `t` | 分割ターミナルを切り替え |
 | `T` | 現在のディレクトリでターミナルを開く |
@@ -381,7 +382,7 @@ zivo は起動時にユーザー設定用の `config.toml` を読み込みます
 | `display` | `default_sort_field` | `name` / `modified` / `size` | 中央ペインの初期ソート項目です。 |
 | `display` | `default_sort_descending` | `true` / `false` | `true` のとき、起動時のソートを降順にします。 |
 | `display` | `directories_first` | `true` / `false` | 中央ペインでディレクトリをファイルより先にまとめて表示します。 |
-| `behavior` | `confirm_delete` | `true` / `false` | ゴミ箱削除の前に確認ダイアログを表示します。`Shift+Delete` による完全削除は常に確認します。 |
+| `behavior` | `confirm_delete` | `true` / `false` | ゴミ箱削除の前に確認ダイアログを表示します。`D` / `Shift+Delete` による完全削除は常に確認します。 |
 | `behavior` | `paste_conflict_action` | `prompt` / `overwrite` / `skip` / `rename` | 貼り付け競合時の既定動作です。`prompt` の場合は競合ダイアログを維持します。 |
 | `logging` | `enabled` | `true` / `false` | 起動失敗や未処理例外をログファイルへ出力するかどうかを切り替えます。 |
 | `logging` | `level` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL` | ログファイルへ出力するログレベルです。既定値は `ERROR` です。設定の反映にはアプリの再起動が必要です。 |

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ When a file is focused, press `e` to switch into a terminal editor in the curren
 | `r` | Rename selected item |
 | `n` | Create new file |
 | `N` | Create new directory |
+| `d` | Move selected items to trash |
+| `D` | Permanently delete selected items |
 | `Delete` | Move selected items to trash (fn + Delete on macOS) |
 | `Shift+Delete` | Permanently delete selected items (fn + Shift + Delete on macOS) |
 | `i` | Show file attributes |
@@ -231,7 +233,6 @@ When a file is focused, press `e` to switch into a terminal editor in the curren
 | `~` | Go to home directory |
 | `.` | Toggle hidden files |
 | `s` | Cycle sort |
-| `d` | Toggle directories-first |
 | `R` | Reload directory |
 | `t` | Toggle split terminal |
 | `T` | Open terminal at current directory |
@@ -381,7 +382,7 @@ The supported settings are:
 | `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. |
 | `display` | `default_sort_descending` | `true` / `false` | Starts the main-pane sort in descending order when enabled. |
 | `display` | `directories_first` | `true` / `false` | Keeps directories grouped before files in the main pane. |
-| `behavior` | `confirm_delete` | `true` / `false` | Shows a confirmation dialog before moving items to trash. Permanent delete via `Shift+Delete` always asks for confirmation. |
+| `behavior` | `confirm_delete` | `true` / `false` | Shows a confirmation dialog before moving items to trash. Permanent delete via `D` / `Shift+Delete` always asks for confirmation. |
 | `behavior` | `paste_conflict_action` | `prompt` / `overwrite` / `skip` / `rename` | Chooses the default paste-conflict behavior. `prompt` keeps the conflict dialog enabled. |
 | `logging` | `enabled` | `true` / `false` | Enables file output for startup failures and unhandled exceptions. |
 | `logging` | `level` | `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL` | Log level for file output. Defaults to `ERROR`. Requires app restart to take effect. |

--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -294,7 +294,7 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
             CommandPaletteItem(
                 id="delete_targets",
                 label="Move to trash",
-                shortcut="Del",
+                shortcut="d",
                 enabled=True,
             )
         )

--- a/src/zivo/state/input.py
+++ b/src/zivo/state/input.py
@@ -132,7 +132,8 @@ BROWSING_KEYMAP = {
     "!": "begin_shell_command",
     ":": "begin_command_palette",
     "s": "cycle_sort",
-    "d": "toggle_directories_first",
+    "d": "delete_targets",
+    "D": "permanent_delete_targets",
     "delete": "delete_targets",
     "shift+delete": "permanent_delete_targets",
     "e": "open_in_editor",
@@ -889,18 +890,6 @@ def _handle_cycle_sort(state: AppState, _ctx: _BrowsingCtx) -> DispatchedActions
     return _supported(_next_sort_action(state))
 
 
-def _handle_toggle_directories_first(
-    state: AppState, _ctx: _BrowsingCtx
-) -> DispatchedActions:
-    return _supported(
-        SetSort(
-            field=state.sort.field,
-            descending=state.sort.descending,
-            directories_first=not state.sort.directories_first,
-        )
-    )
-
-
 def _handle_delete_targets(_state: AppState, ctx: _BrowsingCtx) -> DispatchedActions:
     if not ctx.target_paths:
         return _warn("Nothing to delete")
@@ -982,7 +971,6 @@ _BROWSING_COMPLEX_DISPATCH: dict[str, _BrowsingHandler] = {
     "toggle_bookmark": _handle_toggle_bookmark,
     "begin_rename": _handle_begin_rename,
     "cycle_sort": _handle_cycle_sort,
-    "toggle_directories_first": _handle_toggle_directories_first,
     "delete_targets": _handle_delete_targets,
     "permanent_delete_targets": _handle_permanent_delete_targets,
     "open_in_editor": _handle_open_in_editor,

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -481,7 +481,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
     return HelpBarState(
         (
             "enter open | e edit | i info | space select | c copy | x cut | v paste | "
-            "r rename | z undo",
+            "d delete | r rename | z undo",
             "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to",
             "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit",
         )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2506,7 +2506,7 @@ async def test_app_displays_browsing_help_bar() -> None:
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
         "enter open | e edit | i info | space select | c copy | x cut | v paste | "
-        "r rename | z undo\n"
+        "d delete | r rename | z undo\n"
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to\n"
         "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit"
     )
@@ -4640,13 +4640,18 @@ async def test_app_sort_shortcuts_keep_side_panes_fixed_and_update_status_bar() 
         ),
     )
     loader = FakeBrowserSnapshotLoader(snapshots={path: snapshot})
-    app = create_app(snapshot_loader=loader, initial_path=path)
+    app = create_app(
+        snapshot_loader=loader,
+        initial_path=path,
+        app_config=AppConfig(
+            display=DisplayConfig(directories_first=False),
+        ),
+    )
 
     async with app.run_test() as pilot:
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 3)
 
-        await pilot.press("d")
         await pilot.press("s")
         await asyncio.sleep(0.05)
 
@@ -5264,11 +5269,10 @@ async def test_app_main_flow_round_trip_on_live_filesystem(tmp_path) -> None:
         assert app.app_state.filter.active is False
 
         await pilot.press("s")
-        await pilot.press("d")
         await asyncio.sleep(0.05)
 
         summary_bar = await _wait_for_summary_bar(app)
-        assert str(summary_bar.renderable) == ("4 items | 0 selected | sort: name desc dirs:off")
+        assert str(summary_bar.renderable) == ("4 items | 0 selected | sort: name desc dirs:on")
 
 
 @pytest.mark.asyncio

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -1103,14 +1103,28 @@ def test_browsing_s_cycles_from_name_desc_to_modified_desc() -> None:
     )
 
 
-def test_browsing_d_toggles_directories_first() -> None:
+def test_browsing_d_dispatches_delete_targets() -> None:
     state = build_initial_app_state()
 
     actions = dispatch_key_input(state, key="d", character="d")
 
     assert actions == (
         SetNotification(None),
-        SetSort(field="name", descending=False, directories_first=False),
+        BeginDeleteTargets(("/home/tadashi/develop/zivo/docs",)),
+    )
+
+
+def test_browsing_d_warns_when_no_target_exists() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        current_pane=replace(state.current_pane, entries=(), cursor_path=None),
+    )
+
+    actions = dispatch_key_input(state, key="d", character="d")
+
+    assert actions == (
+        SetNotification(NotificationState(level="warning", message="Nothing to delete")),
     )
 
 
@@ -1147,6 +1161,33 @@ def test_browsing_shift_delete_dispatches_permanent_delete_targets() -> None:
     assert actions == (
         SetNotification(None),
         BeginDeleteTargets(("/home/tadashi/develop/zivo/docs",), mode="permanent"),
+    )
+
+
+def test_browsing_uppercase_D_dispatches_permanent_delete_targets() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="D", character="D")
+
+    assert actions == (
+        SetNotification(None),
+        BeginDeleteTargets(("/home/tadashi/develop/zivo/docs",), mode="permanent"),
+    )
+
+
+def test_browsing_uppercase_D_warns_when_no_target_exists() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        current_pane=replace(state.current_pane, entries=(), cursor_path=None),
+    )
+
+    actions = dispatch_key_input(state, key="D", character="D")
+
+    assert actions == (
+        SetNotification(
+            NotificationState(level="warning", message="Nothing to permanently delete")
+        ),
     )
 
 

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1212,13 +1212,13 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
 
     assert help_state.lines == (
         "enter open | e edit | i info | space select | c copy | x cut | v paste | "
-        "r rename | z undo",
+        "d delete | r rename | z undo",
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to",
         "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit",
     )
     assert help_state.text == (
         "enter open | e edit | i info | space select | c copy | x cut | v paste | "
-        "r rename | z undo\n"
+        "d delete | r rename | z undo\n"
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to\n"
         "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit"
     )


### PR DESCRIPTION
## Summary
- `d` キーを directories_first トグルからゴミ箱への移動（delete_targets）に変更
- `D`（Shift+d）で完全削除（permanent_delete_targets）を追加
- 既存の `delete` / `shift+delete` キーバインドはそのまま残す
- directories_first のトグルはキーバインドから削除し、config.toml からのみ設定可能に変更
- コマンドパレットのショートカット表示とヘルプバーを更新

## Test plan
- [x] `uv run pytest` 全946テスト通過
- [x] `uv run ruff check .` lint チェック通過
- [x] `d` キーで delete_targets が発行されるテスト追加
- [x] `D` キーで permanent_delete_targets が発行されるテスト追加
- [x] 対象なしの場合の警告メッセージテスト追加
- [x] ヘルプバー・コマンドパレット表示のテスト更新

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)