### PR TITLE
Add Filename filter field to Grep Search palette

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -339,7 +339,7 @@ zivo-cd
 | `Previous tab` | 2 タブ以上開いているとき | 前のブラウズタブへ切り替えます。`shift+tab` でも実行できます。 |
 | `Close current tab` | 2 タブ以上開いているとき | アクティブなブラウズタブを閉じます。最後の 1 タブは閉じられません。`w` でも実行できます。 |
 | `Find files` | 常に表示 | 再帰ファイル検索を開きます。 |
-| `Grep search` | 常に表示 | 再帰 grep 検索を開きます（`ripgrep` / `rg` が `PATH` 上に必要）。 |
+| `Grep search` | 常に表示 | 4 フィールドの grep 検索パレット（keyword, filter: filename, filter: include extensions, filter: exclude extensions）を開きます。`Tab` / `Shift+Tab` でフィールドを切り替えられます。 |
 | `History search` | 常に表示 | ディレクトリ履歴リストを開き、選択したディレクトリへ移動します。 |
 | `Show bookmarks` | 常に表示 | 保存済みのブックマークリストを開き、選択したディレクトリへ移動します。 |
 | `Go back` | ディレクトリ履歴に戻り先があるとき | 履歴を一つ戻ります。 |

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Previous tab` | Two or more tabs are open | Activates the previous browser tab. Also available with `shift+tab`. |
 | `Close current tab` | Two or more tabs are open | Closes the active browser tab. The last remaining tab cannot be closed. Also available with `w`. |
 | `Find files` | Always | Opens recursive file search. |
-| `Grep search` | Always | Opens recursive grep search (`ripgrep` / `rg` required on `PATH`). |
+| `Grep search` | Always | Opens a four-field grep search palette (keyword, filter: filename, filter: include extensions, filter: exclude extensions). `Tab` / `Shift+Tab` cycle between fields. |
 | `History search` | Always | Opens directory history list and jump to a selected directory. |
 | `Show bookmarks` | Always | Opens the saved bookmark list and jumps to the selected directory. |
 | `Go back` | Directory history has a previous entry | Moves to the previous directory in history. |

--- a/src/zivo/state/input.py
+++ b/src/zivo/state/input.py
@@ -137,6 +137,7 @@ def _noop_browsing_handler(_state: AppState, _ctx: _BrowsingCtx) -> DispatchedAc
 
     return ()
 
+
 BROWSING_KEYMAP = {
     "up": "cursor_up",
     "shift+up": "cursor_up_selecting",
@@ -349,9 +350,7 @@ def iter_bound_keys() -> tuple[str, ...]:
                 *PALETTE_EXTRA_KEYS,
                 *tuple(
                     dict.fromkeys(
-                        key
-                        for sequence in _MULTI_KEY_COMMAND_DISPATCH
-                        for key in sequence
+                        key for sequence in _MULTI_KEY_COMMAND_DISPATCH for key in sequence
                     )
                 ),
             )
@@ -543,7 +542,9 @@ def _palette_extra_rows(palette_source: str | None) -> int:
         return 3
     if palette_source == "replace_in_grep_files":
         return 5
-    if palette_source in {"grep_search", "replace_text"}:
+    if palette_source == "grep_search":
+        return 3
+    if palette_source == "replace_text":
         return 2
     return 0
 
@@ -1028,27 +1029,19 @@ def _dispatch_pending_multi_key_input(
 # --- Parameterized handlers (Category B) ---
 
 
-def _handle_cursor_up_selecting(
-    _state: AppState, ctx: _BrowsingCtx
-) -> DispatchedActions:
+def _handle_cursor_up_selecting(_state: AppState, ctx: _BrowsingCtx) -> DispatchedActions:
     return _supported(MoveCursorAndSelectRange(delta=-1, visible_paths=ctx.visible_paths))
 
 
-def _handle_cursor_down_selecting(
-    _state: AppState, ctx: _BrowsingCtx
-) -> DispatchedActions:
+def _handle_cursor_down_selecting(_state: AppState, ctx: _BrowsingCtx) -> DispatchedActions:
     return _supported(MoveCursorAndSelectRange(delta=1, visible_paths=ctx.visible_paths))
 
 
-def _handle_jump_cursor_start(
-    _state: AppState, ctx: _BrowsingCtx
-) -> DispatchedActions:
+def _handle_jump_cursor_start(_state: AppState, ctx: _BrowsingCtx) -> DispatchedActions:
     return _supported(JumpCursor(position="start", visible_paths=ctx.visible_paths))
 
 
-def _handle_jump_cursor_end(
-    _state: AppState, ctx: _BrowsingCtx
-) -> DispatchedActions:
+def _handle_jump_cursor_end(_state: AppState, ctx: _BrowsingCtx) -> DispatchedActions:
     return _supported(JumpCursor(position="end", visible_paths=ctx.visible_paths))
 
 
@@ -1156,9 +1149,7 @@ def _handle_delete_targets(_state: AppState, ctx: _BrowsingCtx) -> DispatchedAct
     return _supported(BeginDeleteTargets(ctx.target_paths, mode="trash"))
 
 
-def _handle_permanent_delete_targets(
-    _state: AppState, ctx: _BrowsingCtx
-) -> DispatchedActions:
+def _handle_permanent_delete_targets(_state: AppState, ctx: _BrowsingCtx) -> DispatchedActions:
     if not ctx.target_paths:
         return _warn("Nothing to permanently delete")
     return _supported(BeginDeleteTargets(ctx.target_paths, mode="permanent"))

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -46,7 +46,7 @@ CommandPaletteSource = Literal[
     "replace_in_found_files",
     "replace_in_grep_files",
 ]
-GrepSearchFieldId = Literal["keyword", "include", "exclude"]
+GrepSearchFieldId = Literal["keyword", "filename", "include", "exclude"]
 ReplaceFieldId = Literal["find", "replace"]
 FindReplaceFieldId = Literal["filename", "find", "replace"]
 GrepReplaceFieldId = Literal["keyword", "replace", "filename", "include", "exclude"]
@@ -352,6 +352,7 @@ class CommandPaletteState:
     source: CommandPaletteSource = "commands"
     query: str = ""
     grep_search_keyword: str = ""
+    grep_search_filename_filter: str = ""
     grep_search_include_extensions: str = ""
     grep_search_exclude_extensions: str = ""
     grep_search_active_field: GrepSearchFieldId = "keyword"

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -110,7 +110,7 @@ from .reducer_common import (
 )
 from .selectors import select_target_paths, select_visible_current_entry_states
 
-_GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "include", "exclude")
+_GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "filename", "include", "exclude")
 _REPLACE_FIELDS: tuple[ReplaceFieldId, ...] = ("find", "replace")
 _FIND_REPLACE_FIELDS: tuple[FindReplaceFieldId, ...] = ("filename", "find", "replace")
 _GREP_REPLACE_FIELDS: tuple[GrepReplaceFieldId, ...] = (
@@ -130,6 +130,8 @@ def _grep_field_value(
 ) -> str:
     if field == "keyword":
         return palette.grep_search_keyword
+    if field == "filename":
+        return palette.grep_search_filename_filter
     if field == "include":
         return palette.grep_search_include_extensions
     return palette.grep_search_exclude_extensions
@@ -143,6 +145,8 @@ def _replace_grep_field(
 ) -> CommandPaletteState:
     if field == "keyword":
         return replace(palette, query=value, grep_search_keyword=value)
+    if field == "filename":
+        return replace(palette, grep_search_filename_filter=value)
     if field == "include":
         return replace(palette, grep_search_include_extensions=value)
     return replace(palette, grep_search_exclude_extensions=value)
@@ -453,6 +457,9 @@ def _handle_set_grep_search_field(
     field: GrepSearchFieldId,
     value: str,
 ) -> ReduceResult:
+    if field == "filename":
+        return _handle_set_grep_search_filename(state, value)
+
     next_palette = replace(
         _replace_grep_field(state.command_palette, field=field, value=value),
         grep_search_error_message=None,
@@ -506,6 +513,31 @@ def _handle_set_grep_search_field(
             include_globs=include_globs,
             exclude_globs=exclude_globs,
         ),
+    )
+
+
+def _handle_set_grep_search_filename(
+    state: AppState,
+    value: str,
+) -> ReduceResult:
+    next_palette = replace(
+        state.command_palette,
+        grep_search_filename_filter=value,
+        grep_search_error_message=None,
+        cursor_index=0,
+    )
+    results = _filter_grep_by_filename(state.command_palette.grep_search_results, value)
+    return _sync_grep_preview(
+        replace(
+            state,
+            command_palette=replace(
+                next_palette,
+                grep_search_results=results,
+                grep_search_error_message=None,
+            ),
+            pending_grep_search_request_id=None,
+            pending_child_pane_request_id=None,
+        )
     )
 
 
@@ -1276,8 +1308,7 @@ def _run_replace_text_command(
             next_state,
             level="warning",
             message=(
-                "Replace text requires a selected file or file selection "
-                "in the current directory"
+                "Replace text requires a selected file or file selection in the current directory"
             ),
         )
     return reduce_state(next_state, BeginTextReplace(target_paths=target_paths))
@@ -1673,10 +1704,7 @@ def _handle_grep_search_completed(
     ):
         return _handle_grf_grep_search_completed(state, action)
 
-    if (
-        state.command_palette is None
-        or state.command_palette.source != "grep_search"
-    ):
+    if state.command_palette is None or state.command_palette.source != "grep_search":
         return finalize(state)
 
     return _sync_grep_preview(
@@ -2363,6 +2391,13 @@ def _trigger_grf_preview(
         ),
         RunTextReplacePreviewEffect(request_id=request_id, request=request),
     )
+
+
+def _filter_grep_by_filename(
+    results: tuple[GrepSearchResultState, ...],
+    filename_query: str,
+) -> tuple[GrepSearchResultState, ...]:
+    return _filter_grf_by_filename(results, filename_query)
 
 
 def _filter_grf_by_filename(

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -207,11 +207,7 @@ def _select_child_pane_for_cursor(
         _select_active_app_theme(state),
         _select_active_preview_syntax_theme(state),
     )
-    permissions_label = (
-        _format_permissions_detail_label(cursor_entry)
-        if cursor_entry
-        else ""
-    )
+    permissions_label = _format_permissions_detail_label(cursor_entry) if cursor_entry else ""
     palette_preview = _select_command_palette_preview_pane(state, syntax_theme)
     if palette_preview is not None:
         return palette_preview
@@ -221,20 +217,14 @@ def _select_child_pane_for_cursor(
 
     is_archive = cursor_entry.kind == "file" and is_supported_archive_path(cursor_entry.path)
     if cursor_entry.kind == "dir" or is_archive:
-        if (
-            state.child_pane.mode == "preview"
-            and state.child_pane.preview_message is not None
-        ):
+        if state.child_pane.mode == "preview" and state.child_pane.preview_message is not None:
             pass
         elif (
             state.child_pane.mode != "entries"
             or cursor_entry.path != state.child_pane.directory_path
         ):
             return _build_child_entries_view((), syntax_theme, permissions_label)
-    elif (
-        state.child_pane.mode != "preview"
-        or cursor_entry.path != state.child_pane.preview_path
-    ):
+    elif state.child_pane.mode != "preview" or cursor_entry.path != state.child_pane.preview_path:
         return _build_child_entries_view((), syntax_theme, permissions_label)
 
     if state.child_pane.mode == "preview" and state.child_pane.preview_content is not None:
@@ -429,10 +419,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         return HelpBarState(("type in terminal | ctrl+q close",))
     if state.ui_mode == "CONFIRM":
         if state.delete_confirmation is not None:
-            if (
-                state.delete_confirmation.mode == "trash"
-                and state.config.help_bar.confirm_delete
-            ):
+            if state.delete_confirmation.mode == "trash" and state.config.help_bar.confirm_delete:
                 return HelpBarState(state.config.help_bar.confirm_delete)
             if state.delete_confirmation.mode == "permanent":
                 return HelpBarState(("enter confirm permanent delete | esc cancel",))
@@ -709,9 +696,7 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
             ),
             empty_message=_find_replace_empty_message(state),
             input_fields=_build_find_replace_input_fields(state.command_palette),
-            has_more_items=(
-                len(state.command_palette.rff_preview_results) > len(visible_results)
-            ),
+            has_more_items=(len(state.command_palette.rff_preview_results) > len(visible_results)),
         )
     if state.command_palette.source == "replace_in_grep_files":
         visible_results, title = _select_find_replace_preview_window(
@@ -733,9 +718,7 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
             ),
             empty_message=_grep_replace_empty_message(state),
             input_fields=_build_grep_replace_input_fields(state.command_palette),
-            has_more_items=(
-                len(state.command_palette.grf_preview_results) > len(visible_results)
-            ),
+            has_more_items=(len(state.command_palette.grf_preview_results) > len(visible_results)),
         )
     if state.command_palette.source == "history":
         return _build_command_palette_items_view(
@@ -827,13 +810,19 @@ def _build_grep_search_input_fields(
             active=palette.grep_search_active_field == "keyword",
         ),
         CommandPaletteInputFieldViewState(
-            label="Include",
+            label="Filter: Filename",
+            value=palette.grep_search_filename_filter,
+            placeholder="pattern or re:pattern",
+            active=palette.grep_search_active_field == "filename",
+        ),
+        CommandPaletteInputFieldViewState(
+            label="Filter: Include",
             value=palette.grep_search_include_extensions,
             placeholder="all extensions",
             active=palette.grep_search_active_field == "include",
         ),
         CommandPaletteInputFieldViewState(
-            label="Exclude",
+            label="Filter: Exclude",
             value=palette.grep_search_exclude_extensions,
             placeholder="none",
             active=palette.grep_search_active_field == "exclude",
@@ -953,8 +942,7 @@ def select_conflict_dialog_state(state: AppState) -> ConflictDialogState | None:
         confirmation = state.empty_trash_confirmation
         platform_name = "Linux" if confirmation.platform == "linux" else "macOS"
         message = (
-            f"Permanently delete all items from the {platform_name} trash? "
-            "This cannot be undone."
+            f"Permanently delete all items from the {platform_name} trash? This cannot be undone."
         )
         return ConflictDialogState(
             title="Empty Trash Confirmation",
@@ -1082,14 +1070,16 @@ def select_config_dialog_state(state: AppState) -> ConfigDialogState | None:
                 )
             )
 
-    lines_list.extend([
-        "",
-        _format_custom_editor_hint(config.editor.command),
-        "Terminal launch templates: edit config.toml with e",
-        f"  Linux templates: {len(config.terminal.linux)}",
-        f"  macOS templates: {len(config.terminal.macos)}",
-        f"  Windows templates: {len(config.terminal.windows)}",
-    ])
+    lines_list.extend(
+        [
+            "",
+            _format_custom_editor_hint(config.editor.command),
+            "Terminal launch templates: edit config.toml with e",
+            f"  Linux templates: {len(config.terminal.linux)}",
+            f"  macOS templates: {len(config.terminal.macos)}",
+            f"  Windows templates: {len(config.terminal.windows)}",
+        ]
+    )
 
     title = "Config Editor"
     if state.config_editor.dirty:
@@ -1625,9 +1615,8 @@ def _build_command_palette_items_view(
                 shortcut=item.shortcut,
                 enabled=item.enabled,
                 selected=(
-                    (
-                        selected_override if selected_override is not None else True
-                    ) and index == cursor_index
+                    (selected_override if selected_override is not None else True)
+                    and index == cursor_index
                 ),
             )
             for index, item in visible_items
@@ -1650,7 +1639,10 @@ def _select_file_search_window(
 ) -> tuple[tuple[tuple[int, FileSearchResultState], ...], str]:
     visible_window = compute_search_visible_window(state.terminal_height)
     return _select_search_window(
-        results, cursor_index, title="Find File", visible_window=visible_window,
+        results,
+        cursor_index,
+        title="Find File",
+        visible_window=visible_window,
     )
 
 
@@ -1664,7 +1656,10 @@ def _select_grep_search_window(
         extra_rows=_GREP_SEARCH_EXTRA_INPUT_ROWS,
     )
     return _select_search_window(
-        results, cursor_index, title="Grep", visible_window=visible_window,
+        results,
+        cursor_index,
+        title="Grep",
+        visible_window=visible_window,
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -483,9 +483,7 @@ class BlockingGrepSearchService:
     ) -> None:
         self.results_by_query = results_by_query or {}
         self.blocked_queries = set(blocked_queries)
-        self.executed_requests: list[
-            tuple[str, str, tuple[str, ...], tuple[str, ...], bool]
-        ] = []
+        self.executed_requests: list[tuple[str, str, tuple[str, ...], tuple[str, ...], bool]] = []
         self.cancelled_queries: list[str] = []
         self.release_event = threading.Event()
 
@@ -619,10 +617,7 @@ async def _wait_for_child_preview(
         if child_title is not None and preview is not None and preview.display:
             code = getattr(preview.renderable, "code", None)
             rendered_text = code if code is not None else str(preview.renderable)
-            if (
-                str(child_title.renderable) == expected_title
-                and expected_snippet in rendered_text
-            ):
+            if str(child_title.renderable) == expected_title and expected_snippet in rendered_text:
                 return
         if asyncio.get_running_loop().time() >= deadline:
             raise AssertionError(
@@ -747,11 +742,7 @@ async def test_app_loads_directory_sizes_when_enabled() -> None:
         }
     )
     directory_size_service = FakeDirectorySizeService(
-        results_by_paths={
-            (f"{path}/docs",): (
-                (f"{path}/docs", 4_200),
-            )
-        }
+        results_by_paths={(f"{path}/docs",): ((f"{path}/docs", 4_200),)}
     )
     app = create_app(
         snapshot_loader=loader,
@@ -789,17 +780,14 @@ async def test_app_applies_directory_size_updates_without_full_current_pane_refr
             )
         }
     )
+
     class SlowDirectorySizeService(FakeDirectorySizeService):
         def calculate_sizes(self, paths, *, is_cancelled=None):
             time.sleep(0.05)
             return super().calculate_sizes(paths, is_cancelled=is_cancelled)
 
     directory_size_service = SlowDirectorySizeService(
-        results_by_paths={
-            (f"{path}/docs",): (
-                (f"{path}/docs", 4_200),
-            )
-        }
+        results_by_paths={(f"{path}/docs",): ((f"{path}/docs", 4_200),)}
     )
     set_entries_calls = 0
     apply_size_updates_calls = 0
@@ -857,15 +845,9 @@ async def test_app_keeps_successful_directory_sizes_when_some_paths_fail() -> No
         }
     )
     directory_size_service = FakeDirectorySizeService(
-        results_by_paths={
-            (f"{path}/docs", f"{path}/private"): (
-                (f"{path}/docs", 4_200),
-            )
-        },
+        results_by_paths={(f"{path}/docs", f"{path}/private"): ((f"{path}/docs", 4_200),)},
         failures_by_paths={
-            (f"{path}/docs", f"{path}/private"): (
-                (f"{path}/private", "permission denied"),
-            )
+            (f"{path}/docs", f"{path}/private"): ((f"{path}/private", "permission denied"),)
         },
     )
     app = create_app(
@@ -2402,9 +2384,7 @@ async def test_app_default_viewport_projection_pages_and_jumps_without_losing_cu
         visible_paths = tuple(entry.path for entry in current_entries)
         await _wait_for_row_count(app, visible_window, timeout=2.0)
 
-        await app.dispatch_actions(
-            (MoveCursor(delta=visible_window, visible_paths=visible_paths),)
-        )
+        await app.dispatch_actions((MoveCursor(delta=visible_window, visible_paths=visible_paths),))
         await _wait_for_cursor_path(app, current_entries[visible_window].path, timeout=2.0)
         await _wait_for_table_cell(app, "file_0002.txt", 0, 1, timeout=2.0)
         assert app.app_state.current_pane_window_start == 2
@@ -2457,9 +2437,7 @@ async def test_app_default_viewport_projection_recalculates_window_after_resize(
         visible_paths = tuple(entry.path for entry in current_entries)
         await _wait_for_row_count(app, visible_window, timeout=2.0)
 
-        await app.dispatch_actions(
-            (MoveCursor(delta=visible_window, visible_paths=visible_paths),)
-        )
+        await app.dispatch_actions((MoveCursor(delta=visible_window, visible_paths=visible_paths),))
         await _wait_for_cursor_path(app, current_entries[visible_window].path, timeout=2.0)
 
         await app.dispatch_actions((SetTerminalHeight(height=12),))
@@ -3422,7 +3400,7 @@ async def test_app_grep_search_passes_include_and_exclude_extensions(tmp_path) -
         await _wait_for_snapshot_loaded(app, path)
         await pilot.press("g")
         await pilot.press("t", "o", "d", "o")
-        await pilot.press("tab", "m", "d")
+        await pilot.press("tab", "tab", "m", "d")
         await pilot.press("tab", "l", "o", "g")
 
         await _wait_for_request_count(grep_search_service, 1, timeout=1.0)
@@ -4036,9 +4014,7 @@ async def test_app_config_dialog_save_updates_preview_syntax_theme() -> None:
                 current_path=path,
                 parent_pane=PaneState(
                     directory_path="/tmp",
-                    entries=(
-                        DirectoryEntryState(path, Path(path).name, "dir"),
-                    ),
+                    entries=(DirectoryEntryState(path, Path(path).name, "dir"),),
                     cursor_path=path,
                 ),
                 current_pane=PaneState(
@@ -4107,8 +4083,7 @@ async def test_app_config_dialog_save_updates_preview_syntax_theme() -> None:
         _saved_path, saved_config = config_save_service.saved_requests[0]
         assert saved_config.display.preview_syntax_theme == SUPPORTED_PREVIEW_SYNTAX_THEMES[1]
         assert (
-            app.app_state.config.display.preview_syntax_theme
-            == SUPPORTED_PREVIEW_SYNTAX_THEMES[1]
+            app.app_state.config.display.preview_syntax_theme == SUPPORTED_PREVIEW_SYNTAX_THEMES[1]
         )
         assert (
             select_shell_data(app.app_state).child_pane.syntax_theme
@@ -4523,6 +4498,7 @@ async def test_app_split_terminal_focus_routes_input_to_session() -> None:
 
         session = split_terminal_service.sessions[0]
         assert session.writes == ["a", "\r"]
+
 
 @pytest.mark.asyncio
 async def test_app_split_terminal_focus_sends_tab() -> None:

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -878,6 +878,7 @@ def test_search_palette_down_moves_cursor() -> None:
 
 def test_palette_ctrl_e_opens_grep_result_in_editor() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -894,6 +895,7 @@ def test_palette_ctrl_e_opens_grep_result_in_editor() -> None:
 
 def test_palette_ctrl_e_opens_find_result_in_editor() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -910,6 +912,7 @@ def test_palette_ctrl_e_opens_find_result_in_editor() -> None:
 
 def test_palette_e_key_does_not_open_editor_for_other_sources() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -927,6 +930,7 @@ def test_palette_e_key_does_not_open_editor_for_other_sources() -> None:
 
 def test_palette_ctrl_n_moves_cursor_down_in_grep_palette() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -943,6 +947,7 @@ def test_palette_ctrl_n_moves_cursor_down_in_grep_palette() -> None:
 
 def test_palette_ctrl_p_moves_cursor_up_in_grep_palette() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -959,6 +964,7 @@ def test_palette_ctrl_p_moves_cursor_up_in_grep_palette() -> None:
 
 def test_palette_ctrl_n_moves_cursor_down_in_file_search_palette() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -975,6 +981,7 @@ def test_palette_ctrl_n_moves_cursor_down_in_file_search_palette() -> None:
 
 def test_palette_ctrl_p_moves_cursor_up_in_file_search_palette() -> None:
     from zivo.state.models import CommandPaletteState
+
     state = replace(
         build_initial_app_state(),
         ui_mode="PALETTE",
@@ -1116,7 +1123,7 @@ def test_grep_palette_pageup_accounts_for_extra_input_rows() -> None:
 
     actions = dispatch_key_input(state, key="pageup")
 
-    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-12))
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=-11))
 
 
 def test_grep_palette_pagedown_accounts_for_extra_input_rows() -> None:
@@ -1128,7 +1135,7 @@ def test_grep_palette_pagedown_accounts_for_extra_input_rows() -> None:
 
     actions = dispatch_key_input(state, key="pagedown")
 
-    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=12))
+    assert actions == (SetNotification(None), MoveCommandPaletteCursor(delta=11))
 
 
 def test_palette_unbound_key_shows_guidance() -> None:
@@ -1189,6 +1196,7 @@ def test_split_terminal_focus_sends_navigation_sequences() -> None:
         SetNotification(None),
         SendSplitTerminalInput("\x1b[6~"),
     )
+
 
 def test_split_terminal_focus_sends_tab() -> None:
     state = _focused_split_terminal_state()
@@ -1872,8 +1880,6 @@ def test_browsing_close_brace_dispatches_go_forward() -> None:
     actions = dispatch_key_input(state, key="}")
 
     assert actions == (SetNotification(None), GoForward())
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -595,9 +595,7 @@ def test_select_shell_data_emits_size_delta_updates_for_directory_size_changes()
     assert [
         (update.path, update.size_label, update.row_index)
         for update in shell.current_pane_update.size_updates
-    ] == [
-        ("/home/tadashi/develop/zivo/docs", "4.1KiB", row_index)
-    ]
+    ] == [("/home/tadashi/develop/zivo/docs", "4.1KiB", row_index)]
 
 
 def test_select_shell_data_emits_row_delta_updates_for_selection_changes() -> None:
@@ -625,9 +623,7 @@ def test_select_shell_data_emits_row_delta_updates_for_selection_changes() -> No
     assert [
         (update.path, update.entry.selected, update.row_index)
         for update in shell.current_pane_update.row_updates
-    ] == [
-        (path, True, row_index)
-    ]
+    ] == [(path, True, row_index)]
 
 
 def test_select_shell_data_emits_row_delta_updates_for_cut_changes() -> None:
@@ -652,9 +648,7 @@ def test_select_shell_data_emits_row_delta_updates_for_cut_changes() -> None:
     assert [
         (update.path, update.entry.cut, update.row_index)
         for update in shell.current_pane_update.row_updates
-    ] == [
-        (path, True, row_index)
-    ]
+    ] == [(path, True, row_index)]
 
 
 def test_select_shell_data_keeps_full_refresh_when_sorting_by_size() -> None:
@@ -1025,8 +1019,7 @@ def test_select_shell_data_reuses_current_entries_when_only_cursor_changes() -> 
 def test_select_shell_data_viewport_projection_limits_rendered_entries() -> None:
     path = "/tmp/zivo-viewport-selector"
     current_entries = tuple(
-        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
-        for index in range(12)
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}") for index in range(12)
     )
     state = replace(
         build_initial_app_state(current_pane_projection_mode="viewport"),
@@ -1045,12 +1038,12 @@ def test_select_shell_data_viewport_projection_limits_rendered_entries() -> None
     assert shell.current_summary.item_count == len(current_entries)
 
 
-def test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_inside_window(
-) -> None:
+def test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_inside_window() -> (
+    None
+):
     path = "/tmp/zivo-viewport-selector"
     current_entries = tuple(
-        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
-        for index in range(12)
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}") for index in range(12)
     )
     state = replace(
         build_initial_app_state(current_pane_projection_mode="viewport"),
@@ -1068,8 +1061,7 @@ def test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_ins
 def test_select_shell_data_viewport_projection_shifts_window_after_cursor_crosses_edge() -> None:
     path = "/tmp/zivo-viewport-selector"
     current_entries = tuple(
-        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
-        for index in range(12)
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}") for index in range(12)
     )
     state = replace(
         build_initial_app_state(current_pane_projection_mode="viewport"),
@@ -1094,8 +1086,7 @@ def test_select_shell_data_viewport_projection_shifts_window_after_cursor_crosse
 def test_select_shell_data_viewport_projection_skips_offscreen_row_delta_updates() -> None:
     path = "/tmp/zivo-viewport-selector"
     current_entries = tuple(
-        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}")
-        for index in range(12)
+        entry(f"{path}/item_{index:02d}", name=f"item_{index:02d}") for index in range(12)
     )
     offscreen_path = current_entries[-1].path
     state = replace(
@@ -1418,9 +1409,7 @@ def test_select_help_bar_state_for_history_palette() -> None:
 
     help_bar = select_help_bar_state(state)
 
-    assert help_bar.lines == (
-        "type path | ↑↓ or Ctrl+n/p select | enter jump | esc cancel",
-    )
+    assert help_bar.lines == ("type path | ↑↓ or Ctrl+n/p select | enter jump | esc cancel",)
 
 
 def test_select_help_bar_state_for_bookmarks_palette() -> None:
@@ -1432,9 +1421,7 @@ def test_select_help_bar_state_for_bookmarks_palette() -> None:
 
     help_bar = select_help_bar_state(state)
 
-    assert help_bar.lines == (
-        "type path | ↑↓ or Ctrl+n/p select | enter jump | esc cancel",
-    )
+    assert help_bar.lines == ("type path | ↑↓ or Ctrl+n/p select | enter jump | esc cancel",)
 
 
 def test_select_help_bar_state_for_file_search_palette() -> None:
@@ -1461,8 +1448,7 @@ def test_select_help_bar_state_for_grep_search_palette() -> None:
     help_bar = select_help_bar_state(state)
 
     assert help_bar.lines == (
-        "type text / tab fields / ↑↓ or Ctrl+n/p select | "
-        "enter jump | Ctrl+e edit | esc cancel",
+        "type text / tab fields / ↑↓ or Ctrl+n/p select | enter jump | Ctrl+e edit | esc cancel",
     )
 
 
@@ -1475,9 +1461,7 @@ def test_select_help_bar_state_for_command_palette() -> None:
 
     help_bar = select_help_bar_state(state)
 
-    assert help_bar.lines == (
-        "type command | ↑↓ or Ctrl+n/p select | enter run | esc cancel",
-    )
+    assert help_bar.lines == ("type command | ↑↓ or Ctrl+n/p select | enter run | esc cancel",)
 
 
 def test_select_help_bar_state_for_config_editor() -> None:
@@ -1506,6 +1490,7 @@ def test_select_command_palette_state_for_grep_search_includes_input_fields() ->
             source="grep_search",
             query="todo",
             grep_search_keyword="todo",
+            grep_search_filename_filter="main",
             grep_search_include_extensions="py,ts",
             grep_search_exclude_extensions="log",
             grep_search_active_field="exclude",
@@ -1517,11 +1502,12 @@ def test_select_command_palette_state_for_grep_search_includes_input_fields() ->
     assert palette_state is not None
     assert [field.label for field in palette_state.input_fields] == [
         "Keyword",
-        "Include",
-        "Exclude",
+        "Filter: Filename",
+        "Filter: Include",
+        "Filter: Exclude",
     ]
-    assert [field.value for field in palette_state.input_fields] == ["todo", "py,ts", "log"]
-    assert [field.active for field in palette_state.input_fields] == [False, False, True]
+    assert [field.value for field in palette_state.input_fields] == ["todo", "main", "py,ts", "log"]
+    assert [field.active for field in palette_state.input_fields] == [False, False, False, True]
 
 
 def test_select_command_palette_state_for_text_replace_includes_input_fields() -> None:
@@ -1633,11 +1619,7 @@ def test_select_command_palette_state_switches_bookmark_command_label() -> None:
     )
 
     bookmarked_state = build_initial_app_state(
-        config=AppConfig(
-            bookmarks=BookmarkConfig(
-                paths=("/home/tadashi/develop/zivo",)
-            )
-        )
+        config=AppConfig(bookmarks=BookmarkConfig(paths=("/home/tadashi/develop/zivo",)))
     )
     bookmarked_palette_state = select_command_palette_state(
         replace(
@@ -1702,9 +1684,7 @@ def test_select_command_palette_state_shows_extract_archive_for_supported_file()
         build_initial_app_state(),
         current_pane=PaneState(
             directory_path="/home/tadashi/develop/zivo",
-            entries=(
-                DirectoryEntryState(archive_path, "archive.tar.gz", "file"),
-            ),
+            entries=(DirectoryEntryState(archive_path, "archive.tar.gz", "file"),),
             cursor_path=archive_path,
         ),
     )
@@ -1976,8 +1956,9 @@ def test_select_command_palette_state_for_file_search_results() -> None:
     assert [item.label for item in palette_state.items] == ["README.md"]
 
 
-def test_select_command_palette_state_shows_searching_message_while_file_search_is_pending(
-) -> None:
+def test_select_command_palette_state_shows_searching_message_while_file_search_is_pending() -> (
+    None
+):
     state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
     state = replace(
         state,
@@ -2567,7 +2548,6 @@ class TestSelectCommandPaletteWindow:
         assert 12 in visible_indices
         assert 13 in visible_indices
         assert result[-1][0] == 13  # 最後のアイテムが表示されている
-
 
 
 class TestCommandPaletteDynamicWindow:


### PR DESCRIPTION
## Summary
- Grep Search パレットに Filename フィルタフィールドを追加する（4 フィールド構成: keyword, filter: filename, filter: include extensions, filter: exclude extensions）
- Filename フィールドでは検索結果をメモリ上でフィルタリング（GRF と同じ `_filter_grf_by_filename()` を流用）
- フィールドラベルに "Filter: " プレフィックスを追加してフィルタ用フィールドであることを明確化
- README.md / README.ja.md を更新

## 修正ファイル
- `src/zivo/state/models.py` - `GrepSearchFieldId` に `"filename"` 追加、`grep_search_filename_filter` フィールド追加
- `src/zivo/state/selectors.py` - フィールドラベルに "Filter: " プレフィックス追加
- `src/zivo/state/reducer_palette.py` - filename フィールドハンドラ、フィルタリング関数追加
- `src/zivo/state/input.py` - grep_search extra_rows を 2→3 に変更
- `README.md` / `README.ja.md` - Grep search 説明を更新
- テストファイル 3 件の更新

## テスト結果
- 1020 tests passed
- ruff lint all passed