### PR TITLE
[#582] Add overlay split terminal position

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ zivo aims to be usable by everyone without complex configuration, plugin install
 
 - Multiple tabs let you keep separate working directories open in one zivo session. You can open a new tab, switch to the next or previous tab, and close the current tab without leaving the TUI.
 
-- An embedded terminal can be opened below the browser panes. `t` switches quickly between the browser and terminal, and the terminal starts in the current directory so you can move between browsing and shell work without changing directories manually.
+- An embedded terminal can be opened below the browser panes, to the right, or as an overlay above the browser area. `t` switches quickly between the browser and terminal, and the terminal starts in the current directory so you can move between browsing and shell work without changing directories manually.
 
   ![](docs/resources/screen-split-terminal.png)
 
@@ -382,6 +382,7 @@ The supported settings are:
 | `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. |
 | `display` | `default_sort_descending` | `true` / `false` | Starts the main-pane sort in descending order when enabled. |
 | `display` | `directories_first` | `true` / `false` | Keeps directories grouped before files in the main pane. |
+| `display` | `split_terminal_position` | `bottom` / `right` / `overlay` | Chooses where the embedded terminal opens. `overlay` keeps the help bar and status message visible while placing the terminal over the browser area with a margin. |
 | `behavior` | `confirm_delete` | `true` / `false` | Shows a confirmation dialog before moving items to trash. Permanent delete via `D` / `Shift+Delete` always asks for confirmation. |
 | `behavior` | `paste_conflict_action` | `prompt` / `overwrite` / `skip` / `rename` | Chooses the default paste-conflict behavior. `prompt` keeps the conflict dialog enabled. |
 | `logging` | `enabled` | `true` / `false` | Enables file output for startup failures and unhandled exceptions. |

--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -21,7 +21,12 @@ from zivo.app_runtime import (
     schedule_effects,
     sync_runtime_state,
 )
-from zivo.app_shell import build_body, refresh_shell, resize_split_terminal_session
+from zivo.app_shell import (
+    build_body,
+    build_split_terminal_layer,
+    refresh_shell,
+    resize_split_terminal_session,
+)
 from zivo.models import (
     AppConfig,
     ThreePaneShellData,
@@ -204,6 +209,10 @@ class zivoApp(App[None]):
         shell = select_shell_data(self._app_state)
         yield CurrentPathBar(shell.current_path, id="current-path-bar")
         yield self._build_body(shell)
+        yield build_split_terminal_layer(
+            shell,
+            terminal_position=self._app_state.config.display.split_terminal_position,
+        )
         yield Container(
             CommandPalette(shell.command_palette, id="command-palette"),
             id="command-palette-layer",
@@ -333,6 +342,29 @@ class zivoApp(App[None]):
             row_region.y,
         )
 
+    def _update_split_terminal_overlay_geometry(self) -> None:
+        """Constrain the overlay terminal above the help and status bars."""
+
+        try:
+            split_terminal_layer = self.query_one("#split-terminal-layer", Container)
+            body = self.query_one("#body")
+            help_bar = self.query_one("#help-bar", HelpBar)
+        except NoMatches:
+            return
+
+        body_region = body.region
+        help_bar_region = help_bar.region
+        overlay_height = help_bar_region.y - body_region.y
+        if body_region.width <= 0 or overlay_height <= 0:
+            return
+
+        split_terminal_layer.styles.width = body_region.width
+        split_terminal_layer.styles.height = overlay_height
+        split_terminal_layer.styles.offset = (
+            body_region.x,
+            body_region.y,
+        )
+
     async def on_mount(self) -> None:
         """Load the initial directory snapshot after the UI mounts."""
 
@@ -450,6 +482,10 @@ class zivoApp(App[None]):
                 await self.query_one("#body").remove()
             except NoMatches:
                 pass
+            try:
+                await self.query_one("#split-terminal-layer").remove()
+            except NoMatches:
+                pass
         if changed or theme_changed or layout_changed:
             await self._refresh_shell(theme_changed=theme_changed)
         schedule_effects(self, effects)
@@ -549,6 +585,7 @@ class zivoApp(App[None]):
         self._update_command_palette_geometry()
         self._update_config_dialog_geometry()
         self._update_input_dialog_geometry()
+        self._update_split_terminal_overlay_geometry()
 
     def _resize_split_terminal_session(self) -> None:
         resize_split_terminal_session(

--- a/src/zivo/app.tcss
+++ b/src/zivo/app.tcss
@@ -161,6 +161,10 @@ Screen {
     align-horizontal: center;
 }
 
+.split-terminal-overlay-layer {
+    align: center middle;
+}
+
 .dialog-layer {
     align: center middle;
 }
@@ -329,6 +333,25 @@ Screen {
 }
 
 #split-terminal.split-terminal-right.-focused {
+    background: $boost;
+}
+
+#split-terminal.split-terminal-overlay {
+    display: none;
+    width: 1fr;
+    height: 1fr;
+    min-width: 20;
+    min-height: 6;
+    margin: 1 2;
+    border: round $surface;
+    background: $surface;
+}
+
+#split-terminal.split-terminal-overlay.-visible {
+    display: block;
+}
+
+#split-terminal.split-terminal-overlay.-focused {
     background: $boost;
 }
 

--- a/src/zivo/app_shell.py
+++ b/src/zivo/app_shell.py
@@ -26,6 +26,27 @@ from zivo.ui import (
 )
 
 
+def build_split_terminal_layer(
+    shell: ThreePaneShellData,
+    *,
+    terminal_position: str = "bottom",
+) -> Container:
+    children: tuple[Any, ...] = ()
+    if terminal_position == "overlay":
+        children = (
+            SplitTerminalPane(
+                shell.split_terminal,
+                id="split-terminal",
+                classes="split-terminal-overlay",
+            ),
+        )
+    return Container(
+        *children,
+        id="split-terminal-layer",
+        classes="overlay-layer split-terminal-overlay-layer",
+    )
+
+
 def build_body(shell: ThreePaneShellData, *, terminal_position: str = "bottom") -> Vertical:
     browser_row_children: list[Any] = [
         SidePane(
@@ -61,7 +82,7 @@ def build_body(shell: ThreePaneShellData, *, terminal_position: str = "bottom") 
     body_children: list[Any] = [
         Horizontal(*browser_row_children, id="browser-row"),
     ]
-    if terminal_position != "right":
+    if terminal_position not in {"right", "overlay"}:
         body_children.append(
             SplitTerminalPane(shell.split_terminal, id="split-terminal")
         )
@@ -86,6 +107,7 @@ async def refresh_shell(
         command_palette = app.query_one("#command-palette", CommandPalette)
         help_bar = app.query_one("#help-bar", HelpBar)
         status_bar = app.query_one("#status-bar", StatusBar)
+        split_terminal_layer = app.query_one("#split-terminal-layer", Container)
         command_palette_layer = app.query_one("#command-palette-layer", Container)
         conflict_dialog_layer = app.query_one("#conflict-dialog-layer", Container)
         attribute_dialog_layer = app.query_one("#attribute-dialog-layer", Container)
@@ -102,6 +124,7 @@ async def refresh_shell(
             "#current-path-bar",
             "#tab-bar",
             "#body",
+            "#split-terminal-layer",
             "#command-palette",
             "#command-palette-layer",
             "#split-terminal",
@@ -127,6 +150,12 @@ async def refresh_shell(
         await app.mount(CurrentPathBar(shell.current_path, id="current-path-bar"))
         terminal_position = app_state.config.display.split_terminal_position
         await app.mount(build_body(shell, terminal_position=terminal_position))
+        await app.mount(
+            build_split_terminal_layer(
+                shell,
+                terminal_position=terminal_position,
+            )
+        )
         await app.mount(
             Container(
                 CommandPalette(shell.command_palette, id="command-palette"),
@@ -193,6 +222,9 @@ async def refresh_shell(
     terminal_position = app_state.config.display.split_terminal_position
     if terminal_position == "right":
         child_pane.display = not app_state.split_terminal.visible
+    split_terminal_layer.display = (
+        terminal_position == "overlay" and shell.split_terminal.visible
+    )
     if theme_changed:
         def _refresh_themed_panes() -> None:
             parent_pane.refresh_styles()

--- a/src/zivo/models/config.py
+++ b/src/zivo/models/config.py
@@ -6,7 +6,7 @@ from typing import Literal
 from zivo.theme_support import AUTO_PREVIEW_SYNTAX_THEME, DEFAULT_APP_THEME
 
 ConfigSortField = Literal["name", "modified", "size"]
-SplitTerminalPosition = Literal["bottom", "right"]
+SplitTerminalPosition = Literal["bottom", "right", "overlay"]
 ConfigTheme = str
 PreviewSyntaxTheme = str
 ConfigLogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/src/zivo/services/config.py
+++ b/src/zivo/services/config.py
@@ -44,7 +44,7 @@ _VALID_THEMES = frozenset(SUPPORTED_APP_THEMES)
 _VALID_PREVIEW_SYNTAX_THEMES = frozenset(SUPPORTED_PREVIEW_SYNTAX_THEMES)
 _VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 _VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
-_VALID_SPLIT_TERMINAL_POSITIONS = frozenset({"bottom", "right"})
+_VALID_SPLIT_TERMINAL_POSITIONS = frozenset({"bottom", "right", "overlay"})
 _VALID_TERMINAL_EDITOR_NAMES = frozenset(
     {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
 )
@@ -267,7 +267,7 @@ def _load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
             key="split_terminal_position",
             default=config.split_terminal_position,
             valid_values=_VALID_SPLIT_TERMINAL_POSITIONS,
-            valid_display="bottom, right",
+            valid_display="bottom, right, overlay",
             section_name="display",
             warnings=warnings,
         ),

--- a/src/zivo/state/reducer_common.py
+++ b/src/zivo/state/reducer_common.py
@@ -58,7 +58,7 @@ CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
 CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
 CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
-CONFIG_SPLIT_TERMINAL_POSITIONS = ("bottom", "right")
+CONFIG_SPLIT_TERMINAL_POSITIONS = ("bottom", "right", "overlay")
 REGEX_FILE_SEARCH_PREFIX = "re:"
 REGEX_GREP_SEARCH_PREFIX = "re:"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4958,13 +4958,15 @@ async def test_app_rename_round_trip_updates_status_bar(tmp_path) -> None:
         for _ in range(4):
             await pilot.press("backspace")
         await pilot.press("m", "a", "n", "u", "a", "l", "s", "enter")
-        await asyncio.sleep(0.1)
-
-        status_bar = await _wait_for_status_bar(app)
+        await _wait_for_predicate(
+            lambda: app.app_state.ui_mode == "BROWSING",
+            timeout=1.0,
+            message="rename did not return to browsing mode",
+        )
+        await _wait_for_status_message(app, "info: Renamed to manuals", timeout=1.0)
 
         assert (tmp_path / "manuals").is_dir()
         assert app.app_state.ui_mode == "BROWSING"
-        assert str(status_bar.renderable) == "info: Renamed to manuals"
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4208,6 +4208,52 @@ async def test_app_split_terminal_uses_half_of_body_height_when_visible() -> Non
 
 
 @pytest.mark.asyncio
+async def test_app_overlay_split_terminal_keeps_help_and_status_visible() -> None:
+    path = str(Path("/tmp/zivo-split-terminal-overlay").resolve())
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: _build_snapshot(
+                path,
+                (
+                    DirectoryEntryState(f"{path}/docs", "docs", "dir"),
+                    DirectoryEntryState(f"{path}/README.md", "README.md", "file"),
+                ),
+                child_path=f"{path}/docs",
+            )
+        }
+    )
+    split_terminal_service = FakeSplitTerminalService()
+    app = create_app(
+        snapshot_loader=loader,
+        split_terminal_service=split_terminal_service,
+        app_config=AppConfig(
+            display=DisplayConfig(split_terminal_position="overlay"),
+        ),
+        initial_path=path,
+    )
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        child_pane = app.query_one("#child-pane", ChildPane)
+        body = app.query_one("#body")
+        help_bar = app.query_one("#help-bar", HelpBar)
+        status_bar = app.query_one("#status-bar", StatusBar)
+
+        await pilot.press("t")
+        await asyncio.sleep(0.05)
+
+        split_terminal = await _wait_for_split_terminal(app)
+        split_terminal_layer = app.query_one("#split-terminal-layer")
+
+        assert split_terminal.display is True
+        assert split_terminal_layer.display is True
+        assert child_pane.display is True
+        assert split_terminal.region.y > body.region.y
+        assert split_terminal.region.bottom < help_bar.region.y
+        assert help_bar.region.bottom <= status_bar.region.y
+
+
+@pytest.mark.asyncio
 async def test_app_split_terminal_focus_routes_input_to_session() -> None:
     path = str(Path("/tmp/zivo-split-terminal-input").resolve())
     loader = FakeBrowserSnapshotLoader(

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -334,6 +334,22 @@ def test_loader_reads_split_terminal_position(tmp_path) -> None:
     assert result.config.display.split_terminal_position == "right"
 
 
+def test_loader_reads_overlay_split_terminal_position(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [display]
+        split_terminal_position = "overlay"
+        """,
+        encoding="utf-8",
+    )
+
+    result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
+
+    assert result.warnings == ()
+    assert result.config.display.split_terminal_position == "overlay"
+
+
 def test_loader_rejects_invalid_split_terminal_position(tmp_path) -> None:
     config_path = tmp_path / "config.toml"
     config_path.write_text(

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1472,6 +1472,31 @@ def test_cycle_config_editor_split_terminal_position_updates_draft() -> None:
     assert next_state.config_editor.dirty is True
 
 
+def test_cycle_config_editor_split_terminal_position_reaches_overlay() -> None:
+    original_state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
+    state = replace(
+        original_state,
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/zivo/config.toml",
+            draft=replace(
+                original_state.config,
+                display=replace(
+                    original_state.config.display,
+                    split_terminal_position="right",
+                ),
+            ),
+            cursor_index=11,
+        ),
+    )
+
+    next_state = _reduce_state(state, CycleConfigEditorValue(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.draft.display.split_terminal_position == "overlay"
+    assert next_state.config_editor.dirty is True
+
+
 def test_cycle_config_editor_theme_updates_draft_and_dirty_state() -> None:
     original_state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
     state = replace(


### PR DESCRIPTION
## Summary
- add `overlay` as a supported split terminal position
- render overlay mode in a dedicated overlay layer while keeping the help bar and status bar visible
- add config, reducer, UI, and README coverage for the new display mode

## Testing
- `uv run pytest -q`
- `uv run ruff check .`

Closes #582