### PR TITLE
Fix read-only variable error for zsh status

### DIFF
--- a/src/zivo/__main__.py
+++ b/src/zivo/__main__.py
@@ -43,11 +43,11 @@ def render_shell_init(shell: str) -> str:
         raise ValueError(f"Unsupported shell: {shell}")
     return (
         "zivo-cd() {\n"
-        "  local target status\n"
+        "  local target _status\n"
         '  target="$(command zivo --print-last-dir "$@")"\n'
-        "  status=$?\n"
-        "  if [ $status -ne 0 ]; then\n"
-        "    return $status\n"
+        "  _status=$?\n"
+        "  if [ $_status -ne 0 ]; then\n"
+        "    return $_status\n"
         "  fi\n"
         '  if [ -n "$target" ]; then\n'
         '    builtin cd -- "$target"\n'


### PR DESCRIPTION
## Summary\n\nzshで `status` が読み取り専用変数であるため、`zivo-cd` 関数実行時にエラーが発生する問題を修正する。\n\n## Changes\n\n- `src/zivo/__main__.py`: zshシェルスニペットの変数名 `status` を `_status` に変更\n\n## Test Results\n\n- `uv run ruff check`: All checks passed\n- `uv run pytest tests/test_cli.py`: 10/10 passed\n\n（3件の失敗は環境依存のTrash関連テストで、今回の修正とは無関係）