### PR TITLE
#624 Add filename filter to grep search

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -52,7 +52,7 @@ Overlay表示:
 
   ![](docs/resources/screen-find-command.png)
 
-- カレントディレクトリ配下を対象とした再帰 grep 検索が可能です。検索結果から該当ファイルへジャンプできます。差分箇所の前後数行をプレビューでき、目的のファイルを簡単に見つけることができます。また、ターミナルエディタで該当箇所を直接開くこともできます。
+- カレントディレクトリ配下を対象とした再帰 grep 検索が可能です。検索結果から該当ファイルへジャンプできます。差分箇所の前後数行をプレビューでき、目的のファイルを簡単に見つけることができます。パレットには `Filter: Filename`、`Filter: Include`、`Filter: Exclude` があり、開く前に対象を絞り込めます。また、ターミナルエディタで該当箇所を直接開くこともできます。
 
   ![](docs/resources/screen-grep-command.png)
 
@@ -339,7 +339,7 @@ zivo-cd
 | `Previous tab` | 2 タブ以上開いているとき | 前のブラウズタブへ切り替えます。`shift+tab` でも実行できます。 |
 | `Close current tab` | 2 タブ以上開いているとき | アクティブなブラウズタブを閉じます。最後の 1 タブは閉じられません。`w` でも実行できます。 |
 | `Find files` | 常に表示 | 再帰ファイル検索を開きます。 |
-| `Grep search` | 常に表示 | 再帰 grep 検索を開きます（`ripgrep` / `rg` が `PATH` 上に必要）。 |
+| `Grep search` | 常に表示 | 再帰 grep 検索を開きます（`ripgrep` / `rg` が `PATH` 上に必要）。keyword / filename / include extension / exclude extension の各フィルタを利用できます。 |
 | `History search` | 常に表示 | ディレクトリ履歴リストを開き、選択したディレクトリへ移動します。 |
 | `Show bookmarks` | 常に表示 | 保存済みのブックマークリストを開き、選択したディレクトリへ移動します。 |
 | `Go back` | ディレクトリ履歴に戻り先があるとき | 履歴を一つ戻ります。 |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Overlay display:
 
   ![](docs/resources/screen-find-command.png)
 
-- Recursive grep search is available under the current directory. You can jump from search results directly to the matching file. Context lines around each match can be previewed, making it easy to find what you are looking for. You can also open the matching location directly in a terminal editor.
+- Recursive grep search is available under the current directory. You can jump from search results directly to the matching file. Context lines around each match can be previewed, making it easy to find what you are looking for. The palette now includes `Filter: Filename`, `Filter: Include`, and `Filter: Exclude` fields so you can narrow matches before opening them. You can also open the matching location directly in a terminal editor.
 
   ![](docs/resources/screen-grep-command.png)
 
@@ -338,7 +338,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Previous tab` | Two or more tabs are open | Activates the previous browser tab. Also available with `shift+tab`. |
 | `Close current tab` | Two or more tabs are open | Closes the active browser tab. The last remaining tab cannot be closed. Also available with `w`. |
 | `Find files` | Always | Opens recursive file search. |
-| `Grep search` | Always | Opens recursive grep search (`ripgrep` / `rg` required on `PATH`). |
+| `Grep search` | Always | Opens recursive grep search (`ripgrep` / `rg` required on `PATH`) with keyword, filename, include-extension, and exclude-extension filters. |
 | `History search` | Always | Opens directory history list and jump to a selected directory. |
 | `Show bookmarks` | Always | Opens the saved bookmark list and jumps to the selected directory. |
 | `Go back` | Directory history has a previous entry | Moves to the previous directory in history. |

--- a/src/zivo/state/input.py
+++ b/src/zivo/state/input.py
@@ -498,6 +498,8 @@ def _active_grep_field_value(state: AppState) -> str:
     field = state.command_palette.grep_search_active_field
     if field == "keyword":
         return state.command_palette.grep_search_keyword or state.command_palette.query
+    if field == "filename":
+        return state.command_palette.grep_search_filename_filter
     if field == "include":
         return state.command_palette.grep_search_include_extensions
     return state.command_palette.grep_search_exclude_extensions

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -352,6 +352,7 @@ class CommandPaletteState:
     source: CommandPaletteSource = "commands"
     query: str = ""
     grep_search_keyword: str = ""
+    grep_search_filename_filter: str = ""
     grep_search_include_extensions: str = ""
     grep_search_exclude_extensions: str = ""
     grep_search_active_field: GrepSearchFieldId = "keyword"

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -110,7 +110,7 @@ from .reducer_common import (
 )
 from .selectors import select_target_paths, select_visible_current_entry_states
 
-_GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "include", "exclude")
+_GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "filename", "include", "exclude")
 _REPLACE_FIELDS: tuple[ReplaceFieldId, ...] = ("find", "replace")
 _FIND_REPLACE_FIELDS: tuple[FindReplaceFieldId, ...] = ("filename", "find", "replace")
 _GREP_REPLACE_FIELDS: tuple[GrepReplaceFieldId, ...] = (
@@ -130,6 +130,8 @@ def _grep_field_value(
 ) -> str:
     if field == "keyword":
         return palette.grep_search_keyword
+    if field == "filename":
+        return palette.grep_search_filename_filter
     if field == "include":
         return palette.grep_search_include_extensions
     return palette.grep_search_exclude_extensions
@@ -143,6 +145,8 @@ def _replace_grep_field(
 ) -> CommandPaletteState:
     if field == "keyword":
         return replace(palette, query=value, grep_search_keyword=value)
+    if field == "filename":
+        return replace(palette, grep_search_filename_filter=value)
     if field == "include":
         return replace(palette, grep_search_include_extensions=value)
     return replace(palette, grep_search_exclude_extensions=value)
@@ -238,6 +242,19 @@ def _validate_grep_search_filters(
             f"Extensions cannot be included and excluded at the same time: {formatted}"
         )
     return include_globs, exclude_globs
+
+
+def _filter_grep_results_by_filename(
+    results: tuple[GrepSearchResultState, ...],
+    filename_query: str,
+) -> tuple[GrepSearchResultState, ...]:
+    if not filename_query.strip():
+        return results
+    if is_regex_file_search_query(filename_query):
+        pattern = re.compile(filename_query[3:], re.IGNORECASE)
+        return tuple(result for result in results if pattern.search(result.display_path))
+    lowered = filename_query.casefold()
+    return tuple(result for result in results if lowered in result.display_path.casefold())
 
 
 def _notify(
@@ -1684,7 +1701,10 @@ def _handle_grep_search_completed(
             state,
             command_palette=replace(
                 state.command_palette,
-                grep_search_results=action.results,
+                grep_search_results=_filter_grep_results_by_filename(
+                    action.results,
+                    state.command_palette.grep_search_filename_filter,
+                ),
                 grep_search_error_message=None,
                 cursor_index=0,
             ),
@@ -2369,13 +2389,7 @@ def _filter_grf_by_filename(
     results: tuple[GrepSearchResultState, ...],
     filename_query: str,
 ) -> tuple[GrepSearchResultState, ...]:
-    if not filename_query.strip():
-        return results
-    if is_regex_file_search_query(filename_query):
-        pattern = re.compile(filename_query[3:], re.IGNORECASE)
-        return tuple(r for r in results if pattern.search(r.display_path))
-    lowered = filename_query.casefold()
-    return tuple(r for r in results if lowered in r.display_path.casefold())
+    return _filter_grep_results_by_filename(results, filename_query)
 
 
 def _handle_grf_grep_search_completed(

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -827,13 +827,19 @@ def _build_grep_search_input_fields(
             active=palette.grep_search_active_field == "keyword",
         ),
         CommandPaletteInputFieldViewState(
-            label="Include",
+            label="Filter: Filename",
+            value=palette.grep_search_filename_filter,
+            placeholder="pattern or re:pattern",
+            active=palette.grep_search_active_field == "filename",
+        ),
+        CommandPaletteInputFieldViewState(
+            label="Filter: Include",
             value=palette.grep_search_include_extensions,
             placeholder="all extensions",
             active=palette.grep_search_active_field == "include",
         ),
         CommandPaletteInputFieldViewState(
-            label="Exclude",
+            label="Filter: Exclude",
             value=palette.grep_search_exclude_extensions,
             placeholder="none",
             active=palette.grep_search_active_field == "exclude",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3425,14 +3425,22 @@ async def test_app_grep_search_passes_include_and_exclude_extensions(tmp_path) -
         await pilot.press("tab", "tab", "m", "d")
         await pilot.press("tab", "l", "o", "g")
 
-        await _wait_for_request_count(grep_search_service, 1, timeout=1.0)
-        assert grep_search_service.executed_requests[-1] == (
+        expected_request = (
             path,
             "todo",
             ("*.md",),
             ("*.log",),
             False,
         )
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while True:
+            if expected_request in grep_search_service.executed_requests:
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError(
+                    "grep request with include/exclude filters was not executed"
+                )
+            await asyncio.sleep(0.01)
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3422,7 +3422,7 @@ async def test_app_grep_search_passes_include_and_exclude_extensions(tmp_path) -
         await _wait_for_snapshot_loaded(app, path)
         await pilot.press("g")
         await pilot.press("t", "o", "d", "o")
-        await pilot.press("tab", "m", "d")
+        await pilot.press("tab", "tab", "m", "d")
         await pilot.press("tab", "l", "o", "g")
 
         await _wait_for_request_count(grep_search_service, 1, timeout=1.0)
@@ -3433,6 +3433,40 @@ async def test_app_grep_search_passes_include_and_exclude_extensions(tmp_path) -
             ("*.log",),
             False,
         )
+
+
+@pytest.mark.asyncio
+async def test_app_grep_search_filters_results_by_filename(tmp_path) -> None:
+    path = str(tmp_path)
+    (tmp_path / "README.md").write_text("TODO: readme\n", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("TODO: notes\n", encoding="utf-8")
+    grep_search_service = FakeGrepSearchService(
+        results_by_query={
+            (path, "todo", (), (), False): (
+                GrepSearchResultState(
+                    path=f"{path}/README.md",
+                    display_path="README.md",
+                    line_number=1,
+                    line_text="TODO: readme",
+                ),
+                GrepSearchResultState(
+                    path=f"{path}/notes.txt",
+                    display_path="notes.txt",
+                    line_number=1,
+                    line_text="TODO: notes",
+                ),
+            )
+        }
+    )
+    app = create_app(grep_search_service=grep_search_service, initial_path=path)
+
+    async with app.run_test() as pilot:
+        await _wait_for_snapshot_loaded(app, path)
+        await pilot.press("g")
+        await pilot.press("t", "o", "d", "o")
+        await pilot.press("tab", "R", "E", "A", "D")
+
+        await _wait_for_request_count(grep_search_service, 1, timeout=1.0)
         assert app.app_state.command_palette is not None
         assert [
             result.display_label for result in app.app_state.command_palette.grep_search_results

--- a/tests/test_input_dispatch.py
+++ b/tests/test_input_dispatch.py
@@ -852,6 +852,25 @@ def test_grep_palette_printable_key_updates_include_field() -> None:
     )
 
 
+def test_grep_palette_printable_key_updates_filename_field() -> None:
+    state = replace(
+        build_initial_app_state(),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="grep_search",
+            grep_search_active_field="filename",
+            grep_search_filename_filter="READ",
+        ),
+    )
+
+    actions = dispatch_key_input(state, key="m", character="m")
+
+    assert actions == (
+        SetNotification(None),
+        SetGrepSearchField(field="filename", value="READm"),
+    )
+
+
 def test_commands_palette_j_key_moves_cursor() -> None:
     state = replace(
         build_initial_app_state(),

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -2558,6 +2558,97 @@ def test_set_grep_search_field_builds_include_and_exclude_globs() -> None:
     )
 
 
+def test_set_grep_search_filename_filter_updates_palette_and_requests_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
+
+    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="readme"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_filename_filter == "readme"
+    assert result.effects == (
+        RunGrepSearchEffect(
+            request_id=2,
+            root_path="/home/tadashi/develop/zivo",
+            query="todo",
+            show_hidden=False,
+            include_globs=(),
+            exclude_globs=(),
+        ),
+    )
+
+
+def test_grep_search_completed_filters_results_by_filename() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="todo",
+            grep_search_filename_filter="readme",
+        ),
+        pending_grep_search_request_id=4,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="TODO",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/docs/guide.md",
+            display_path="docs/guide.md",
+            line_number=2,
+            line_text="TODO",
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        GrepSearchCompleted(request_id=4, query="todo", results=results),
+    )
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_results == (results[0],)
+    assert result.state.pending_grep_search_request_id is None
+
+
+def test_grep_search_completed_filters_results_by_filename_regex() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="todo",
+            grep_search_filename_filter="re:^docs/.+\\.md$",
+        ),
+        pending_grep_search_request_id=4,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="TODO",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/docs/guide.md",
+            display_path="docs/guide.md",
+            line_number=2,
+            line_text="TODO",
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        GrepSearchCompleted(request_id=4, query="todo", results=results),
+    )
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_results == (results[1],)
+
+
 def test_set_grep_search_field_rejects_conflicting_extensions() -> None:
     state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
     state = _reduce_state(state, SetCommandPaletteQuery("todo"))

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -1506,6 +1506,7 @@ def test_select_command_palette_state_for_grep_search_includes_input_fields() ->
             source="grep_search",
             query="todo",
             grep_search_keyword="todo",
+            grep_search_filename_filter="main",
             grep_search_include_extensions="py,ts",
             grep_search_exclude_extensions="log",
             grep_search_active_field="exclude",
@@ -1517,11 +1518,12 @@ def test_select_command_palette_state_for_grep_search_includes_input_fields() ->
     assert palette_state is not None
     assert [field.label for field in palette_state.input_fields] == [
         "Keyword",
-        "Include",
-        "Exclude",
+        "Filter: Filename",
+        "Filter: Include",
+        "Filter: Exclude",
     ]
-    assert [field.value for field in palette_state.input_fields] == ["todo", "py,ts", "log"]
-    assert [field.active for field in palette_state.input_fields] == [False, False, True]
+    assert [field.value for field in palette_state.input_fields] == ["todo", "main", "py,ts", "log"]
+    assert [field.active for field in palette_state.input_fields] == [False, False, False, True]
 
 
 def test_select_command_palette_state_for_text_replace_includes_input_fields() -> None:


### PR DESCRIPTION
## Summary
- add a `Filter: Filename` field to the grep search palette and include it in tab navigation
- filter grep results by filename while keeping include/exclude extension filters on the ripgrep request
- add reducer, selector, input-dispatch, app tests and update README docs

## Testing
- `uv run pytest tests/test_state_reducer.py tests/test_state_selectors.py tests/test_input_dispatch.py tests/test_app.py`
- `uv run ruff check .`

Closes #624
