### PR TITLE
[#615] Split palette reducers by workflow

### DIFF
--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -1,13 +1,10 @@
 """Command palette reducer handlers."""
 
-import re
 from dataclasses import replace
 from pathlib import Path
-from typing import Callable, Literal
+from typing import Callable
 
 from zivo.archive_utils import is_supported_archive_path
-from zivo.models import TextReplaceRequest
-from zivo.models.external_launch import ExternalLaunchRequest
 
 from .actions import (
     Action,
@@ -56,7 +53,6 @@ from .actions import (
     OpenTerminalAtPath,
     ReloadDirectory,
     RemoveBookmark,
-    RequestBrowserSnapshot,
     SelectAllVisibleEntries,
     SetCommandPaletteQuery,
     SetFindReplaceField,
@@ -75,279 +71,74 @@ from .actions import (
     UndoLastOperation,
 )
 from .command_palette import get_command_palette_items, normalize_command_palette_cursor
-from .effects import (
-    LoadChildPaneSnapshotEffect,
-    ReduceResult,
-    RunFileSearchEffect,
-    RunGrepSearchEffect,
-    RunTextReplaceApplyEffect,
-    RunTextReplacePreviewEffect,
-)
-from .models import (
-    AppState,
-    AttributeInspectionState,
-    CommandPaletteState,
-    ConfigEditorState,
-    FileSearchResultState,
-    FindReplaceFieldId,
-    GrepReplaceFieldId,
-    GrepReplaceSelectedFieldId,
-    GrepSearchFieldId,
-    GrepSearchResultState,
-    NotificationState,
-    PaneState,
-    ReplaceFieldId,
-    ReplacePreviewResultState,
-)
+from .effects import ReduceResult
+from .models import AppState, AttributeInspectionState, ConfigEditorState
 from .reducer_common import (
     ReducerFn,
-    browser_snapshot_invalidation_paths,
     expand_and_validate_path,
-    filter_file_search_results,
     finalize,
-    is_regex_file_search_query,
     list_matching_directory_paths,
-    run_external_launch_request,
     single_target_entry,
     single_target_path,
     sync_child_pane,
 )
-from .selectors import select_target_paths, select_visible_current_entry_states
-
-_GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "filename", "include", "exclude")
-_REPLACE_FIELDS: tuple[ReplaceFieldId, ...] = ("find", "replace")
-_FIND_REPLACE_FIELDS: tuple[FindReplaceFieldId, ...] = ("filename", "find", "replace")
-_GREP_REPLACE_FIELDS: tuple[GrepReplaceFieldId, ...] = (
-    "keyword",
-    "replace",
-    "filename",
-    "include",
-    "exclude",
+from .reducer_palette_replace import (
+    handle_cycle_find_replace_field,
+    handle_cycle_grep_replace_field,
+    handle_cycle_grep_replace_selected_field,
+    handle_cycle_replace_field,
+    handle_set_find_replace_field,
+    handle_set_grep_replace_field,
+    handle_set_grep_replace_selected_field,
+    handle_set_replace_field,
+    handle_submit_find_and_replace_palette,
+    handle_submit_grep_replace_palette,
+    handle_submit_grep_replace_selected_palette,
+    handle_submit_replace_palette,
+    handle_text_replace_applied,
+    handle_text_replace_apply_failed,
+    handle_text_replace_preview_completed,
+    handle_text_replace_preview_failed,
+    sync_find_replace_preview,
+    sync_grep_replace_preview,
+    sync_grep_replace_selected_preview,
+    sync_replace_preview,
 )
-_GREP_REPLACE_SELECTED_FIELDS: tuple[GrepReplaceSelectedFieldId, ...] = ("keyword", "replace")
-_EXTENSION_SEPARATOR_RE = re.compile(r"[\s,]+")
-_VALID_EXTENSION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]*")
-
-
-def _grep_field_value(
-    palette: CommandPaletteState,
-    field: GrepSearchFieldId,
-) -> str:
-    if field == "keyword":
-        return palette.grep_search_keyword
-    if field == "filename":
-        return palette.grep_search_filename_filter
-    if field == "include":
-        return palette.grep_search_include_extensions
-    return palette.grep_search_exclude_extensions
-
-
-def _replace_grep_field(
-    palette: CommandPaletteState,
-    *,
-    field: GrepSearchFieldId,
-    value: str,
-) -> CommandPaletteState:
-    if field == "keyword":
-        return replace(palette, query=value, grep_search_keyword=value)
-    if field == "filename":
-        return replace(palette, grep_search_filename_filter=value)
-    if field == "include":
-        return replace(palette, grep_search_include_extensions=value)
-    return replace(palette, grep_search_exclude_extensions=value)
-
-
-def _replace_field_value(
-    palette: CommandPaletteState,
-    field: ReplaceFieldId,
-) -> str:
-    if field == "find":
-        return palette.replace_find_text
-    return palette.replace_replacement_text
-
-
-def _replace_replace_field(
-    palette: CommandPaletteState,
-    *,
-    field: ReplaceFieldId,
-    value: str,
-) -> CommandPaletteState:
-    if field == "find":
-        return replace(palette, replace_find_text=value)
-    return replace(palette, replace_replacement_text=value)
-
-
-def _grf_field_value(
-    palette: CommandPaletteState,
-    field: GrepReplaceFieldId,
-) -> str:
-    if field == "keyword":
-        return palette.grf_keyword
-    if field == "replace":
-        return palette.grf_replacement_text
-    if field == "filename":
-        return palette.grf_filename_filter
-    if field == "include":
-        return palette.grf_include_extensions
-    return palette.grf_exclude_extensions
-
-
-def _replace_grf_field(
-    palette: CommandPaletteState,
-    *,
-    field: GrepReplaceFieldId,
-    value: str,
-) -> CommandPaletteState:
-    if field == "keyword":
-        return replace(palette, query=value, grf_keyword=value)
-    if field == "replace":
-        return replace(palette, grf_replacement_text=value)
-    if field == "filename":
-        return replace(palette, grf_filename_filter=value)
-    if field == "include":
-        return replace(palette, grf_include_extensions=value)
-    return replace(palette, grf_exclude_extensions=value)
-
-
-def _normalize_grep_extension_filters(
-    raw_value: str,
-    *,
-    label: str,
-) -> tuple[str, ...]:
-    normalized_globs: list[str] = []
-    seen: set[str] = set()
-    for token in _EXTENSION_SEPARATOR_RE.split(raw_value.strip()):
-        if not token:
-            continue
-        normalized_token = token.strip().lstrip(".").casefold()
-        if not normalized_token or not _VALID_EXTENSION_RE.fullmatch(normalized_token):
-            raise ValueError(f"Invalid {label} extension: {token}")
-        glob = f"*.{normalized_token}"
-        if glob not in seen:
-            seen.add(glob)
-            normalized_globs.append(glob)
-    return tuple(normalized_globs)
-
-
-def _validate_grep_search_filters(
-    palette: CommandPaletteState,
-) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    include_globs = _normalize_grep_extension_filters(
-        palette.grep_search_include_extensions,
-        label="include",
-    )
-    exclude_globs = _normalize_grep_extension_filters(
-        palette.grep_search_exclude_extensions,
-        label="exclude",
-    )
-    conflicts = tuple(sorted(set(include_globs) & set(exclude_globs)))
-    if conflicts:
-        formatted = ", ".join(glob.removeprefix("*.") for glob in conflicts)
-        raise ValueError(
-            f"Extensions cannot be included and excluded at the same time: {formatted}"
-        )
-    return include_globs, exclude_globs
-
-
-def _filter_grep_results_by_filename(
-    results: tuple[GrepSearchResultState, ...],
-    filename_query: str,
-) -> tuple[GrepSearchResultState, ...]:
-    if not filename_query.strip():
-        return results
-    if is_regex_file_search_query(filename_query):
-        pattern = re.compile(filename_query[3:], re.IGNORECASE)
-        return tuple(result for result in results if pattern.search(result.display_path))
-    lowered = filename_query.casefold()
-    return tuple(result for result in results if lowered in result.display_path.casefold())
-
-
-def _notify(
-    state: AppState,
-    *,
-    level: str,
-    message: str,
-) -> ReduceResult:
-    return finalize(
-        replace(
-            state,
-            notification=NotificationState(level=level, message=message),
-        )
-    )
-
-
-def _enter_palette(
-    state: AppState,
-    *,
-    source: str = "commands",
-    history_results: tuple[str, ...] = (),
-) -> AppState:
-    return replace(
-        state,
-        ui_mode="PALETTE",
-        notification=None,
-        pending_input=None,
-        command_palette=CommandPaletteState(
-            source=source,
-            history_results=history_results,
-        ),
-        pending_file_search_request_id=None,
-        pending_grep_search_request_id=None,
-        pending_replace_preview_request_id=None,
-        pending_replace_apply_request_id=None,
-        delete_confirmation=None,
-        name_conflict=None,
-        attribute_inspection=None,
-    )
-
-
-def _restore_browsing_from_palette(
-    state: AppState,
-    *,
-    clear_name_conflict: bool = False,
-) -> AppState:
-    next_state = replace(
-        state,
-        ui_mode="BROWSING",
-        notification=None,
-        command_palette=None,
-        pending_file_search_request_id=None,
-        pending_grep_search_request_id=None,
-        pending_replace_preview_request_id=None,
-        pending_replace_apply_request_id=None,
-        attribute_inspection=None,
-    )
-    if clear_name_conflict:
-        next_state = replace(next_state, name_conflict=None)
-    return next_state
-
-
-def _request_palette_snapshot(
-    state: AppState,
-    reduce_state: ReducerFn,
-    *,
-    path: str,
-    cursor_path: str | None = None,
-) -> ReduceResult:
-    return reduce_state(
-        _restore_browsing_from_palette(state),
-        RequestBrowserSnapshot(path, cursor_path=cursor_path, blocking=True),
-    )
+from .reducer_palette_search import (
+    handle_file_search_completed,
+    handle_file_search_failed,
+    handle_grep_search_completed,
+    handle_grep_search_failed,
+    handle_open_find_result_in_editor,
+    handle_open_grep_result_in_editor,
+    handle_set_file_search_query,
+    handle_set_grep_search_field,
+    handle_submit_file_search_palette,
+    handle_submit_grep_search_palette,
+    sync_file_search_preview,
+    sync_grep_preview,
+)
+from .reducer_palette_shared import (
+    GREP_SEARCH_FIELDS,
+    enter_palette,
+    notify,
+    request_palette_snapshot,
+    restore_browsing_from_palette,
+    selected_current_file_paths,
+)
+from .selectors import select_target_paths, select_visible_current_entry_states
 
 
 def _handle_begin_history_search(state: AppState) -> ReduceResult:
     history_items = tuple(dict.fromkeys(state.history.visited_all))
-    return finalize(_enter_palette(state, source="history", history_results=history_items))
+    return finalize(enter_palette(state, source="history", history_results=history_items))
 
 
 def _handle_begin_bookmark_search(state: AppState) -> ReduceResult:
-    return finalize(_enter_palette(state, source="bookmarks"))
+    return finalize(enter_palette(state, source="bookmarks"))
 
 
-def _handle_move_palette_cursor(
-    state: AppState,
-    action: MoveCommandPaletteCursor,
-) -> ReduceResult:
+def _handle_move_palette_cursor(state: AppState, action: MoveCommandPaletteCursor) -> ReduceResult:
     if state.command_palette is None:
         return finalize(state)
     next_palette = replace(
@@ -359,26 +150,23 @@ def _handle_move_palette_cursor(
     )
     if state.command_palette.source == "go_to_path":
         next_palette = replace(next_palette, go_to_path_selection_active=True)
-    next_state = replace(
-        state,
-        command_palette=next_palette,
-    )
+    next_state = replace(state, command_palette=next_palette)
     if state.command_palette.source == "file_search":
-        return _sync_file_search_preview(next_state)
+        return sync_file_search_preview(next_state)
     if state.command_palette.source == "grep_search":
-        return _sync_grep_preview(next_state)
+        return sync_grep_preview(next_state)
     if state.command_palette.source == "replace_text":
-        return _sync_replace_preview(next_state)
+        return sync_replace_preview(next_state)
     if state.command_palette.source == "replace_in_found_files":
-        return _sync_find_replace_preview(next_state)
+        return sync_find_replace_preview(next_state)
     if state.command_palette.source == "replace_in_grep_files":
-        return _sync_grep_replace_preview(next_state)
+        return sync_grep_replace_preview(next_state)
     if state.command_palette.source == "grep_replace_selected":
-        return _sync_grep_replace_selected_preview(next_state)
+        return sync_grep_replace_selected_preview(next_state)
     return finalize(next_state)
 
 
-def _next_palette_query_state(state: AppState, query: str) -> CommandPaletteState:
+def _next_palette_query_state(state: AppState, query: str):
     return replace(
         state.command_palette,
         query=query,
@@ -388,389 +176,7 @@ def _next_palette_query_state(state: AppState, query: str) -> CommandPaletteStat
     )
 
 
-def _handle_set_palette_query(
-    state: AppState,
-    action: SetCommandPaletteQuery,
-) -> ReduceResult:
-    if state.command_palette is None:
-        return finalize(state)
-
-    next_palette = _next_palette_query_state(state, action.query)
-
-    if state.command_palette.source == "file_search":
-        return _handle_set_file_search_query(state, next_palette, action.query)
-    if state.command_palette.source == "grep_search":
-        return _handle_set_grep_search_field(state, "keyword", action.query)
-    if state.command_palette.source == "go_to_path":
-        return _handle_set_go_to_path_query(state, next_palette, action.query)
-    if state.command_palette.source == "replace_in_grep_files":
-        return _handle_set_grep_replace_field(state, "keyword", action.query)
-    if state.command_palette.source == "grep_replace_selected":
-        return _handle_set_grep_replace_selected_field(state, "keyword", action.query)
-    return finalize(replace(state, command_palette=next_palette))
-
-
-def _handle_set_file_search_query(
-    state: AppState,
-    next_palette: CommandPaletteState,
-    query: str,
-) -> ReduceResult:
-    stripped_query = query.strip()
-    if not stripped_query:
-        return _sync_file_search_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    file_search_results=(),
-                    file_search_error_message=None,
-                ),
-                pending_file_search_request_id=None,
-                pending_grep_search_request_id=None,
-                pending_child_pane_request_id=None,
-            )
-        )
-
-    is_regex_query = is_regex_file_search_query(stripped_query)
-    normalized_query = stripped_query.casefold()
-    if (
-        not is_regex_query
-        and state.command_palette.file_search_cache_query
-        and normalized_query.startswith(state.command_palette.file_search_cache_query)
-        and state.command_palette.file_search_cache_root_path == state.current_path
-        and state.command_palette.file_search_cache_show_hidden == state.show_hidden
-    ):
-        return _sync_file_search_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    file_search_results=filter_file_search_results(
-                        state.command_palette.file_search_cache_results,
-                        normalized_query,
-                    ),
-                ),
-                pending_file_search_request_id=None,
-                pending_grep_search_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        command_palette=next_palette,
-        pending_file_search_request_id=request_id,
-        pending_grep_search_request_id=None,
-        next_request_id=request_id + 1,
-    )
-    return finalize(
-        next_state,
-        RunFileSearchEffect(
-            request_id=request_id,
-            root_path=state.current_path,
-            query=stripped_query,
-            show_hidden=state.show_hidden,
-        ),
-    )
-
-
-def _handle_set_grep_search_field(
-    state: AppState,
-    field: GrepSearchFieldId,
-    value: str,
-) -> ReduceResult:
-    next_palette = replace(
-        _replace_grep_field(state.command_palette, field=field, value=value),
-        grep_search_error_message=None,
-        cursor_index=0,
-    )
-    stripped_query = next_palette.grep_search_keyword.strip()
-    if not stripped_query:
-        return _sync_grep_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grep_search_results=(),
-                    grep_search_error_message=None,
-                ),
-                pending_grep_search_request_id=None,
-                pending_child_pane_request_id=None,
-            )
-        )
-
-    try:
-        include_globs, exclude_globs = _validate_grep_search_filters(next_palette)
-    except ValueError as error:
-        return _sync_grep_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grep_search_results=(),
-                    grep_search_error_message=str(error),
-                ),
-                pending_grep_search_request_id=None,
-                pending_child_pane_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        command_palette=next_palette,
-        pending_grep_search_request_id=request_id,
-        next_request_id=request_id + 1,
-    )
-    return finalize(
-        next_state,
-        RunGrepSearchEffect(
-            request_id=request_id,
-            root_path=state.current_path,
-            query=stripped_query,
-            show_hidden=state.show_hidden,
-            include_globs=include_globs,
-            exclude_globs=exclude_globs,
-        ),
-    )
-
-
-def _handle_set_replace_field(
-    state: AppState,
-    field: ReplaceFieldId,
-    value: str,
-) -> ReduceResult:
-    next_palette = replace(
-        _replace_replace_field(state.command_palette, field=field, value=value),
-        replace_error_message=None,
-        replace_status_message=None,
-        cursor_index=0,
-    )
-    find_text = next_palette.replace_find_text.strip()
-    if not find_text:
-        return finalize(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    replace_preview_results=(),
-                    replace_total_match_count=0,
-                ),
-                child_pane=PaneState(directory_path=state.current_path, entries=()),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=next_palette.replace_target_paths,
-        find_text=next_palette.replace_find_text,
-        replace_text=next_palette.replace_replacement_text,
-    )
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_set_find_replace_field(
-    state: AppState,
-    field: FindReplaceFieldId,
-    value: str,
-) -> ReduceResult:
-    if state.command_palette is None:
-        return finalize(state)
-
-    if field == "filename":
-        return _handle_set_rff_filename(state, value)
-
-    return _handle_set_rff_text_field(state, field, value)
-
-
-def _handle_set_rff_filename(state: AppState, value: str) -> ReduceResult:
-    next_palette = replace(
-        state.command_palette,
-        rff_filename_query=value,
-        rff_file_error_message=None,
-        cursor_index=0,
-    )
-    query = value.strip()
-    if not query:
-        return finalize(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    rff_file_results=(),
-                    rff_preview_results=(),
-                    rff_error_message=None,
-                    rff_status_message=None,
-                    rff_total_match_count=0,
-                ),
-                child_pane=PaneState(directory_path=state.current_path, entries=()),
-                pending_file_search_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_file_search_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunFileSearchEffect(
-            request_id=request_id,
-            root_path=state.current_path,
-            query=query,
-            show_hidden=state.show_hidden,
-        ),
-    )
-
-
-def _handle_set_rff_text_field(
-    state: AppState,
-    field: Literal["find", "replace"],
-    value: str,
-) -> ReduceResult:
-    if field == "find":
-        next_palette = replace(
-            state.command_palette,
-            rff_find_text=value,
-            rff_error_message=None,
-            rff_status_message=None,
-            cursor_index=0,
-        )
-    else:
-        next_palette = replace(
-            state.command_palette,
-            rff_replacement_text=value,
-            rff_error_message=None,
-            rff_status_message=None,
-            cursor_index=0,
-        )
-
-    find_text = next_palette.rff_find_text.strip()
-    file_paths = tuple(r.path for r in next_palette.rff_file_results)
-
-    if not find_text or not file_paths:
-        return finalize(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    rff_preview_results=(),
-                    rff_total_match_count=0,
-                ),
-                child_pane=PaneState(directory_path=state.current_path, entries=()),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=next_palette.rff_find_text,
-        replace_text=next_palette.rff_replacement_text,
-    )
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_cycle_replace_field(
-    state: AppState,
-    action: CycleReplaceField,
-) -> ReduceResult:
-    if state.command_palette is None or state.command_palette.source != "replace_text":
-        return finalize(state)
-    current_index = _REPLACE_FIELDS.index(state.command_palette.replace_active_field)
-    next_index = (current_index + action.delta) % len(_REPLACE_FIELDS)
-    return finalize(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                replace_active_field=_REPLACE_FIELDS[next_index],
-            ),
-        )
-    )
-
-
-def _handle_cycle_find_replace_field(
-    state: AppState,
-    action: CycleFindReplaceField,
-) -> ReduceResult:
-    if state.command_palette is None or state.command_palette.source != "replace_in_found_files":
-        return finalize(state)
-    current_index = _FIND_REPLACE_FIELDS.index(state.command_palette.rff_active_field)
-    next_index = (current_index + action.delta) % len(_FIND_REPLACE_FIELDS)
-    return finalize(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                rff_active_field=_FIND_REPLACE_FIELDS[next_index],
-            ),
-        )
-    )
-
-
-def _handle_cycle_grep_replace_field(
-    state: AppState,
-    action: CycleGrepReplaceField,
-) -> ReduceResult:
-    if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
-        return finalize(state)
-    current_index = _GREP_REPLACE_FIELDS.index(state.command_palette.grf_active_field)
-    next_index = (current_index + action.delta) % len(_GREP_REPLACE_FIELDS)
-    return finalize(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                grf_active_field=_GREP_REPLACE_FIELDS[next_index],
-            ),
-        )
-    )
-
-
-def _handle_cycle_grep_search_field(
-    state: AppState,
-    action: CycleGrepSearchField,
-) -> ReduceResult:
-    if state.command_palette is None or state.command_palette.source != "grep_search":
-        return finalize(state)
-    current_index = _GREP_SEARCH_FIELDS.index(state.command_palette.grep_search_active_field)
-    next_index = (current_index + action.delta) % len(_GREP_SEARCH_FIELDS)
-    return finalize(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                grep_search_active_field=_GREP_SEARCH_FIELDS[next_index],
-            ),
-        )
-    )
-
-
-def _handle_set_go_to_path_query(
-    state: AppState,
-    next_palette: CommandPaletteState,
-    query: str,
-) -> ReduceResult:
+def _handle_set_go_to_path_query(state: AppState, next_palette, query: str) -> ReduceResult:
     matches = list_matching_directory_paths(query, state.current_path)
     has_trailing_separator = query.endswith("/")
     return finalize(
@@ -785,266 +191,66 @@ def _handle_set_go_to_path_query(
     )
 
 
-def _handle_submit_palette(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
+def _handle_set_palette_query(state: AppState, action: SetCommandPaletteQuery) -> ReduceResult:
     if state.command_palette is None:
         return finalize(state)
-
+    next_palette = _next_palette_query_state(state, action.query)
     if state.command_palette.source == "file_search":
-        return _handle_submit_file_search_palette(state, reduce_state)
+        return handle_set_file_search_query(state, next_palette, action.query)
     if state.command_palette.source == "grep_search":
-        return _handle_submit_grep_search_palette(state, reduce_state)
-    if state.command_palette.source == "replace_text":
-        return _handle_submit_replace_palette(state)
-    if state.command_palette.source == "replace_in_found_files":
-        return _handle_submit_find_and_replace_palette(state)
-    if state.command_palette.source == "replace_in_grep_files":
-        return _handle_submit_grep_replace_palette(state)
-    if state.command_palette.source == "grep_replace_selected":
-        return _handle_submit_grep_replace_selected_palette(state)
-    if state.command_palette.source == "history":
-        return _handle_submit_history_palette(state, reduce_state)
-    if state.command_palette.source == "bookmarks":
-        return _handle_submit_bookmarks_palette(state, reduce_state)
+        return handle_set_grep_search_field(state, "keyword", action.query)
     if state.command_palette.source == "go_to_path":
-        return _handle_submit_go_to_path_palette(state, reduce_state)
-    return _handle_submit_commands_palette(state, reduce_state)
+        return _handle_set_go_to_path_query(state, next_palette, action.query)
+    if state.command_palette.source == "replace_in_grep_files":
+        return handle_set_grep_replace_field(state, "keyword", action.query)
+    if state.command_palette.source == "grep_replace_selected":
+        return handle_set_grep_replace_selected_field(state, "keyword", action.query)
+    return finalize(replace(state, command_palette=next_palette))
 
 
-def _handle_submit_file_search_palette(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    results = state.command_palette.file_search_results
-    message = state.command_palette.file_search_error_message or "No matching files"
-    if not results:
-        return _notify(state, level="warning", message=message)
-
-    selected_result = results[
-        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
-    ]
-    return _request_palette_snapshot(
-        state,
-        reduce_state,
-        path=str(Path(selected_result.path).parent),
-        cursor_path=selected_result.path,
-    )
-
-
-def _handle_submit_grep_search_palette(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    results = state.command_palette.grep_search_results
-    message = state.command_palette.grep_search_error_message or "No matching lines"
-    if not results:
-        return _notify(state, level="warning", message=message)
-
-    selected_result = results[
-        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
-    ]
-    return _request_palette_snapshot(
-        state,
-        reduce_state,
-        path=str(Path(selected_result.path).parent),
-        cursor_path=selected_result.path,
-    )
-
-
-def _handle_open_grep_result_in_editor(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    results = state.command_palette.grep_search_results
-    message = state.command_palette.grep_search_error_message or "No matching lines"
-    if not results:
-        return _notify(state, level="warning", message=message)
-
-    selected_result = results[
-        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
-    ]
-    return run_external_launch_request(
-        replace(state, notification=None),
-        ExternalLaunchRequest(
-            kind="open_editor",
-            path=selected_result.path,
-            line_number=selected_result.line_number,
-        ),
-    )
-
-
-def _handle_open_find_result_in_editor(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    results = state.command_palette.file_search_results
-    message = state.command_palette.file_search_error_message or "No matching files"
-    if not results:
-        return _notify(state, level="warning", message=message)
-
-    selected_result = results[
-        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
-    ]
-    return run_external_launch_request(
-        replace(state, notification=None),
-        ExternalLaunchRequest(
-            kind="open_editor",
-            path=selected_result.path,
-            line_number=None,  # File search doesn't have line numbers
-        ),
-    )
-
-
-def _handle_submit_replace_palette(state: AppState) -> ReduceResult:
-    if state.pending_replace_preview_request_id is not None:
-        return _notify(state, level="warning", message="Replacement preview is still running")
-    if state.command_palette is None:
+def _handle_cycle_grep_search_field(state: AppState, action: CycleGrepSearchField) -> ReduceResult:
+    if state.command_palette is None or state.command_palette.source != "grep_search":
         return finalize(state)
-    if not state.command_palette.replace_find_text.strip():
-        return _notify(state, level="warning", message="Find text is required")
-    if state.command_palette.replace_error_message is not None:
-        return _notify(state, level="warning", message=state.command_palette.replace_error_message)
-    if not state.command_palette.replace_preview_results:
-        message = state.command_palette.replace_status_message or "No matching files"
-        return _notify(state, level="warning", message=message)
-
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=state.command_palette.replace_target_paths,
-        find_text=state.command_palette.replace_find_text,
-        replace_text=state.command_palette.replace_replacement_text,
-    )
-    next_state = _restore_browsing_from_palette(state)
+    current_index = GREP_SEARCH_FIELDS.index(state.command_palette.grep_search_active_field)
+    next_index = (current_index + action.delta) % len(GREP_SEARCH_FIELDS)
     return finalize(
         replace(
-            next_state,
-            pending_replace_apply_request_id=request_id,
-            next_request_id=request_id + 1,
-            notification=NotificationState(level="info", message="Applying replacement..."),
-        ),
-        RunTextReplaceApplyEffect(request_id=request_id, request=request),
+            state,
+            command_palette=replace(
+                state.command_palette,
+                grep_search_active_field=GREP_SEARCH_FIELDS[next_index],
+            ),
+        )
     )
 
 
-def _handle_submit_find_and_replace_palette(state: AppState) -> ReduceResult:
-    if state.pending_replace_preview_request_id is not None:
-        return _notify(state, level="warning", message="Replacement preview is still running")
-    if state.pending_file_search_request_id is not None:
-        return _notify(state, level="warning", message="File search is still running")
-    if state.command_palette is None:
-        return finalize(state)
-    if not state.command_palette.rff_find_text.strip():
-        return _notify(state, level="warning", message="Find text is required")
-    if state.command_palette.rff_error_message is not None:
-        return _notify(state, level="warning", message=state.command_palette.rff_error_message)
-    if not state.command_palette.rff_preview_results:
-        message = state.command_palette.rff_status_message or "No matching files"
-        return _notify(state, level="warning", message=message)
-
-    file_paths = tuple(r.path for r in state.command_palette.rff_file_results)
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=state.command_palette.rff_find_text,
-        replace_text=state.command_palette.rff_replacement_text,
-    )
-    next_state = _restore_browsing_from_palette(state)
-    return finalize(
-        replace(
-            next_state,
-            pending_replace_apply_request_id=request_id,
-            next_request_id=request_id + 1,
-            notification=NotificationState(level="info", message="Applying replacement..."),
-        ),
-        RunTextReplaceApplyEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_submit_grep_replace_palette(state: AppState) -> ReduceResult:
-    if state.pending_replace_preview_request_id is not None:
-        return _notify(state, level="warning", message="Replacement preview is still running")
-    if state.pending_grep_search_request_id is not None:
-        return _notify(state, level="warning", message="Grep search is still running")
-    if state.command_palette is None:
-        return finalize(state)
-    if not state.command_palette.grf_keyword.strip():
-        return _notify(state, level="warning", message="Keyword is required")
-    if state.command_palette.grf_error_message is not None:
-        return _notify(state, level="warning", message=state.command_palette.grf_error_message)
-    if not state.command_palette.grf_preview_results:
-        message = state.command_palette.grf_status_message or "No matching files"
-        return _notify(state, level="warning", message=message)
-
-    filtered_results = _filter_grf_by_filename(
-        state.command_palette.grf_grep_results, state.command_palette.grf_filename_filter
-    )
-    file_paths = _grf_unique_file_paths(filtered_results)
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=state.command_palette.grf_keyword,
-        replace_text=state.command_palette.grf_replacement_text,
-    )
-    next_state = _restore_browsing_from_palette(state)
-    return finalize(
-        replace(
-            next_state,
-            pending_replace_apply_request_id=request_id,
-            next_request_id=request_id + 1,
-            notification=NotificationState(level="info", message="Applying replacement..."),
-        ),
-        RunTextReplaceApplyEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_submit_history_palette(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
+def _handle_submit_history_palette(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
     items = get_command_palette_items(state)
     if not items:
-        return _notify(state, level="warning", message="No directory history")
-
+        return notify(state, level="warning", message="No directory history")
     selected_item = items[
         normalize_command_palette_cursor(state, state.command_palette.cursor_index)
     ]
-    return _request_palette_snapshot(
-        state,
-        reduce_state,
-        path=selected_item.path,
-    )
+    return request_palette_snapshot(state, reduce_state, path=selected_item.path)
 
 
-def _handle_submit_bookmarks_palette(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
+def _handle_submit_bookmarks_palette(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
     items = get_command_palette_items(state)
     if not items:
-        return _notify(state, level="warning", message="No bookmarks")
-
+        return notify(state, level="warning", message="No bookmarks")
     selected_item = items[
         normalize_command_palette_cursor(state, state.command_palette.cursor_index)
     ]
     if selected_item.path is None or not Path(selected_item.path).is_dir():
-        return _notify(
+        return notify(
             state,
             level="error",
             message="Bookmarked path does not exist or is not a directory",
         )
-    return _request_palette_snapshot(
-        state,
-        reduce_state,
-        path=selected_item.path,
-    )
+    return request_palette_snapshot(state, reduce_state, path=selected_item.path)
 
 
-def _handle_submit_go_to_path_palette(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
+def _handle_submit_go_to_path_palette(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
     items = get_command_palette_items(state)
     expanded_path = None
     if items and state.command_palette.go_to_path_selection_active:
@@ -1052,43 +258,270 @@ def _handle_submit_go_to_path_palette(
             normalize_command_palette_cursor(state, state.command_palette.cursor_index)
         ].path
     if expanded_path is None:
-        expanded_path = expand_and_validate_path(
-            state.command_palette.query,
-            state.current_path,
-        )
+        expanded_path = expand_and_validate_path(state.command_palette.query, state.current_path)
     if expanded_path is None:
-        return _notify(
-            state,
-            level="error",
-            message="Path does not exist or is not a directory",
+        return notify(state, level="error", message="Path does not exist or is not a directory")
+    return request_palette_snapshot(state, reduce_state, path=expanded_path)
+
+
+def _run_new_tab_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, OpenNewTab())
+
+
+def _run_next_tab_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, ActivateNextTab())
+
+
+def _run_previous_tab_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, ActivatePreviousTab())
+
+
+def _run_close_current_tab_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, CloseCurrentTab())
+
+
+def _run_file_search_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginFileSearch())
+
+
+def _run_grep_search_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginGrepSearch())
+
+
+def _run_history_search_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginHistorySearch())
+
+
+def _run_bookmark_search_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginBookmarkSearch())
+
+
+def _run_go_back_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, GoBack())
+
+
+def _run_go_forward_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, GoForward())
+
+
+def _run_go_to_path_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginGoToPath())
+
+
+def _run_go_to_home_directory_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, GoToHomeDirectory())
+
+
+def _run_reload_directory_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, ReloadDirectory())
+
+
+def _run_toggle_split_terminal_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, ToggleSplitTerminal())
+
+
+def _run_select_all_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    visible_paths = tuple(entry.path for entry in select_visible_current_entry_states(state))
+    return reduce_state(state, SelectAllVisibleEntries(visible_paths))
+
+
+def _run_replace_text_command(
+    state: AppState,
+    next_state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    target_paths = selected_current_file_paths(state)
+    if not target_paths:
+        return notify(
+            next_state,
+            level="warning",
+            message=(
+                "Replace text requires a selected file or file selection "
+                "in the current directory"
+            ),
         )
-    return _request_palette_snapshot(
-        state,
-        reduce_state,
-        path=expanded_path,
+    return reduce_state(next_state, BeginTextReplace(target_paths=target_paths))
+
+
+def _run_find_and_replace_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginFindAndReplace())
+
+
+def _run_grep_replace_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginGrepReplace())
+
+
+def _run_show_attributes_command(state: AppState) -> ReduceResult:
+    entry = single_target_entry(state)
+    if entry is None:
+        return notify(state, level="warning", message="Show attributes requires a single target")
+    return finalize(
+        replace(
+            state,
+            ui_mode="DETAIL",
+            notification=None,
+            command_palette=None,
+            pending_file_search_request_id=None,
+            pending_grep_search_request_id=None,
+            attribute_inspection=AttributeInspectionState(
+                name=entry.name,
+                kind=entry.kind,
+                path=entry.path,
+                size_bytes=entry.size_bytes,
+                modified_at=entry.modified_at,
+                hidden=entry.hidden,
+                permissions_mode=entry.permissions_mode,
+            ),
+        )
     )
 
 
-def _handle_submit_commands_palette(
+def _run_copy_path_command(next_state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(next_state, CopyPathsToClipboard())
+
+
+def _run_rename_command(
     state: AppState,
+    next_state: AppState,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    items = get_command_palette_items(state)
-    if not items:
-        return _notify(state, level="warning", message="No matching command")
+    target_path = single_target_path(state)
+    if target_path is None:
+        return notify(next_state, level="warning", message="Rename requires a single target")
+    return reduce_state(next_state, BeginRenameInput(path=target_path))
 
-    selected_item = items[
-        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
-    ]
-    if not selected_item.enabled:
-        return _notify(
-            state,
+
+def _run_open_in_editor_command(
+    state: AppState,
+    next_state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    entry = single_target_entry(state)
+    if entry is None:
+        return notify(
+            next_state,
             level="warning",
-            message=f"{selected_item.label} is not available yet",
+            message="Open in editor requires a single target",
         )
+    if entry.kind != "file":
+        return notify(next_state, level="warning", message="Can only open files in editor")
+    return reduce_state(next_state, OpenPathInEditor(path=entry.path))
 
-    next_state = _restore_browsing_from_palette(state)
-    return _run_palette_command_item(state, next_state, selected_item.id, reduce_state)
+
+def _run_extract_archive_command(
+    state: AppState,
+    next_state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    entry = single_target_entry(state)
+    if entry is None:
+        return notify(
+            next_state,
+            level="warning",
+            message="Extract archive requires a single target",
+        )
+    if entry.kind != "file" or not is_supported_archive_path(entry.path):
+        return notify(
+            next_state,
+            level="warning",
+            message="Extract archive requires a supported archive file",
+        )
+    return reduce_state(next_state, BeginExtractArchiveInput(source_path=entry.path))
+
+
+def _run_compress_as_zip_command(
+    state: AppState,
+    next_state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    target_paths = select_target_paths(state)
+    if not target_paths:
+        return notify(
+            next_state,
+            level="warning",
+            message="Compress as zip requires at least one target",
+        )
+    return reduce_state(next_state, BeginZipCompressInput(source_paths=target_paths))
+
+
+def _run_delete_targets_command(
+    state: AppState,
+    next_state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    target_paths = select_target_paths(state)
+    if not target_paths:
+        return notify(state, level="warning", message="Nothing to delete")
+    return reduce_state(next_state, BeginDeleteTargets(paths=target_paths))
+
+
+def _run_empty_trash_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginEmptyTrash())
+
+
+def _run_open_file_manager_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, OpenPathWithDefaultApp(state.current_path))
+
+
+def _run_open_terminal_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, OpenTerminalAtPath(state.current_path))
+
+
+def _run_shell_command_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginShellCommandInput())
+
+
+def _run_add_bookmark_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, AddBookmark(path=state.current_path))
+
+
+def _run_remove_bookmark_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, RemoveBookmark(path=state.current_path))
+
+
+def _run_toggle_hidden_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, ToggleHiddenFiles())
+
+
+def _run_edit_config_command(state: AppState) -> ReduceResult:
+    return finalize(
+        replace(
+            state,
+            ui_mode="CONFIG",
+            notification=None,
+            command_palette=None,
+            pending_file_search_request_id=None,
+            pending_grep_search_request_id=None,
+            attribute_inspection=None,
+            config_editor=ConfigEditorState(path=state.config_path, draft=state.config),
+        )
+    )
+
+
+def _run_create_file_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginCreateInput("file"))
+
+
+def _run_create_dir_command(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    return reduce_state(state, BeginCreateInput("dir"))
+
+
+def _run_grep_replace_selected_command(
+    state: AppState,
+    next_state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    target_paths = selected_current_file_paths(state)
+    if not target_paths:
+        return notify(
+            next_state,
+            level="warning",
+            message=(
+                "Grep replace requires a selected file or file selection "
+                "in the current directory"
+            ),
+        )
+    return reduce_state(next_state, BeginGrepReplaceSelected(target_paths=target_paths))
 
 
 def _run_palette_command_item(
@@ -1174,1820 +607,45 @@ def _run_palette_command_item(
     return finalize(next_state)
 
 
-def _run_new_tab_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, OpenNewTab())
-
-
-def _run_next_tab_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, ActivateNextTab())
-
-
-def _run_previous_tab_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, ActivatePreviousTab())
-
-
-def _run_close_current_tab_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, CloseCurrentTab())
-
-
-def _run_file_search_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginFileSearch())
-
-
-def _run_grep_search_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginGrepSearch())
-
-
-def _run_history_search_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginHistorySearch())
-
-
-def _run_bookmark_search_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginBookmarkSearch())
-
-
-def _run_go_back_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, GoBack())
-
-
-def _run_go_forward_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, GoForward())
-
-
-def _run_go_to_path_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginGoToPath())
-
-
-def _run_go_to_home_directory_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, GoToHomeDirectory())
-
-
-def _run_reload_directory_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, ReloadDirectory())
-
-
-def _run_toggle_split_terminal_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, ToggleSplitTerminal())
-
-
-def _run_select_all_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    visible_paths = tuple(entry.path for entry in select_visible_current_entry_states(state))
-    return reduce_state(state, SelectAllVisibleEntries(visible_paths))
-
-
-def _selected_current_file_paths(state: AppState) -> tuple[str, ...]:
-    selected_paths = tuple(
-        entry.path
-        for entry in select_visible_current_entry_states(state)
-        if entry.path in state.current_pane.selected_paths and entry.kind == "file"
-    )
-    if state.current_pane.selected_paths:
-        return selected_paths
-
-    entry = single_target_entry(state)
-    if entry is None or entry.kind != "file":
-        return ()
-    return (entry.path,)
-
-
-def _run_replace_text_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    target_paths = _selected_current_file_paths(state)
-    if not target_paths:
-        return _notify(
-            next_state,
-            level="warning",
-            message=(
-                "Replace text requires a selected file or file selection "
-                "in the current directory"
-            ),
-        )
-    return reduce_state(next_state, BeginTextReplace(target_paths=target_paths))
-
-
-def _run_find_and_replace_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginFindAndReplace())
-
-
-def _run_grep_replace_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginGrepReplace())
-
-
-def _run_show_attributes_command(state: AppState) -> ReduceResult:
-    entry = single_target_entry(state)
-    if entry is None:
-        return _notify(
+def _handle_submit_commands_palette(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
+    items = get_command_palette_items(state)
+    if not items:
+        return notify(state, level="warning", message="No matching command")
+    selected_item = items[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    if not selected_item.enabled:
+        return notify(
             state,
             level="warning",
-            message="Show attributes requires a single target",
+            message=f"{selected_item.label} is not available yet",
         )
+    next_state = restore_browsing_from_palette(state)
+    return _run_palette_command_item(state, next_state, selected_item.id, reduce_state)
 
-    return finalize(
-        replace(
-            state,
-            ui_mode="DETAIL",
-            notification=None,
-            command_palette=None,
-            pending_file_search_request_id=None,
-            pending_grep_search_request_id=None,
-            attribute_inspection=AttributeInspectionState(
-                name=entry.name,
-                kind=entry.kind,
-                path=entry.path,
-                size_bytes=entry.size_bytes,
-                modified_at=entry.modified_at,
-                hidden=entry.hidden,
-                permissions_mode=entry.permissions_mode,
-            ),
-        )
-    )
 
-
-def _run_copy_path_command(
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(next_state, CopyPathsToClipboard())
-
-
-def _run_rename_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    target_path = single_target_path(state)
-    if target_path is None:
-        return _notify(
-            next_state,
-            level="warning",
-            message="Rename requires a single target",
-        )
-    return reduce_state(next_state, BeginRenameInput(path=target_path))
-
-
-def _run_open_in_editor_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    entry = single_target_entry(state)
-    if entry is None:
-        return _notify(
-            next_state,
-            level="warning",
-            message="Open in editor requires a single target",
-        )
-    if entry.kind != "file":
-        return _notify(
-            next_state,
-            level="warning",
-            message="Can only open files in editor",
-        )
-    return reduce_state(next_state, OpenPathInEditor(path=entry.path))
-
-
-def _run_extract_archive_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    entry = single_target_entry(state)
-    if entry is None:
-        return _notify(
-            next_state,
-            level="warning",
-            message="Extract archive requires a single target",
-        )
-    if entry.kind != "file" or not is_supported_archive_path(entry.path):
-        return _notify(
-            next_state,
-            level="warning",
-            message="Extract archive requires a supported archive file",
-        )
-    return reduce_state(next_state, BeginExtractArchiveInput(source_path=entry.path))
-
-
-def _run_compress_as_zip_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    target_paths = select_target_paths(state)
-    if not target_paths:
-        return _notify(
-            next_state,
-            level="warning",
-            message="Compress as zip requires at least one target",
-        )
-    return reduce_state(next_state, BeginZipCompressInput(source_paths=target_paths))
-
-
-def _run_delete_targets_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    target_paths = select_target_paths(state)
-    if not target_paths:
-        return _notify(state, level="warning", message="Nothing to delete")
-    return reduce_state(next_state, BeginDeleteTargets(paths=target_paths))
-
-
-def _run_empty_trash_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginEmptyTrash())
-
-
-def _run_open_file_manager_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, OpenPathWithDefaultApp(state.current_path))
-
-
-def _run_open_terminal_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, OpenTerminalAtPath(state.current_path))
-
-
-def _run_shell_command_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginShellCommandInput())
-
-
-def _run_add_bookmark_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, AddBookmark(path=state.current_path))
-
-
-def _run_remove_bookmark_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, RemoveBookmark(path=state.current_path))
-
-
-def _run_toggle_hidden_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, ToggleHiddenFiles())
-
-
-def _run_edit_config_command(state: AppState) -> ReduceResult:
-    return finalize(
-        replace(
-            state,
-            ui_mode="CONFIG",
-            notification=None,
-            command_palette=None,
-            pending_file_search_request_id=None,
-            pending_grep_search_request_id=None,
-            attribute_inspection=None,
-            config_editor=ConfigEditorState(
-                path=state.config_path,
-                draft=state.config,
-            ),
-        )
-    )
-
-
-def _run_create_file_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginCreateInput("file"))
-
-
-def _run_create_dir_command(
-    state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return reduce_state(state, BeginCreateInput("dir"))
-
-
-def _matches_search_completion(
-    state: AppState,
-    *,
-    request_id: int,
-    pending_request_id: int | None,
-    source: str,
-    query: str,
-) -> bool:
-    return (
-        request_id == pending_request_id
-        and state.command_palette is not None
-        and state.command_palette.source == source
-        and state.command_palette.query.strip() == query
-    )
-
-
-def _handle_file_search_completed(
-    state: AppState,
-    action: FileSearchCompleted,
-) -> ReduceResult:
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "replace_in_found_files"
-    ):
-        return _handle_rff_file_search_completed(state, action)
-
-    if not _matches_search_completion(
-        state,
-        request_id=action.request_id,
-        pending_request_id=state.pending_file_search_request_id,
-        source="file_search",
-        query=action.query,
-    ):
-        return finalize(state)
-
-    cache_query = ""
-    cache_results = ()
-    if not is_regex_file_search_query(action.query):
-        cache_query = action.query.casefold()
-        cache_results = action.results
-
-    return _sync_file_search_preview(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                file_search_results=action.results,
-                file_search_error_message=None,
-                cursor_index=0,
-                file_search_cache_query=cache_query,
-                file_search_cache_results=cache_results,
-                file_search_cache_root_path=state.current_path,
-                file_search_cache_show_hidden=state.show_hidden,
-            ),
-            pending_file_search_request_id=None,
-        )
-    )
-
-
-def _handle_rff_file_search_completed(
-    state: AppState,
-    action: FileSearchCompleted,
-) -> ReduceResult:
-    if action.request_id != state.pending_file_search_request_id:
-        return finalize(state)
-
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            rff_file_results=action.results,
-            rff_file_error_message=None,
-            cursor_index=0,
-        ),
-        pending_file_search_request_id=None,
-    )
-
-    find_text = next_state.command_palette.rff_find_text.strip()
-    if not find_text or not action.results:
-        return _sync_find_replace_preview(
-            replace(
-                next_state,
-                command_palette=replace(
-                    next_state.command_palette,
-                    rff_preview_results=(),
-                    rff_total_match_count=0,
-                ),
-            )
-        )
-
-    file_paths = tuple(r.path for r in action.results)
-    request_id = next_state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=next_state.command_palette.rff_find_text,
-        replace_text=next_state.command_palette.rff_replacement_text,
-    )
-    return finalize(
-        replace(
-            next_state,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_file_search_failed(
-    state: AppState,
-    action: FileSearchFailed,
-) -> ReduceResult:
-    if action.request_id != state.pending_file_search_request_id:
-        return finalize(state)
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "replace_in_found_files"
-    ):
-        if action.invalid_query:
-            return _sync_find_replace_preview(
-                replace(
-                    state,
-                    command_palette=replace(
-                        state.command_palette,
-                        rff_file_results=(),
-                        rff_file_error_message=action.message,
-                        rff_preview_results=(),
-                        rff_total_match_count=0,
-                    ),
-                    pending_file_search_request_id=None,
-                )
-            )
-        return finalize(
-            replace(
-                state,
-                notification=NotificationState(level="error", message=action.message),
-                pending_file_search_request_id=None,
-            )
-        )
-
-    if state.command_palette is not None and action.invalid_query:
-        return _sync_file_search_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    state.command_palette,
-                    file_search_results=(),
-                    file_search_error_message=action.message,
-                ),
-                pending_file_search_request_id=None,
-            )
-        )
-
-    return finalize(
-        replace(
-            state,
-            notification=NotificationState(level="error", message=action.message),
-            pending_file_search_request_id=None,
-        )
-    )
-
-
-def _handle_grep_search_completed(
-    state: AppState,
-    action: GrepSearchCompleted,
-) -> ReduceResult:
-    if action.request_id != state.pending_grep_search_request_id:
-        return finalize(state)
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "replace_in_grep_files"
-    ):
-        return _handle_grf_grep_search_completed(state, action)
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "grep_replace_selected"
-    ):
-        return _handle_grs_grep_search_completed(state, action)
-
-    if (
-        state.command_palette is None
-        or state.command_palette.source != "grep_search"
-    ):
-        return finalize(state)
-
-    return _sync_grep_preview(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                grep_search_results=_filter_grep_results_by_filename(
-                    action.results,
-                    state.command_palette.grep_search_filename_filter,
-                ),
-                grep_search_error_message=None,
-                cursor_index=0,
-            ),
-            pending_grep_search_request_id=None,
-        )
-    )
-
-
-def _handle_grep_search_failed(
-    state: AppState,
-    action: GrepSearchFailed,
-) -> ReduceResult:
-    if action.request_id != state.pending_grep_search_request_id:
-        return finalize(state)
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "replace_in_grep_files"
-    ):
-        if action.invalid_query:
-            return _sync_grep_replace_preview(
-                replace(
-                    state,
-                    command_palette=replace(
-                        state.command_palette,
-                        grf_grep_results=(),
-                        grf_grep_error_message=action.message,
-                        grf_preview_results=(),
-                        grf_total_match_count=0,
-                        cursor_index=0,
-                    ),
-                    pending_grep_search_request_id=None,
-                )
-            )
-        return finalize(
-            replace(
-                state,
-                notification=NotificationState(level="error", message=action.message),
-                pending_grep_search_request_id=None,
-            )
-        )
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "grep_replace_selected"
-    ):
-        if action.invalid_query:
-            return _sync_grep_replace_selected_preview(
-                replace(
-                    state,
-                    command_palette=replace(
-                        state.command_palette,
-                        grs_grep_results=(),
-                        grs_grep_error_message=action.message,
-                        grs_preview_results=(),
-                        grs_total_match_count=0,
-                        cursor_index=0,
-                    ),
-                    pending_grep_search_request_id=None,
-                )
-            )
-        return finalize(
-            replace(
-                state,
-                notification=NotificationState(level="error", message=action.message),
-                pending_grep_search_request_id=None,
-            )
-        )
-
-    if state.command_palette is not None and action.invalid_query:
-        return _sync_grep_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    state.command_palette,
-                    grep_search_results=(),
-                    grep_search_error_message=action.message,
-                    cursor_index=0,
-                ),
-                pending_grep_search_request_id=None,
-                pending_child_pane_request_id=None,
-            )
-        )
-
-    return finalize(
-        replace(
-            state,
-            notification=NotificationState(level="error", message=action.message),
-            pending_grep_search_request_id=None,
-        )
-    )
-
-
-def _handle_text_replace_preview_completed(
-    state: AppState,
-    action: TextReplacePreviewCompleted,
-) -> ReduceResult:
-    if action.request_id != state.pending_replace_preview_request_id:
-        return finalize(state)
+def _handle_submit_palette(state: AppState, reduce_state: ReducerFn) -> ReduceResult:
     if state.command_palette is None:
         return finalize(state)
-
+    if state.command_palette.source == "file_search":
+        return handle_submit_file_search_palette(state, reduce_state)
+    if state.command_palette.source == "grep_search":
+        return handle_submit_grep_search_palette(state, reduce_state)
+    if state.command_palette.source == "replace_text":
+        return handle_submit_replace_palette(state)
     if state.command_palette.source == "replace_in_found_files":
-        return _handle_rff_preview_completed(state, action)
+        return handle_submit_find_and_replace_palette(state)
     if state.command_palette.source == "replace_in_grep_files":
-        return _handle_grf_preview_completed(state, action)
+        return handle_submit_grep_replace_palette(state)
     if state.command_palette.source == "grep_replace_selected":
-        return _handle_grs_preview_completed(state, action)
-    if state.command_palette.source != "replace_text":
-        return finalize(state)
-
-    preview_results = tuple(
-        ReplacePreviewResultState(
-            path=entry.path,
-            display_path=str(Path(entry.path).name)
-            if Path(entry.path).parent == Path(state.current_path)
-            else str(Path(entry.path).relative_to(state.current_path)),
-            diff_text=entry.diff_text,
-            match_count=entry.match_count,
-            first_match_line_number=entry.first_match_line_number,
-            first_match_before=entry.first_match_before,
-            first_match_after=entry.first_match_after,
-        )
-        for entry in action.result.changed_entries
-    )
-    status_message = None
-    if action.result.skipped_paths:
-        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            replace_preview_results=preview_results,
-            replace_error_message=None,
-            replace_status_message=status_message,
-            replace_total_match_count=action.result.total_match_count,
-            cursor_index=0,
-        ),
-        pending_replace_preview_request_id=None,
-    )
-    return _sync_replace_preview(next_state)
-
-
-def _handle_rff_preview_completed(
-    state: AppState,
-    action: TextReplacePreviewCompleted,
-) -> ReduceResult:
-    preview_results = tuple(
-        ReplacePreviewResultState(
-            path=entry.path,
-            display_path=str(Path(entry.path).name)
-            if Path(entry.path).parent == Path(state.current_path)
-            else str(Path(entry.path).relative_to(state.current_path)),
-            diff_text=entry.diff_text,
-            match_count=entry.match_count,
-            first_match_line_number=entry.first_match_line_number,
-            first_match_before=entry.first_match_before,
-            first_match_after=entry.first_match_after,
-        )
-        for entry in action.result.changed_entries
-    )
-    status_message = None
-    if action.result.skipped_paths:
-        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            rff_preview_results=preview_results,
-            rff_error_message=None,
-            rff_status_message=status_message,
-            rff_total_match_count=action.result.total_match_count,
-            cursor_index=0,
-        ),
-        pending_replace_preview_request_id=None,
-    )
-    return _sync_find_replace_preview(next_state)
-
-
-def _handle_text_replace_preview_failed(
-    state: AppState,
-    action: TextReplacePreviewFailed,
-) -> ReduceResult:
-    if action.request_id != state.pending_replace_preview_request_id:
-        return finalize(state)
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "replace_in_found_files"
-    ):
-        if action.invalid_query:
-            return _sync_find_replace_preview(
-                replace(
-                    state,
-                    command_palette=replace(
-                        state.command_palette,
-                        rff_preview_results=(),
-                        rff_error_message=action.message,
-                        rff_status_message=None,
-                        rff_total_match_count=0,
-                        cursor_index=0,
-                    ),
-                    child_pane=PaneState(directory_path=state.current_path, entries=()),
-                    pending_replace_preview_request_id=None,
-                )
-            )
-        return finalize(
-            replace(
-                state,
-                notification=NotificationState(level="error", message=action.message),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "replace_in_grep_files"
-    ):
-        if action.invalid_query:
-            return _sync_grep_replace_preview(
-                replace(
-                    state,
-                    command_palette=replace(
-                        state.command_palette,
-                        grf_preview_results=(),
-                        grf_error_message=action.message,
-                        grf_status_message=None,
-                        grf_total_match_count=0,
-                        cursor_index=0,
-                    ),
-                    child_pane=PaneState(directory_path=state.current_path, entries=()),
-                    pending_replace_preview_request_id=None,
-                )
-            )
-        return finalize(
-            replace(
-                state,
-                notification=NotificationState(level="error", message=action.message),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    if (
-        state.command_palette is not None
-        and state.command_palette.source == "grep_replace_selected"
-    ):
-        if action.invalid_query:
-            return _sync_grep_replace_selected_preview(
-                replace(
-                    state,
-                    command_palette=replace(
-                        state.command_palette,
-                        grs_preview_results=(),
-                        grs_error_message=action.message,
-                        grs_status_message=None,
-                        grs_total_match_count=0,
-                        cursor_index=0,
-                    ),
-                    child_pane=PaneState(directory_path=state.current_path, entries=()),
-                    pending_replace_preview_request_id=None,
-                )
-            )
-        return finalize(
-            replace(
-                state,
-                notification=NotificationState(level="error", message=action.message),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    if state.command_palette is not None and action.invalid_query:
-        return finalize(
-            replace(
-                state,
-                command_palette=replace(
-                    state.command_palette,
-                    replace_preview_results=(),
-                    replace_error_message=action.message,
-                    replace_status_message=None,
-                    replace_total_match_count=0,
-                    cursor_index=0,
-                ),
-                child_pane=PaneState(directory_path=state.current_path, entries=()),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    return finalize(
-        replace(
-            state,
-            notification=NotificationState(level="error", message=action.message),
-            pending_replace_preview_request_id=None,
-        )
-    )
-
-
-def _handle_text_replace_applied(
-    state: AppState,
-    action: TextReplaceApplied,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    if action.request_id != state.pending_replace_apply_request_id:
-        return finalize(state)
-
-    next_state = replace(
-        state,
-        pending_replace_apply_request_id=None,
-        post_reload_notification=NotificationState(
-            level=action.result.level,
-            message=action.result.message,
-        ),
-        notification=None,
-    )
-    return reduce_state(
-        next_state,
-        RequestBrowserSnapshot(
-            path=state.current_path,
-            cursor_path=state.current_pane.cursor_path,
-            blocking=True,
-            invalidate_paths=browser_snapshot_invalidation_paths(
-                state.current_path,
-                *action.result.changed_paths,
-            ),
-        ),
-    )
-
-
-def _handle_text_replace_apply_failed(
-    state: AppState,
-    action: TextReplaceApplyFailed,
-) -> ReduceResult:
-    if action.request_id != state.pending_replace_apply_request_id:
-        return finalize(state)
-    return finalize(
-        replace(
-            state,
-            pending_replace_apply_request_id=None,
-            notification=NotificationState(level="error", message=action.message),
-        )
-    )
-
-
-def _selected_grep_result(state: AppState) -> GrepSearchResultState | None:
-    if state.command_palette is None or state.command_palette.source != "grep_search":
-        return None
-    results = state.command_palette.grep_search_results
-    if not results:
-        return None
-    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
-
-
-def _selected_file_search_result(state: AppState) -> FileSearchResultState | None:
-    if state.command_palette is None or state.command_palette.source != "file_search":
-        return None
-    results = state.command_palette.file_search_results
-    if not results:
-        return None
-    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
-
-
-def _matches_file_search_preview(
-    state: AppState,
-    result: FileSearchResultState,
-) -> bool:
-    return (
-        state.child_pane.mode == "preview"
-        and state.child_pane.preview_path == result.path
-        and state.child_pane.preview_title is None
-        and state.child_pane.preview_start_line is None
-        and state.child_pane.preview_highlight_line is None
-    )
-
-
-def _sync_file_search_preview(state: AppState) -> ReduceResult:
-    selected_result = _selected_file_search_result(state)
-    if selected_result is None or not state.config.display.show_preview:
-        return finalize(replace(state, pending_child_pane_request_id=None))
-
-    if state.pending_child_pane_request_id is None and _matches_file_search_preview(
-        state,
-        selected_result,
-    ):
-        return finalize(state)
-
-    request_id = state.next_request_id
-    return finalize(
-        replace(
-            state,
-            pending_child_pane_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        LoadChildPaneSnapshotEffect(
-            request_id=request_id,
-            current_path=state.current_path,
-            cursor_path=selected_result.path,
-            preview_max_bytes=state.config.display.preview_max_kib * 1024,
-        ),
-    )
-
-
-def _matches_grep_preview(
-    state: AppState,
-    result: GrepSearchResultState,
-) -> bool:
-    return (
-        state.child_pane.mode == "preview"
-        and state.child_pane.preview_path == result.path
-        and state.child_pane.preview_highlight_line == result.line_number
-    )
-
-
-def _sync_grep_preview(state: AppState) -> ReduceResult:
-    selected_result = _selected_grep_result(state)
-    if selected_result is None or not state.config.display.show_preview:
-        return finalize(replace(state, pending_child_pane_request_id=None))
-
-    if state.pending_child_pane_request_id is None and _matches_grep_preview(
-        state,
-        selected_result,
-    ):
-        return finalize(state)
-
-    request_id = state.next_request_id
-    return finalize(
-        replace(
-            state,
-            pending_child_pane_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        LoadChildPaneSnapshotEffect(
-            request_id=request_id,
-            current_path=state.current_path,
-            cursor_path=selected_result.path,
-            preview_max_bytes=state.config.display.preview_max_kib * 1024,
-            grep_result=selected_result,
-            grep_context_lines=state.config.display.grep_preview_context_lines,
-        ),
-    )
-
-
-def _matches_replace_preview(
-    state: AppState,
-    result: ReplacePreviewResultState,
-) -> bool:
-    return (
-        state.child_pane.mode == "preview"
-        and state.child_pane.preview_title == "Replace Preview"
-        and state.child_pane.preview_path == result.path
-        and state.child_pane.preview_content == result.diff_text
-    )
-
-
-def _selected_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
-    if state.command_palette is None or state.command_palette.source != "replace_text":
-        return None
-    results = state.command_palette.replace_preview_results
-    if not results:
-        return None
-    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
-
-
-def _sync_replace_preview(state: AppState) -> ReduceResult:
-    selected_result = _selected_replace_preview_result(state)
-    if selected_result is None:
-        preview_message = "No matching files"
-        if state.command_palette is not None and state.command_palette.source == "replace_text":
-            preview_message = state.command_palette.replace_status_message or preview_message
-        return finalize(
-            replace(
-                state,
-                child_pane=PaneState(
-                    directory_path=state.current_path,
-                    entries=(),
-                    mode="preview",
-                    preview_path=state.current_path,
-                    preview_title="Replace Preview",
-                    preview_content="",
-                    preview_message=preview_message,
-                ),
-            )
-        )
-
-    if _matches_replace_preview(state, selected_result):
-        return finalize(state)
-
-    return finalize(
-        replace(
-            state,
-            child_pane=PaneState(
-                directory_path=state.current_path,
-                entries=(),
-                mode="preview",
-                preview_path=selected_result.path,
-                preview_title="Replace Preview",
-                preview_content=selected_result.diff_text,
-                preview_message=(
-                    state.command_palette.replace_status_message
-                    if state.command_palette is not None
-                    else None
-                ),
-            ),
-        )
-    )
-
-
-def _selected_find_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
-    if state.command_palette is None or state.command_palette.source != "replace_in_found_files":
-        return None
-    results = state.command_palette.rff_preview_results
-    if not results:
-        return None
-    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
-
-
-def _sync_find_replace_preview(state: AppState) -> ReduceResult:
-    selected_result = _selected_find_replace_preview_result(state)
-    if selected_result is None:
-        preview_message = "No matching files"
-        if (
-            state.command_palette is not None
-            and state.command_palette.source == "replace_in_found_files"
-        ):
-            preview_message = state.command_palette.rff_status_message or preview_message
-        return finalize(
-            replace(
-                state,
-                child_pane=PaneState(
-                    directory_path=state.current_path,
-                    entries=(),
-                    mode="preview",
-                    preview_path=state.current_path,
-                    preview_title="Replace Preview",
-                    preview_content="",
-                    preview_message=preview_message,
-                ),
-            )
-        )
-
-    if _matches_replace_preview(state, selected_result):
-        return finalize(state)
-
-    return finalize(
-        replace(
-            state,
-            child_pane=PaneState(
-                directory_path=state.current_path,
-                entries=(),
-                mode="preview",
-                preview_path=selected_result.path,
-                preview_title="Replace Preview",
-                preview_content=selected_result.diff_text,
-                preview_message=(
-                    state.command_palette.rff_status_message
-                    if state.command_palette is not None
-                    else None
-                ),
-            ),
-        )
-    )
-
-
-def _grf_unique_file_paths(
-    grep_results: tuple[GrepSearchResultState, ...],
-) -> tuple[str, ...]:
-    return tuple(dict.fromkeys(r.path for r in grep_results))
-
-
-def _handle_set_grep_replace_field(
-    state: AppState,
-    field: GrepReplaceFieldId,
-    value: str,
-) -> ReduceResult:
-    if state.command_palette is None:
-        return finalize(state)
-
-    if field in ("keyword", "include", "exclude"):
-        return _handle_set_grf_keyword(state, field, value)
-
-    if field == "replace":
-        return _handle_set_grf_replace(state, value)
-
-    return _handle_set_grf_filename(state, value)
-
-
-def _handle_set_grf_keyword(
-    state: AppState,
-    field: GrepReplaceFieldId,
-    value: str,
-) -> ReduceResult:
-    next_palette = _replace_grf_field(
-        state.command_palette,
-        field=field,
-        value=value,
-    )
-    next_palette = replace(next_palette, grf_grep_error_message=None, cursor_index=0)
-
-    keyword = next_palette.grf_keyword.strip()
-    if not keyword:
-        return _sync_grep_replace_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grf_grep_results=(),
-                    grf_grep_error_message=None,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
-                ),
-                pending_grep_search_request_id=None,
-            )
-        )
-
-    try:
-        include_globs, exclude_globs = _validate_grf_filters(next_palette)
-    except ValueError as error:
-        return _sync_grep_replace_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grf_grep_results=(),
-                    grf_grep_error_message=str(error),
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
-                ),
-                pending_grep_search_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_grep_search_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunGrepSearchEffect(
-            request_id=request_id,
-            root_path=state.current_path,
-            query=keyword,
-            show_hidden=state.show_hidden,
-            include_globs=include_globs,
-            exclude_globs=exclude_globs,
-        ),
-    )
-
-
-def _validate_grf_filters(
-    palette: CommandPaletteState,
-) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    include_globs = _normalize_grep_extension_filters(
-        palette.grf_include_extensions,
-        label="include",
-    )
-    exclude_globs = _normalize_grep_extension_filters(
-        palette.grf_exclude_extensions,
-        label="exclude",
-    )
-    conflicts = tuple(sorted(set(include_globs) & set(exclude_globs)))
-    if conflicts:
-        formatted = ", ".join(glob.removeprefix("*.") for glob in conflicts)
-        raise ValueError(
-            f"Extensions cannot be included and excluded at the same time: {formatted}"
-        )
-    return include_globs, exclude_globs
-
-
-def _handle_set_grf_replace(
-    state: AppState,
-    value: str,
-) -> ReduceResult:
-    next_palette = replace(
-        state.command_palette,
-        grf_replacement_text=value,
-        grf_error_message=None,
-        grf_status_message=None,
-        cursor_index=0,
-    )
-    return _trigger_grf_preview(state, next_palette)
-
-
-def _handle_set_grf_filename(
-    state: AppState,
-    value: str,
-) -> ReduceResult:
-    next_palette = replace(
-        state.command_palette,
-        grf_filename_filter=value,
-        grf_error_message=None,
-        grf_status_message=None,
-        cursor_index=0,
-    )
-    return _trigger_grf_preview(state, next_palette)
-
-
-def _trigger_grf_preview(
-    state: AppState,
-    next_palette: CommandPaletteState,
-) -> ReduceResult:
-    keyword = next_palette.grf_keyword.strip()
-    filtered_results = _filter_grf_by_filename(
-        next_palette.grf_grep_results, next_palette.grf_filename_filter
-    )
-    file_paths = _grf_unique_file_paths(filtered_results)
-
-    if not keyword or not file_paths:
-        return _sync_grep_replace_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
-                ),
-                child_pane=PaneState(directory_path=state.current_path, entries=()),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=keyword,
-        replace_text=next_palette.grf_replacement_text,
-    )
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _filter_grf_by_filename(
-    results: tuple[GrepSearchResultState, ...],
-    filename_query: str,
-) -> tuple[GrepSearchResultState, ...]:
-    return _filter_grep_results_by_filename(results, filename_query)
-
-
-def _handle_grf_grep_search_completed(
-    state: AppState,
-    action: GrepSearchCompleted,
-) -> ReduceResult:
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_grep_results=action.results,
-            grf_grep_error_message=None,
-            cursor_index=0,
-        ),
-        pending_grep_search_request_id=None,
-    )
-
-    keyword = next_state.command_palette.grf_keyword.strip()
-    if not keyword or not action.results:
-        return _sync_grep_replace_preview(
-            replace(
-                next_state,
-                command_palette=replace(
-                    next_state.command_palette,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
-                ),
-            )
-        )
-
-    filtered_results = _filter_grf_by_filename(
-        action.results, next_state.command_palette.grf_filename_filter
-    )
-    file_paths = _grf_unique_file_paths(filtered_results)
-    if not file_paths:
-        return _sync_grep_replace_preview(
-            replace(
-                next_state,
-                command_palette=replace(
-                    next_state.command_palette,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
-                ),
-            )
-        )
-
-    request_id = next_state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=keyword,
-        replace_text=next_state.command_palette.grf_replacement_text,
-    )
-    return finalize(
-        replace(
-            next_state,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_grf_preview_completed(
-    state: AppState,
-    action: TextReplacePreviewCompleted,
-) -> ReduceResult:
-    preview_results = tuple(
-        ReplacePreviewResultState(
-            path=entry.path,
-            display_path=str(Path(entry.path).name)
-            if Path(entry.path).parent == Path(state.current_path)
-            else str(Path(entry.path).relative_to(state.current_path)),
-            diff_text=entry.diff_text,
-            match_count=entry.match_count,
-            first_match_line_number=entry.first_match_line_number,
-            first_match_before=entry.first_match_before,
-            first_match_after=entry.first_match_after,
-        )
-        for entry in action.result.changed_entries
-    )
-    status_message = None
-    if action.result.skipped_paths:
-        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_preview_results=preview_results,
-            grf_error_message=None,
-            grf_status_message=status_message,
-            grf_total_match_count=action.result.total_match_count,
-            cursor_index=0,
-        ),
-        pending_replace_preview_request_id=None,
-    )
-    return _sync_grep_replace_preview(next_state)
-
-
-def _selected_grep_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
-    if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
-        return None
-    results = state.command_palette.grf_preview_results
-    if not results:
-        return None
-    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
-
-
-def _sync_grep_replace_preview(state: AppState) -> ReduceResult:
-    selected_result = _selected_grep_replace_preview_result(state)
-    if selected_result is None:
-        preview_message = "No matching files"
-        if (
-            state.command_palette is not None
-            and state.command_palette.source == "replace_in_grep_files"
-        ):
-            preview_message = state.command_palette.grf_status_message or preview_message
-        return finalize(
-            replace(
-                state,
-                child_pane=PaneState(
-                    directory_path=state.current_path,
-                    entries=(),
-                    mode="preview",
-                    preview_path=state.current_path,
-                    preview_title="Replace Preview",
-                    preview_content="",
-                    preview_message=preview_message,
-                ),
-            )
-        )
-
-    if _matches_replace_preview(state, selected_result):
-        return finalize(state)
-
-    return finalize(
-        replace(
-            state,
-            child_pane=PaneState(
-                directory_path=state.current_path,
-                entries=(),
-                mode="preview",
-                preview_path=selected_result.path,
-                preview_title="Replace Preview",
-                preview_content=selected_result.diff_text,
-                preview_message=(
-                    state.command_palette.grf_status_message
-                    if state.command_palette is not None
-                    else None
-                ),
-            ),
-        )
-    )
-
-
-# ---------------------------------------------------------------------------
-# Grep replace selected (grs) helpers
-# ---------------------------------------------------------------------------
-
-
-def _grs_field_value(
-    palette: CommandPaletteState,
-    field: GrepReplaceSelectedFieldId,
-) -> str:
-    if field == "keyword":
-        return palette.grs_keyword or palette.query
-    return palette.grs_replacement_text
-
-
-def _replace_grs_field(
-    palette: CommandPaletteState,
-    *,
-    field: GrepReplaceSelectedFieldId,
-    value: str,
-) -> CommandPaletteState:
-    if field == "keyword":
-        return replace(palette, grs_keyword=value)
-    return replace(palette, grs_replacement_text=value)
-
-
-def _grs_unique_file_paths(
-    grep_results: tuple[GrepSearchResultState, ...],
-) -> tuple[str, ...]:
-    return tuple(dict.fromkeys(r.path for r in grep_results))
-
-
-def _handle_set_grs_keyword(
-    state: AppState,
-    value: str,
-) -> ReduceResult:
-    next_palette = replace(
-        state.command_palette,
-        grs_keyword=value,
-        grs_grep_error_message=None,
-        cursor_index=0,
-    )
-
-    keyword = next_palette.grs_keyword.strip()
-    if not keyword:
-        return _sync_grep_replace_selected_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grs_grep_results=(),
-                    grs_grep_error_message=None,
-                    grs_preview_results=(),
-                    grs_total_match_count=0,
-                ),
-                pending_grep_search_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_grep_search_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunGrepSearchEffect(
-            request_id=request_id,
-            root_path=state.current_path,
-            query=keyword,
-            show_hidden=state.show_hidden,
-        ),
-    )
-
-
-def _handle_set_grs_replace(
-    state: AppState,
-    value: str,
-) -> ReduceResult:
-    next_palette = replace(
-        state.command_palette,
-        grs_replacement_text=value,
-        grs_error_message=None,
-        grs_status_message=None,
-        cursor_index=0,
-    )
-    return _trigger_grs_preview(state, next_palette)
-
-
-def _trigger_grs_preview(
-    state: AppState,
-    next_palette: CommandPaletteState,
-) -> ReduceResult:
-    keyword = next_palette.grs_keyword.strip()
-    file_paths = _grs_unique_file_paths(next_palette.grs_grep_results)
-
-    if not keyword or not file_paths:
-        return _sync_grep_replace_selected_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grs_preview_results=(),
-                    grs_total_match_count=0,
-                ),
-                child_pane=PaneState(directory_path=state.current_path, entries=()),
-                pending_replace_preview_request_id=None,
-            )
-        )
-
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=keyword,
-        replace_text=next_palette.grs_replacement_text,
-    )
-    return finalize(
-        replace(
-            state,
-            command_palette=next_palette,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_grs_grep_search_completed(
-    state: AppState,
-    action: GrepSearchCompleted,
-) -> ReduceResult:
-    target_set = frozenset(state.command_palette.grs_target_paths)
-    filtered_results = tuple(r for r in action.results if r.path in target_set)
-
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_grep_results=filtered_results,
-            grs_grep_error_message=None,
-            cursor_index=0,
-        ),
-        pending_grep_search_request_id=None,
-    )
-
-    keyword = next_state.command_palette.grs_keyword.strip()
-    if not keyword or not filtered_results:
-        return _sync_grep_replace_selected_preview(
-            replace(
-                next_state,
-                command_palette=replace(
-                    next_state.command_palette,
-                    grs_preview_results=(),
-                    grs_total_match_count=0,
-                ),
-            )
-        )
-
-    file_paths = _grs_unique_file_paths(filtered_results)
-    request_id = next_state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=keyword,
-        replace_text=next_state.command_palette.grs_replacement_text,
-    )
-    return finalize(
-        replace(
-            next_state,
-            pending_replace_preview_request_id=request_id,
-            next_request_id=request_id + 1,
-        ),
-        RunTextReplacePreviewEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_grs_preview_completed(
-    state: AppState,
-    action: TextReplacePreviewCompleted,
-) -> ReduceResult:
-    preview_results = tuple(
-        ReplacePreviewResultState(
-            path=entry.path,
-            display_path=str(Path(entry.path).name)
-            if Path(entry.path).parent == Path(state.current_path)
-            else str(Path(entry.path).relative_to(state.current_path)),
-            diff_text=entry.diff_text,
-            match_count=entry.match_count,
-            first_match_line_number=entry.first_match_line_number,
-            first_match_before=entry.first_match_before,
-            first_match_after=entry.first_match_after,
-        )
-        for entry in action.result.changed_entries
-    )
-    status_message = None
-    if action.result.skipped_paths:
-        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
-    next_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_preview_results=preview_results,
-            grs_error_message=None,
-            grs_status_message=status_message,
-            grs_total_match_count=action.result.total_match_count,
-            cursor_index=0,
-        ),
-        pending_replace_preview_request_id=None,
-    )
-    return _sync_grep_replace_selected_preview(next_state)
-
-
-def _selected_grep_replace_selected_preview_result(
-    state: AppState,
-) -> ReplacePreviewResultState | None:
-    if state.command_palette is None or state.command_palette.source != "grep_replace_selected":
-        return None
-    results = state.command_palette.grs_preview_results
-    if not results:
-        return None
-    cursor = normalize_command_palette_cursor(state, state.command_palette.cursor_index)
-    return results[cursor]
-
-
-def _sync_grep_replace_selected_preview(state: AppState) -> ReduceResult:
-    selected_result = _selected_grep_replace_selected_preview_result(state)
-    if selected_result is None:
-        preview_message = "No matching files"
-        if (
-            state.command_palette is not None
-            and state.command_palette.source == "grep_replace_selected"
-        ):
-            preview_message = state.command_palette.grs_status_message or preview_message
-        return finalize(
-            replace(
-                state,
-                child_pane=PaneState(
-                    directory_path=state.current_path,
-                    entries=(),
-                    mode="preview",
-                    preview_path=state.current_path,
-                    preview_title="Replace Preview",
-                    preview_content="",
-                    preview_message=preview_message,
-                ),
-            )
-        )
-
-    if _matches_replace_preview(state, selected_result):
-        return finalize(state)
-
-    return finalize(
-        replace(
-            state,
-            child_pane=PaneState(
-                directory_path=state.current_path,
-                entries=(),
-                mode="preview",
-                preview_path=selected_result.path,
-                preview_title="Replace Preview",
-                preview_content=selected_result.diff_text,
-                preview_message=(
-                    state.command_palette.grs_status_message
-                    if state.command_palette is not None
-                    else None
-                ),
-            ),
-        )
-    )
-
-
-def _handle_submit_grep_replace_selected_palette(state: AppState) -> ReduceResult:
-    if state.pending_replace_preview_request_id is not None:
-        return _notify(state, level="warning", message="Replacement preview is still running")
-    if state.pending_grep_search_request_id is not None:
-        return _notify(state, level="warning", message="Grep search is still running")
-    if state.command_palette is None:
-        return finalize(state)
-    if not state.command_palette.grs_keyword.strip():
-        return _notify(state, level="warning", message="Keyword is required")
-    if state.command_palette.grs_error_message is not None:
-        return _notify(state, level="warning", message=state.command_palette.grs_error_message)
-    if not state.command_palette.grs_preview_results:
-        message = state.command_palette.grs_status_message or "No matching files"
-        return _notify(state, level="warning", message=message)
-
-    file_paths = _grs_unique_file_paths(state.command_palette.grs_grep_results)
-    request_id = state.next_request_id
-    request = TextReplaceRequest(
-        paths=file_paths,
-        find_text=state.command_palette.grs_keyword,
-        replace_text=state.command_palette.grs_replacement_text,
-    )
-    next_state = _restore_browsing_from_palette(state)
-    return finalize(
-        replace(
-            next_state,
-            pending_replace_apply_request_id=request_id,
-            next_request_id=request_id + 1,
-            notification=NotificationState(level="info", message="Applying replacement..."),
-        ),
-        RunTextReplaceApplyEffect(request_id=request_id, request=request),
-    )
-
-
-def _handle_set_grep_replace_selected_field(
-    state: AppState,
-    field: GrepReplaceSelectedFieldId,
-    value: str,
-) -> ReduceResult:
-    if state.command_palette is None:
-        return finalize(state)
-
-    if field == "keyword":
-        return _handle_set_grs_keyword(state, value)
-    return _handle_set_grs_replace(state, value)
-
-
-def _handle_cycle_grep_replace_selected_field(
-    state: AppState,
-    action: CycleGrepReplaceSelectedField,
-) -> ReduceResult:
-    if state.command_palette is None or state.command_palette.source != "grep_replace_selected":
-        return finalize(state)
-    current_index = _GREP_REPLACE_SELECTED_FIELDS.index(state.command_palette.grs_active_field)
-    next_index = (current_index + action.delta) % len(_GREP_REPLACE_SELECTED_FIELDS)
-    return finalize(
-        replace(
-            state,
-            command_palette=replace(
-                state.command_palette,
-                grs_active_field=_GREP_REPLACE_SELECTED_FIELDS[next_index],
-            ),
-        )
-    )
-
-
-def _run_grep_replace_selected_command(
-    state: AppState,
-    next_state: AppState,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    target_paths = _selected_current_file_paths(state)
-    if not target_paths:
-        return _notify(
-            next_state,
-            level="warning",
-            message=(
-                "Grep replace requires a selected file or file selection "
-                "in the current directory"
-            ),
-        )
-    return reduce_state(next_state, BeginGrepReplaceSelected(target_paths=target_paths))
-
-
-def _dispatch_set_grep_replace_selected_field(
-    state: AppState,
-    action: SetGrepReplaceSelectedField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_set_grep_replace_selected_field(state, action.field, action.value)
-
-
-def _dispatch_cycle_grep_replace_selected_field(
-    state: AppState,
-    action: CycleGrepReplaceSelectedField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_cycle_grep_replace_selected_field(state, action)
+        return handle_submit_grep_replace_selected_palette(state)
+    if state.command_palette.source == "history":
+        return _handle_submit_history_palette(state, reduce_state)
+    if state.command_palette.source == "bookmarks":
+        return _handle_submit_bookmarks_palette(state, reduce_state)
+    if state.command_palette.source == "go_to_path":
+        return _handle_submit_go_to_path_palette(state, reduce_state)
+    return _handle_submit_commands_palette(state, reduce_state)
 
 
 def _handle_begin_command_palette(
@@ -2995,7 +653,8 @@ def _handle_begin_command_palette(
     action: BeginCommandPalette,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(_enter_palette(state))
+    del action, reduce_state
+    return finalize(enter_palette(state))
 
 
 def _handle_begin_file_search(
@@ -3003,7 +662,8 @@ def _handle_begin_file_search(
     action: BeginFileSearch,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(_enter_palette(state, source="file_search"))
+    del action, reduce_state
+    return finalize(enter_palette(state, source="file_search"))
 
 
 def _handle_begin_grep_search(
@@ -3011,7 +671,8 @@ def _handle_begin_grep_search(
     action: BeginGrepSearch,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(_enter_palette(state, source="grep_search"))
+    del action, reduce_state
+    return finalize(enter_palette(state, source="grep_search"))
 
 
 def _handle_begin_text_replace(
@@ -3019,7 +680,8 @@ def _handle_begin_text_replace(
     action: BeginTextReplace,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    next_state = _enter_palette(state, source="replace_text")
+    del reduce_state
+    next_state = enter_palette(state, source="replace_text")
     return finalize(
         replace(
             next_state,
@@ -3036,7 +698,8 @@ def _handle_begin_find_and_replace(
     action: BeginFindAndReplace,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(_enter_palette(state, source="replace_in_found_files"))
+    del action, reduce_state
+    return finalize(enter_palette(state, source="replace_in_found_files"))
 
 
 def _handle_begin_grep_replace(
@@ -3044,7 +707,8 @@ def _handle_begin_grep_replace(
     action: BeginGrepReplace,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(_enter_palette(state, source="replace_in_grep_files"))
+    del action, reduce_state
+    return finalize(enter_palette(state, source="replace_in_grep_files"))
 
 
 def _handle_begin_grep_replace_selected(
@@ -3052,7 +716,8 @@ def _handle_begin_grep_replace_selected(
     action: BeginGrepReplaceSelected,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    next_state = _enter_palette(state, source="grep_replace_selected")
+    del reduce_state
+    next_state = enter_palette(state, source="grep_replace_selected")
     return finalize(
         replace(
             next_state,
@@ -3069,7 +734,7 @@ def _dispatch_begin_history_search(
     action: BeginHistorySearch,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    # Call the original helper function (note: different signature)
+    del action, reduce_state
     return _handle_begin_history_search(state)
 
 
@@ -3078,7 +743,7 @@ def _dispatch_begin_bookmark_search(
     action: BeginBookmarkSearch,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    # Call the original helper function (note: different signature)
+    del action, reduce_state
     return _handle_begin_bookmark_search(state)
 
 
@@ -3087,7 +752,8 @@ def _handle_begin_go_to_path(
     action: BeginGoToPath,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(_enter_palette(state, source="go_to_path"))
+    del action, reduce_state
+    return finalize(enter_palette(state, source="go_to_path"))
 
 
 def _handle_cancel_command_palette(
@@ -3095,7 +761,8 @@ def _handle_cancel_command_palette(
     action: CancelCommandPalette,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    next_state = _restore_browsing_from_palette(state, clear_name_conflict=True)
+    del action
+    next_state = restore_browsing_from_palette(state, clear_name_conflict=True)
     if state.command_palette is not None and state.command_palette.source in {
         "file_search",
         "grep_search",
@@ -3113,6 +780,7 @@ def _handle_dismiss_attribute_dialog(
     action: DismissAttributeDialog,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
+    del action, reduce_state
     return finalize(
         replace(
             state,
@@ -3128,180 +796,9 @@ def _handle_show_attributes(
     action: ShowAttributes,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
+    del action, reduce_state
     return _run_show_attributes_command(state)
 
-
-def _dispatch_move_palette_cursor(
-    state: AppState,
-    action: MoveCommandPaletteCursor,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_move_palette_cursor(state, action)
-
-
-def _dispatch_set_command_palette_query(
-    state: AppState,
-    action: SetCommandPaletteQuery,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_set_palette_query(state, action)
-
-
-def _dispatch_set_grep_search_field(
-    state: AppState,
-    action: SetGrepSearchField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_set_grep_search_field(state, action.field, action.value)
-
-
-def _dispatch_set_replace_field(
-    state: AppState,
-    action: SetReplaceField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_set_replace_field(state, action.field, action.value)
-
-
-def _dispatch_cycle_grep_search_field(
-    state: AppState,
-    action: CycleGrepSearchField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_cycle_grep_search_field(state, action)
-
-
-def _dispatch_cycle_replace_field(
-    state: AppState,
-    action: CycleReplaceField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_cycle_replace_field(state, action)
-
-
-def _dispatch_set_find_replace_field(
-    state: AppState,
-    action: SetFindReplaceField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_set_find_replace_field(state, action.field, action.value)
-
-
-def _dispatch_cycle_find_replace_field(
-    state: AppState,
-    action: CycleFindReplaceField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_cycle_find_replace_field(state, action)
-
-
-def _dispatch_set_grep_replace_field(
-    state: AppState,
-    action: SetGrepReplaceField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_set_grep_replace_field(state, action.field, action.value)
-
-
-def _dispatch_cycle_grep_replace_field(
-    state: AppState,
-    action: CycleGrepReplaceField,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_cycle_grep_replace_field(state, action)
-
-
-def _dispatch_submit_command_palette(
-    state: AppState,
-    action: SubmitCommandPalette,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_submit_palette(state, reduce_state)
-
-
-def _dispatch_file_search_completed(
-    state: AppState,
-    action: FileSearchCompleted,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_file_search_completed(state, action)
-
-
-def _dispatch_file_search_failed(
-    state: AppState,
-    action: FileSearchFailed,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_file_search_failed(state, action)
-
-
-def _dispatch_grep_search_completed(
-    state: AppState,
-    action: GrepSearchCompleted,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_grep_search_completed(state, action)
-
-
-def _dispatch_grep_search_failed(
-    state: AppState,
-    action: GrepSearchFailed,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_grep_search_failed(state, action)
-
-
-def _dispatch_text_replace_preview_completed(
-    state: AppState,
-    action: TextReplacePreviewCompleted,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_text_replace_preview_completed(state, action)
-
-
-def _dispatch_text_replace_preview_failed(
-    state: AppState,
-    action: TextReplacePreviewFailed,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_text_replace_preview_failed(state, action)
-
-
-def _dispatch_text_replace_applied(
-    state: AppState,
-    action: TextReplaceApplied,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_text_replace_applied(state, action, reduce_state)
-
-
-def _dispatch_text_replace_apply_failed(
-    state: AppState,
-    action: TextReplaceApplyFailed,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_text_replace_apply_failed(state, action)
-
-
-def _dispatch_open_grep_result_in_editor(
-    state: AppState,
-    action: OpenGrepResultInEditor,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_open_grep_result_in_editor(state, reduce_state)
-
-
-def _dispatch_open_find_result_in_editor(
-    state: AppState,
-    action: OpenFindResultInEditor,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    return _handle_open_find_result_in_editor(state, reduce_state)
-
-
-# ---------------------------------------------------------------------------
-# Dispatch table
-# ---------------------------------------------------------------------------
 
 _PaletteHandler = Callable[[AppState, Action, ReducerFn], ReduceResult]
 
@@ -3319,35 +816,34 @@ _PALETTE_HANDLERS: dict[type[Action], _PaletteHandler] = {
     CancelCommandPalette: _handle_cancel_command_palette,
     DismissAttributeDialog: _handle_dismiss_attribute_dialog,
     ShowAttributes: _handle_show_attributes,
-    MoveCommandPaletteCursor: _dispatch_move_palette_cursor,
-    SetCommandPaletteQuery: _dispatch_set_command_palette_query,
-    SetGrepSearchField: _dispatch_set_grep_search_field,
-    SetReplaceField: _dispatch_set_replace_field,
-    CycleGrepSearchField: _dispatch_cycle_grep_search_field,
-    CycleReplaceField: _dispatch_cycle_replace_field,
-    SetFindReplaceField: _dispatch_set_find_replace_field,
-    CycleFindReplaceField: _dispatch_cycle_find_replace_field,
-    SetGrepReplaceField: _dispatch_set_grep_replace_field,
-    SetGrepReplaceSelectedField: _dispatch_set_grep_replace_selected_field,
-    CycleGrepReplaceField: _dispatch_cycle_grep_replace_field,
-    CycleGrepReplaceSelectedField: _dispatch_cycle_grep_replace_selected_field,
-    SubmitCommandPalette: _dispatch_submit_command_palette,
-    FileSearchCompleted: _dispatch_file_search_completed,
-    FileSearchFailed: _dispatch_file_search_failed,
-    GrepSearchCompleted: _dispatch_grep_search_completed,
-    GrepSearchFailed: _dispatch_grep_search_failed,
-    TextReplacePreviewCompleted: _dispatch_text_replace_preview_completed,
-    TextReplacePreviewFailed: _dispatch_text_replace_preview_failed,
-    TextReplaceApplied: _dispatch_text_replace_applied,
-    TextReplaceApplyFailed: _dispatch_text_replace_apply_failed,
-    OpenGrepResultInEditor: _dispatch_open_grep_result_in_editor,
-    OpenFindResultInEditor: _dispatch_open_find_result_in_editor,
+    MoveCommandPaletteCursor: lambda s, a, r: _handle_move_palette_cursor(s, a),
+    SetCommandPaletteQuery: lambda s, a, r: _handle_set_palette_query(s, a),
+    SetGrepSearchField: lambda s, a, r: handle_set_grep_search_field(s, a.field, a.value),
+    SetReplaceField: lambda s, a, r: handle_set_replace_field(s, a.field, a.value),
+    CycleGrepSearchField: lambda s, a, r: _handle_cycle_grep_search_field(s, a),
+    CycleReplaceField: lambda s, a, r: handle_cycle_replace_field(s, a),
+    SetFindReplaceField: lambda s, a, r: handle_set_find_replace_field(s, a.field, a.value),
+    CycleFindReplaceField: lambda s, a, r: handle_cycle_find_replace_field(s, a),
+    SetGrepReplaceField: lambda s, a, r: handle_set_grep_replace_field(s, a.field, a.value),
+    SetGrepReplaceSelectedField: lambda s, a, r: handle_set_grep_replace_selected_field(
+        s,
+        a.field,
+        a.value,
+    ),
+    CycleGrepReplaceField: lambda s, a, r: handle_cycle_grep_replace_field(s, a),
+    CycleGrepReplaceSelectedField: lambda s, a, r: handle_cycle_grep_replace_selected_field(s, a),
+    SubmitCommandPalette: lambda s, a, r: _handle_submit_palette(s, r),
+    FileSearchCompleted: lambda s, a, r: handle_file_search_completed(s, a),
+    FileSearchFailed: lambda s, a, r: handle_file_search_failed(s, a),
+    GrepSearchCompleted: lambda s, a, r: handle_grep_search_completed(s, a),
+    GrepSearchFailed: lambda s, a, r: handle_grep_search_failed(s, a),
+    TextReplacePreviewCompleted: lambda s, a, r: handle_text_replace_preview_completed(s, a),
+    TextReplacePreviewFailed: lambda s, a, r: handle_text_replace_preview_failed(s, a),
+    TextReplaceApplied: lambda s, a, r: handle_text_replace_applied(s, a, r),
+    TextReplaceApplyFailed: lambda s, a, r: handle_text_replace_apply_failed(s, a),
+    OpenGrepResultInEditor: lambda s, a, r: handle_open_grep_result_in_editor(s, r),
+    OpenFindResultInEditor: lambda s, a, r: handle_open_find_result_in_editor(s, r),
 }
-
-
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
 
 
 def handle_palette_action(

--- a/src/zivo/state/reducer_palette_replace.py
+++ b/src/zivo/state/reducer_palette_replace.py
@@ -1,0 +1,1255 @@
+"""Replace-related command palette reducers."""
+
+from dataclasses import replace
+
+from zivo.models import TextReplaceRequest
+
+from .actions import (
+    CycleFindReplaceField,
+    CycleGrepReplaceField,
+    CycleGrepReplaceSelectedField,
+    CycleReplaceField,
+    FileSearchCompleted,
+    GrepSearchCompleted,
+    TextReplaceApplied,
+    TextReplaceApplyFailed,
+    TextReplacePreviewCompleted,
+    TextReplacePreviewFailed,
+)
+from .command_palette import normalize_command_palette_cursor
+from .effects import (
+    ReduceResult,
+    RunGrepSearchEffect,
+    RunTextReplaceApplyEffect,
+    RunTextReplacePreviewEffect,
+)
+from .models import (
+    AppState,
+    GrepSearchResultState,
+    NotificationState,
+    PaneState,
+    ReplacePreviewResultState,
+)
+from .reducer_common import browser_snapshot_invalidation_paths, finalize
+from .reducer_palette_shared import (
+    FIND_REPLACE_FIELDS,
+    GREP_REPLACE_FIELDS,
+    GREP_REPLACE_SELECTED_FIELDS,
+    REPLACE_FIELDS,
+    build_replace_preview_results,
+    filter_grep_results_by_filename,
+    matches_replace_preview,
+    normalize_grep_extension_filters,
+    notify,
+    replace_grf_field,
+    replace_replace_field,
+    restore_browsing_from_palette,
+)
+
+
+def handle_set_replace_field(state: AppState, field, value: str) -> ReduceResult:
+    next_palette = replace(
+        replace_replace_field(state.command_palette, field=field, value=value),
+        replace_error_message=None,
+        replace_status_message=None,
+        cursor_index=0,
+    )
+    find_text = next_palette.replace_find_text.strip()
+    if not find_text:
+        return finalize(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    replace_preview_results=(),
+                    replace_total_match_count=0,
+                ),
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_replace_preview_request_id=None,
+            )
+        )
+
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=next_palette.replace_target_paths,
+        find_text=next_palette.replace_find_text,
+        replace_text=next_palette.replace_replacement_text,
+    )
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_set_find_replace_field(state: AppState, field, value: str) -> ReduceResult:
+    if state.command_palette is None:
+        return finalize(state)
+
+    if field == "filename":
+        return handle_set_rff_filename(state, value)
+    return handle_set_rff_text_field(state, field, value)
+
+
+def handle_set_rff_filename(state: AppState, value: str) -> ReduceResult:
+    next_palette = replace(
+        state.command_palette,
+        rff_filename_query=value,
+        rff_file_error_message=None,
+        cursor_index=0,
+    )
+    query = value.strip()
+    if not query:
+        return finalize(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    rff_file_results=(),
+                    rff_preview_results=(),
+                    rff_error_message=None,
+                    rff_status_message=None,
+                    rff_total_match_count=0,
+                ),
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_file_search_request_id=None,
+            )
+        )
+
+    request_id = state.next_request_id
+    from .effects import RunFileSearchEffect
+
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_file_search_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunFileSearchEffect(
+            request_id=request_id,
+            root_path=state.current_path,
+            query=query,
+            show_hidden=state.show_hidden,
+        ),
+    )
+
+
+def handle_set_rff_text_field(state: AppState, field: str, value: str) -> ReduceResult:
+    if field == "find":
+        next_palette = replace(
+            state.command_palette,
+            rff_find_text=value,
+            rff_error_message=None,
+            rff_status_message=None,
+            cursor_index=0,
+        )
+    else:
+        next_palette = replace(
+            state.command_palette,
+            rff_replacement_text=value,
+            rff_error_message=None,
+            rff_status_message=None,
+            cursor_index=0,
+        )
+
+    find_text = next_palette.rff_find_text.strip()
+    file_paths = tuple(r.path for r in next_palette.rff_file_results)
+    if not find_text or not file_paths:
+        return finalize(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    rff_preview_results=(),
+                    rff_total_match_count=0,
+                ),
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_replace_preview_request_id=None,
+            )
+        )
+
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=next_palette.rff_find_text,
+        replace_text=next_palette.rff_replacement_text,
+    )
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_cycle_replace_field(state: AppState, action: CycleReplaceField) -> ReduceResult:
+    if state.command_palette is None or state.command_palette.source != "replace_text":
+        return finalize(state)
+    current_index = REPLACE_FIELDS.index(state.command_palette.replace_active_field)
+    next_index = (current_index + action.delta) % len(REPLACE_FIELDS)
+    return finalize(
+        replace(
+            state,
+            command_palette=replace(
+                state.command_palette,
+                replace_active_field=REPLACE_FIELDS[next_index],
+            ),
+        )
+    )
+
+
+def handle_cycle_find_replace_field(
+    state: AppState,
+    action: CycleFindReplaceField,
+) -> ReduceResult:
+    if state.command_palette is None or state.command_palette.source != "replace_in_found_files":
+        return finalize(state)
+    current_index = FIND_REPLACE_FIELDS.index(state.command_palette.rff_active_field)
+    next_index = (current_index + action.delta) % len(FIND_REPLACE_FIELDS)
+    return finalize(
+        replace(
+            state,
+            command_palette=replace(
+                state.command_palette,
+                rff_active_field=FIND_REPLACE_FIELDS[next_index],
+            ),
+        )
+    )
+
+
+def handle_cycle_grep_replace_field(
+    state: AppState,
+    action: CycleGrepReplaceField,
+) -> ReduceResult:
+    if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
+        return finalize(state)
+    current_index = GREP_REPLACE_FIELDS.index(state.command_palette.grf_active_field)
+    next_index = (current_index + action.delta) % len(GREP_REPLACE_FIELDS)
+    return finalize(
+        replace(
+            state,
+            command_palette=replace(
+                state.command_palette,
+                grf_active_field=GREP_REPLACE_FIELDS[next_index],
+            ),
+        )
+    )
+
+
+def handle_cycle_grep_replace_selected_field(
+    state: AppState,
+    action: CycleGrepReplaceSelectedField,
+) -> ReduceResult:
+    if state.command_palette is None or state.command_palette.source != "grep_replace_selected":
+        return finalize(state)
+    current_index = GREP_REPLACE_SELECTED_FIELDS.index(state.command_palette.grs_active_field)
+    next_index = (current_index + action.delta) % len(GREP_REPLACE_SELECTED_FIELDS)
+    return finalize(
+        replace(
+            state,
+            command_palette=replace(
+                state.command_palette,
+                grs_active_field=GREP_REPLACE_SELECTED_FIELDS[next_index],
+            ),
+        )
+    )
+
+
+def handle_set_grep_replace_field(state: AppState, field, value: str) -> ReduceResult:
+    if state.command_palette is None:
+        return finalize(state)
+    if field in ("keyword", "include", "exclude"):
+        return handle_set_grf_keyword(state, field, value)
+    if field == "replace":
+        return handle_set_grf_replace(state, value)
+    return handle_set_grf_filename(state, value)
+
+
+def validate_grf_filters(palette) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    include_globs = normalize_grep_extension_filters(
+        palette.grf_include_extensions,
+        label="include",
+    )
+    exclude_globs = normalize_grep_extension_filters(
+        palette.grf_exclude_extensions,
+        label="exclude",
+    )
+    conflicts = tuple(sorted(set(include_globs) & set(exclude_globs)))
+    if conflicts:
+        formatted = ", ".join(glob.removeprefix("*.") for glob in conflicts)
+        raise ValueError(
+            f"Extensions cannot be included and excluded at the same time: {formatted}"
+        )
+    return include_globs, exclude_globs
+
+
+def handle_set_grf_keyword(state: AppState, field, value: str) -> ReduceResult:
+    next_palette = replace_grf_field(state.command_palette, field=field, value=value)
+    next_palette = replace(next_palette, grf_grep_error_message=None, cursor_index=0)
+    keyword = next_palette.grf_keyword.strip()
+    if not keyword:
+        return sync_grep_replace_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grf_grep_results=(),
+                    grf_grep_error_message=None,
+                    grf_preview_results=(),
+                    grf_total_match_count=0,
+                ),
+                pending_grep_search_request_id=None,
+            )
+        )
+    try:
+        include_globs, exclude_globs = validate_grf_filters(next_palette)
+    except ValueError as error:
+        return sync_grep_replace_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grf_grep_results=(),
+                    grf_grep_error_message=str(error),
+                    grf_preview_results=(),
+                    grf_total_match_count=0,
+                ),
+                pending_grep_search_request_id=None,
+            )
+        )
+
+    request_id = state.next_request_id
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_grep_search_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunGrepSearchEffect(
+            request_id=request_id,
+            root_path=state.current_path,
+            query=keyword,
+            show_hidden=state.show_hidden,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+        ),
+    )
+
+
+def handle_set_grf_replace(state: AppState, value: str) -> ReduceResult:
+    next_palette = replace(
+        state.command_palette,
+        grf_replacement_text=value,
+        grf_error_message=None,
+        grf_status_message=None,
+        cursor_index=0,
+    )
+    return trigger_grf_preview(state, next_palette)
+
+
+def handle_set_grf_filename(state: AppState, value: str) -> ReduceResult:
+    next_palette = replace(
+        state.command_palette,
+        grf_filename_filter=value,
+        grf_error_message=None,
+        grf_status_message=None,
+        cursor_index=0,
+    )
+    return trigger_grf_preview(state, next_palette)
+
+
+def grf_unique_file_paths(grep_results: tuple[GrepSearchResultState, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(r.path for r in grep_results))
+
+
+def trigger_grf_preview(state: AppState, next_palette) -> ReduceResult:
+    keyword = next_palette.grf_keyword.strip()
+    filtered_results = filter_grep_results_by_filename(
+        next_palette.grf_grep_results,
+        next_palette.grf_filename_filter,
+    )
+    file_paths = grf_unique_file_paths(filtered_results)
+    if not keyword or not file_paths:
+        return sync_grep_replace_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grf_preview_results=(),
+                    grf_total_match_count=0,
+                ),
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_replace_preview_request_id=None,
+            )
+        )
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=keyword,
+        replace_text=next_palette.grf_replacement_text,
+    )
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_set_grep_replace_selected_field(state: AppState, field, value: str) -> ReduceResult:
+    if state.command_palette is None:
+        return finalize(state)
+    if field == "keyword":
+        return handle_set_grs_keyword(state, value)
+    return handle_set_grs_replace(state, value)
+
+
+def grs_unique_file_paths(grep_results: tuple[GrepSearchResultState, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(r.path for r in grep_results))
+
+
+def handle_set_grs_keyword(state: AppState, value: str) -> ReduceResult:
+    next_palette = replace(
+        state.command_palette,
+        grs_keyword=value,
+        grs_grep_error_message=None,
+        cursor_index=0,
+    )
+    keyword = next_palette.grs_keyword.strip()
+    if not keyword:
+        return sync_grep_replace_selected_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grs_grep_results=(),
+                    grs_grep_error_message=None,
+                    grs_preview_results=(),
+                    grs_total_match_count=0,
+                ),
+                pending_grep_search_request_id=None,
+            )
+        )
+    request_id = state.next_request_id
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_grep_search_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunGrepSearchEffect(
+            request_id=request_id,
+            root_path=state.current_path,
+            query=keyword,
+            show_hidden=state.show_hidden,
+        ),
+    )
+
+
+def handle_set_grs_replace(state: AppState, value: str) -> ReduceResult:
+    next_palette = replace(
+        state.command_palette,
+        grs_replacement_text=value,
+        grs_error_message=None,
+        grs_status_message=None,
+        cursor_index=0,
+    )
+    return trigger_grs_preview(state, next_palette)
+
+
+def trigger_grs_preview(state: AppState, next_palette) -> ReduceResult:
+    keyword = next_palette.grs_keyword.strip()
+    file_paths = grs_unique_file_paths(next_palette.grs_grep_results)
+    if not keyword or not file_paths:
+        return sync_grep_replace_selected_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grs_preview_results=(),
+                    grs_total_match_count=0,
+                ),
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_replace_preview_request_id=None,
+            )
+        )
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=keyword,
+        replace_text=next_palette.grs_replacement_text,
+    )
+    return finalize(
+        replace(
+            state,
+            command_palette=next_palette,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_submit_replace_palette(state: AppState) -> ReduceResult:
+    if state.pending_replace_preview_request_id is not None:
+        return notify(state, level="warning", message="Replacement preview is still running")
+    if state.command_palette is None:
+        return finalize(state)
+    if not state.command_palette.replace_find_text.strip():
+        return notify(state, level="warning", message="Find text is required")
+    if state.command_palette.replace_error_message is not None:
+        return notify(state, level="warning", message=state.command_palette.replace_error_message)
+    if not state.command_palette.replace_preview_results:
+        message = state.command_palette.replace_status_message or "No matching files"
+        return notify(state, level="warning", message=message)
+
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=state.command_palette.replace_target_paths,
+        find_text=state.command_palette.replace_find_text,
+        replace_text=state.command_palette.replace_replacement_text,
+    )
+    next_state = restore_browsing_from_palette(state)
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_apply_request_id=request_id,
+            next_request_id=request_id + 1,
+            notification=NotificationState(level="info", message="Applying replacement..."),
+        ),
+        RunTextReplaceApplyEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_submit_find_and_replace_palette(state: AppState) -> ReduceResult:
+    if state.pending_replace_preview_request_id is not None:
+        return notify(state, level="warning", message="Replacement preview is still running")
+    if state.pending_file_search_request_id is not None:
+        return notify(state, level="warning", message="File search is still running")
+    if state.command_palette is None:
+        return finalize(state)
+    if not state.command_palette.rff_find_text.strip():
+        return notify(state, level="warning", message="Find text is required")
+    if state.command_palette.rff_error_message is not None:
+        return notify(state, level="warning", message=state.command_palette.rff_error_message)
+    if not state.command_palette.rff_preview_results:
+        message = state.command_palette.rff_status_message or "No matching files"
+        return notify(state, level="warning", message=message)
+
+    file_paths = tuple(r.path for r in state.command_palette.rff_file_results)
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=state.command_palette.rff_find_text,
+        replace_text=state.command_palette.rff_replacement_text,
+    )
+    next_state = restore_browsing_from_palette(state)
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_apply_request_id=request_id,
+            next_request_id=request_id + 1,
+            notification=NotificationState(level="info", message="Applying replacement..."),
+        ),
+        RunTextReplaceApplyEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_submit_grep_replace_palette(state: AppState) -> ReduceResult:
+    if state.pending_replace_preview_request_id is not None:
+        return notify(state, level="warning", message="Replacement preview is still running")
+    if state.pending_grep_search_request_id is not None:
+        return notify(state, level="warning", message="Grep search is still running")
+    if state.command_palette is None:
+        return finalize(state)
+    if not state.command_palette.grf_keyword.strip():
+        return notify(state, level="warning", message="Keyword is required")
+    if state.command_palette.grf_error_message is not None:
+        return notify(state, level="warning", message=state.command_palette.grf_error_message)
+    if not state.command_palette.grf_preview_results:
+        message = state.command_palette.grf_status_message or "No matching files"
+        return notify(state, level="warning", message=message)
+
+    filtered_results = filter_grep_results_by_filename(
+        state.command_palette.grf_grep_results,
+        state.command_palette.grf_filename_filter,
+    )
+    file_paths = grf_unique_file_paths(filtered_results)
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=state.command_palette.grf_keyword,
+        replace_text=state.command_palette.grf_replacement_text,
+    )
+    next_state = restore_browsing_from_palette(state)
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_apply_request_id=request_id,
+            next_request_id=request_id + 1,
+            notification=NotificationState(level="info", message="Applying replacement..."),
+        ),
+        RunTextReplaceApplyEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_submit_grep_replace_selected_palette(state: AppState) -> ReduceResult:
+    if state.pending_replace_preview_request_id is not None:
+        return notify(state, level="warning", message="Replacement preview is still running")
+    if state.pending_grep_search_request_id is not None:
+        return notify(state, level="warning", message="Grep search is still running")
+    if state.command_palette is None:
+        return finalize(state)
+    if not state.command_palette.grs_keyword.strip():
+        return notify(state, level="warning", message="Keyword is required")
+    if state.command_palette.grs_error_message is not None:
+        return notify(state, level="warning", message=state.command_palette.grs_error_message)
+    if not state.command_palette.grs_preview_results:
+        message = state.command_palette.grs_status_message or "No matching files"
+        return notify(state, level="warning", message=message)
+
+    file_paths = grs_unique_file_paths(state.command_palette.grs_grep_results)
+    request_id = state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=state.command_palette.grs_keyword,
+        replace_text=state.command_palette.grs_replacement_text,
+    )
+    next_state = restore_browsing_from_palette(state)
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_apply_request_id=request_id,
+            next_request_id=request_id + 1,
+            notification=NotificationState(level="info", message="Applying replacement..."),
+        ),
+        RunTextReplaceApplyEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_rff_file_search_completed(state: AppState, action: FileSearchCompleted) -> ReduceResult:
+    if action.request_id != state.pending_file_search_request_id:
+        return finalize(state)
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            rff_file_results=action.results,
+            rff_file_error_message=None,
+            cursor_index=0,
+        ),
+        pending_file_search_request_id=None,
+    )
+    find_text = next_state.command_palette.rff_find_text.strip()
+    if not find_text or not action.results:
+        return sync_find_replace_preview(
+            replace(
+                next_state,
+                command_palette=replace(
+                    next_state.command_palette,
+                    rff_preview_results=(),
+                    rff_total_match_count=0,
+                ),
+            )
+        )
+    file_paths = tuple(r.path for r in action.results)
+    request_id = next_state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=next_state.command_palette.rff_find_text,
+        replace_text=next_state.command_palette.rff_replacement_text,
+    )
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_grf_grep_search_completed(state: AppState, action: GrepSearchCompleted) -> ReduceResult:
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_grep_results=action.results,
+            grf_grep_error_message=None,
+            cursor_index=0,
+        ),
+        pending_grep_search_request_id=None,
+    )
+    keyword = next_state.command_palette.grf_keyword.strip()
+    if not keyword or not action.results:
+        return sync_grep_replace_preview(
+            replace(
+                next_state,
+                command_palette=replace(
+                    next_state.command_palette,
+                    grf_preview_results=(),
+                    grf_total_match_count=0,
+                ),
+            )
+        )
+    filtered_results = filter_grep_results_by_filename(
+        action.results,
+        next_state.command_palette.grf_filename_filter,
+    )
+    file_paths = grf_unique_file_paths(filtered_results)
+    if not file_paths:
+        return sync_grep_replace_preview(
+            replace(
+                next_state,
+                command_palette=replace(
+                    next_state.command_palette,
+                    grf_preview_results=(),
+                    grf_total_match_count=0,
+                ),
+            )
+        )
+    request_id = next_state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=keyword,
+        replace_text=next_state.command_palette.grf_replacement_text,
+    )
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_grs_grep_search_completed(state: AppState, action: GrepSearchCompleted) -> ReduceResult:
+    target_set = frozenset(state.command_palette.grs_target_paths)
+    filtered_results = tuple(r for r in action.results if r.path in target_set)
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_grep_results=filtered_results,
+            grs_grep_error_message=None,
+            cursor_index=0,
+        ),
+        pending_grep_search_request_id=None,
+    )
+    keyword = next_state.command_palette.grs_keyword.strip()
+    if not keyword or not filtered_results:
+        return sync_grep_replace_selected_preview(
+            replace(
+                next_state,
+                command_palette=replace(
+                    next_state.command_palette,
+                    grs_preview_results=(),
+                    grs_total_match_count=0,
+                ),
+            )
+        )
+    file_paths = grs_unique_file_paths(filtered_results)
+    request_id = next_state.next_request_id
+    request = TextReplaceRequest(
+        paths=file_paths,
+        find_text=keyword,
+        replace_text=next_state.command_palette.grs_replacement_text,
+    )
+    return finalize(
+        replace(
+            next_state,
+            pending_replace_preview_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        RunTextReplacePreviewEffect(request_id=request_id, request=request),
+    )
+
+
+def handle_text_replace_preview_completed(
+    state: AppState,
+    action: TextReplacePreviewCompleted,
+) -> ReduceResult:
+    if action.request_id != state.pending_replace_preview_request_id:
+        return finalize(state)
+    if state.command_palette is None:
+        return finalize(state)
+    if state.command_palette.source == "replace_in_found_files":
+        return handle_rff_preview_completed(state, action)
+    if state.command_palette.source == "replace_in_grep_files":
+        return handle_grf_preview_completed(state, action)
+    if state.command_palette.source == "grep_replace_selected":
+        return handle_grs_preview_completed(state, action)
+    if state.command_palette.source != "replace_text":
+        return finalize(state)
+
+    preview_results = build_replace_preview_results(state, action.result.changed_entries)
+    status_message = None
+    if action.result.skipped_paths:
+        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            replace_preview_results=preview_results,
+            replace_error_message=None,
+            replace_status_message=status_message,
+            replace_total_match_count=action.result.total_match_count,
+            cursor_index=0,
+        ),
+        pending_replace_preview_request_id=None,
+    )
+    return sync_replace_preview(next_state)
+
+
+def handle_rff_preview_completed(
+    state: AppState,
+    action: TextReplacePreviewCompleted,
+) -> ReduceResult:
+    preview_results = build_replace_preview_results(state, action.result.changed_entries)
+    status_message = None
+    if action.result.skipped_paths:
+        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            rff_preview_results=preview_results,
+            rff_error_message=None,
+            rff_status_message=status_message,
+            rff_total_match_count=action.result.total_match_count,
+            cursor_index=0,
+        ),
+        pending_replace_preview_request_id=None,
+    )
+    return sync_find_replace_preview(next_state)
+
+
+def handle_grf_preview_completed(
+    state: AppState,
+    action: TextReplacePreviewCompleted,
+) -> ReduceResult:
+    preview_results = build_replace_preview_results(state, action.result.changed_entries)
+    status_message = None
+    if action.result.skipped_paths:
+        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_preview_results=preview_results,
+            grf_error_message=None,
+            grf_status_message=status_message,
+            grf_total_match_count=action.result.total_match_count,
+            cursor_index=0,
+        ),
+        pending_replace_preview_request_id=None,
+    )
+    return sync_grep_replace_preview(next_state)
+
+
+def handle_grs_preview_completed(
+    state: AppState,
+    action: TextReplacePreviewCompleted,
+) -> ReduceResult:
+    preview_results = build_replace_preview_results(state, action.result.changed_entries)
+    status_message = None
+    if action.result.skipped_paths:
+        status_message = f"Skipped {len(action.result.skipped_paths)} unreadable file(s)"
+    next_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_preview_results=preview_results,
+            grs_error_message=None,
+            grs_status_message=status_message,
+            grs_total_match_count=action.result.total_match_count,
+            cursor_index=0,
+        ),
+        pending_replace_preview_request_id=None,
+    )
+    return sync_grep_replace_selected_preview(next_state)
+
+
+def handle_text_replace_preview_failed(
+    state: AppState,
+    action: TextReplacePreviewFailed,
+) -> ReduceResult:
+    if action.request_id != state.pending_replace_preview_request_id:
+        return finalize(state)
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "replace_in_found_files"
+    ):
+        if action.invalid_query:
+            return sync_find_replace_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        rff_preview_results=(),
+                        rff_error_message=action.message,
+                        rff_status_message=None,
+                        rff_total_match_count=0,
+                        cursor_index=0,
+                    ),
+                    child_pane=PaneState(directory_path=state.current_path, entries=()),
+                    pending_replace_preview_request_id=None,
+                )
+            )
+        return notify(
+            replace(state, pending_replace_preview_request_id=None),
+            level="error",
+            message=action.message,
+        )
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "replace_in_grep_files"
+    ):
+        if action.invalid_query:
+            return sync_grep_replace_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        grf_preview_results=(),
+                        grf_error_message=action.message,
+                        grf_status_message=None,
+                        grf_total_match_count=0,
+                        cursor_index=0,
+                    ),
+                    child_pane=PaneState(directory_path=state.current_path, entries=()),
+                    pending_replace_preview_request_id=None,
+                )
+            )
+        return notify(
+            replace(state, pending_replace_preview_request_id=None),
+            level="error",
+            message=action.message,
+        )
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "grep_replace_selected"
+    ):
+        if action.invalid_query:
+            return sync_grep_replace_selected_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        grs_preview_results=(),
+                        grs_error_message=action.message,
+                        grs_status_message=None,
+                        grs_total_match_count=0,
+                        cursor_index=0,
+                    ),
+                    child_pane=PaneState(directory_path=state.current_path, entries=()),
+                    pending_replace_preview_request_id=None,
+                )
+            )
+        return notify(
+            replace(state, pending_replace_preview_request_id=None),
+            level="error",
+            message=action.message,
+        )
+
+    if state.command_palette is not None and action.invalid_query:
+        return finalize(
+            replace(
+                state,
+                command_palette=replace(
+                    state.command_palette,
+                    replace_preview_results=(),
+                    replace_error_message=action.message,
+                    replace_status_message=None,
+                    replace_total_match_count=0,
+                    cursor_index=0,
+                ),
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_replace_preview_request_id=None,
+            )
+        )
+    return notify(
+        replace(state, pending_replace_preview_request_id=None),
+        level="error",
+        message=action.message,
+    )
+
+
+def handle_text_replace_applied(
+    state: AppState,
+    action: TextReplaceApplied,
+    reduce_state,
+) -> ReduceResult:
+    if action.request_id != state.pending_replace_apply_request_id:
+        return finalize(state)
+    next_state = replace(
+        state,
+        pending_replace_apply_request_id=None,
+        post_reload_notification=NotificationState(
+            level=action.result.level,
+            message=action.result.message,
+        ),
+        notification=None,
+    )
+    from .actions import RequestBrowserSnapshot
+
+    return reduce_state(
+        next_state,
+        RequestBrowserSnapshot(
+            path=state.current_path,
+            cursor_path=state.current_pane.cursor_path,
+            blocking=True,
+            invalidate_paths=browser_snapshot_invalidation_paths(
+                state.current_path,
+                *action.result.changed_paths,
+            ),
+        ),
+    )
+
+
+def handle_text_replace_apply_failed(
+    state: AppState,
+    action: TextReplaceApplyFailed,
+) -> ReduceResult:
+    if action.request_id != state.pending_replace_apply_request_id:
+        return finalize(state)
+    return finalize(
+        replace(
+            state,
+            pending_replace_apply_request_id=None,
+            notification=NotificationState(level="error", message=action.message),
+        )
+    )
+
+
+def selected_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
+    if state.command_palette is None or state.command_palette.source != "replace_text":
+        return None
+    results = state.command_palette.replace_preview_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def sync_replace_preview(state: AppState) -> ReduceResult:
+    selected_result = selected_replace_preview_result(state)
+    if selected_result is None:
+        preview_message = "No matching files"
+        if state.command_palette is not None and state.command_palette.source == "replace_text":
+            preview_message = state.command_palette.replace_status_message or preview_message
+        return finalize(
+            replace(
+                state,
+                child_pane=PaneState(
+                    directory_path=state.current_path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=state.current_path,
+                    preview_title="Replace Preview",
+                    preview_content="",
+                    preview_message=preview_message,
+                ),
+            )
+        )
+    if matches_replace_preview(state, selected_result):
+        return finalize(state)
+    return finalize(
+        replace(
+            state,
+            child_pane=PaneState(
+                directory_path=state.current_path,
+                entries=(),
+                mode="preview",
+                preview_path=selected_result.path,
+                preview_title="Replace Preview",
+                preview_content=selected_result.diff_text,
+                preview_message=(
+                    state.command_palette.replace_status_message
+                    if state.command_palette is not None
+                    else None
+                ),
+            ),
+        )
+    )
+
+
+def selected_find_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
+    if state.command_palette is None or state.command_palette.source != "replace_in_found_files":
+        return None
+    results = state.command_palette.rff_preview_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def sync_find_replace_preview(state: AppState) -> ReduceResult:
+    selected_result = selected_find_replace_preview_result(state)
+    if selected_result is None:
+        preview_message = "No matching files"
+        if (
+            state.command_palette is not None
+            and state.command_palette.source == "replace_in_found_files"
+        ):
+            preview_message = state.command_palette.rff_status_message or preview_message
+        return finalize(
+            replace(
+                state,
+                child_pane=PaneState(
+                    directory_path=state.current_path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=state.current_path,
+                    preview_title="Replace Preview",
+                    preview_content="",
+                    preview_message=preview_message,
+                ),
+            )
+        )
+    if matches_replace_preview(state, selected_result):
+        return finalize(state)
+    return finalize(
+        replace(
+            state,
+            child_pane=PaneState(
+                directory_path=state.current_path,
+                entries=(),
+                mode="preview",
+                preview_path=selected_result.path,
+                preview_title="Replace Preview",
+                preview_content=selected_result.diff_text,
+                preview_message=(
+                    state.command_palette.rff_status_message
+                    if state.command_palette is not None
+                    else None
+                ),
+            ),
+        )
+    )
+
+
+def selected_grep_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
+    if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
+        return None
+    results = state.command_palette.grf_preview_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def sync_grep_replace_preview(state: AppState) -> ReduceResult:
+    selected_result = selected_grep_replace_preview_result(state)
+    if selected_result is None:
+        preview_message = "No matching files"
+        if (
+            state.command_palette is not None
+            and state.command_palette.source == "replace_in_grep_files"
+        ):
+            preview_message = state.command_palette.grf_status_message or preview_message
+        return finalize(
+            replace(
+                state,
+                child_pane=PaneState(
+                    directory_path=state.current_path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=state.current_path,
+                    preview_title="Replace Preview",
+                    preview_content="",
+                    preview_message=preview_message,
+                ),
+            )
+        )
+    if matches_replace_preview(state, selected_result):
+        return finalize(state)
+    return finalize(
+        replace(
+            state,
+            child_pane=PaneState(
+                directory_path=state.current_path,
+                entries=(),
+                mode="preview",
+                preview_path=selected_result.path,
+                preview_title="Replace Preview",
+                preview_content=selected_result.diff_text,
+                preview_message=(
+                    state.command_palette.grf_status_message
+                    if state.command_palette is not None
+                    else None
+                ),
+            ),
+        )
+    )
+
+
+def selected_grep_replace_selected_preview_result(
+    state: AppState,
+) -> ReplacePreviewResultState | None:
+    if state.command_palette is None or state.command_palette.source != "grep_replace_selected":
+        return None
+    results = state.command_palette.grs_preview_results
+    if not results:
+        return None
+    cursor = normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    return results[cursor]
+
+
+def sync_grep_replace_selected_preview(state: AppState) -> ReduceResult:
+    selected_result = selected_grep_replace_selected_preview_result(state)
+    if selected_result is None:
+        preview_message = "No matching files"
+        if (
+            state.command_palette is not None
+            and state.command_palette.source == "grep_replace_selected"
+        ):
+            preview_message = state.command_palette.grs_status_message or preview_message
+        return finalize(
+            replace(
+                state,
+                child_pane=PaneState(
+                    directory_path=state.current_path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=state.current_path,
+                    preview_title="Replace Preview",
+                    preview_content="",
+                    preview_message=preview_message,
+                ),
+            )
+        )
+    if matches_replace_preview(state, selected_result):
+        return finalize(state)
+    return finalize(
+        replace(
+            state,
+            child_pane=PaneState(
+                directory_path=state.current_path,
+                entries=(),
+                mode="preview",
+                preview_path=selected_result.path,
+                preview_title="Replace Preview",
+                preview_content=selected_result.diff_text,
+                preview_message=(
+                    state.command_palette.grs_status_message
+                    if state.command_palette is not None
+                    else None
+                ),
+            ),
+        )
+    )

--- a/src/zivo/state/reducer_palette_search.py
+++ b/src/zivo/state/reducer_palette_search.py
@@ -1,0 +1,575 @@
+"""Search-related command palette reducers."""
+
+from dataclasses import replace
+from pathlib import Path
+
+from zivo.models.external_launch import ExternalLaunchRequest
+
+from .actions import FileSearchCompleted, FileSearchFailed, GrepSearchCompleted, GrepSearchFailed
+from .command_palette import normalize_command_palette_cursor
+from .effects import (
+    LoadChildPaneSnapshotEffect,
+    ReduceResult,
+    RunFileSearchEffect,
+    RunGrepSearchEffect,
+)
+from .models import AppState, FileSearchResultState, GrepSearchResultState, NotificationState
+from .reducer_common import (
+    filter_file_search_results,
+    finalize,
+    is_regex_file_search_query,
+    run_external_launch_request,
+)
+from .reducer_palette_replace import (
+    handle_grf_grep_search_completed,
+    handle_grs_grep_search_completed,
+    handle_rff_file_search_completed,
+    sync_find_replace_preview,
+    sync_grep_replace_preview,
+    sync_grep_replace_selected_preview,
+)
+from .reducer_palette_shared import (
+    filter_grep_results_by_filename,
+    matches_search_completion,
+    notify,
+    replace_grep_field,
+    request_palette_snapshot,
+)
+
+
+def validate_grep_search_filters(
+    include_extensions: str,
+    exclude_extensions: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    from .reducer_palette_shared import normalize_grep_extension_filters
+
+    include_globs = normalize_grep_extension_filters(include_extensions, label="include")
+    exclude_globs = normalize_grep_extension_filters(exclude_extensions, label="exclude")
+    conflicts = tuple(sorted(set(include_globs) & set(exclude_globs)))
+    if conflicts:
+        formatted = ", ".join(glob.removeprefix("*.") for glob in conflicts)
+        raise ValueError(
+            f"Extensions cannot be included and excluded at the same time: {formatted}"
+        )
+    return include_globs, exclude_globs
+
+
+def handle_set_file_search_query(
+    state: AppState,
+    next_palette,
+    query: str,
+) -> ReduceResult:
+    stripped_query = query.strip()
+    if not stripped_query:
+        return sync_file_search_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    file_search_results=(),
+                    file_search_error_message=None,
+                ),
+                pending_file_search_request_id=None,
+                pending_grep_search_request_id=None,
+                pending_child_pane_request_id=None,
+            )
+        )
+
+    is_regex_query = is_regex_file_search_query(stripped_query)
+    normalized_query = stripped_query.casefold()
+    if (
+        not is_regex_query
+        and state.command_palette.file_search_cache_query
+        and normalized_query.startswith(state.command_palette.file_search_cache_query)
+        and state.command_palette.file_search_cache_root_path == state.current_path
+        and state.command_palette.file_search_cache_show_hidden == state.show_hidden
+    ):
+        return sync_file_search_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    file_search_results=filter_file_search_results(
+                        state.command_palette.file_search_cache_results,
+                        normalized_query,
+                    ),
+                ),
+                pending_file_search_request_id=None,
+                pending_grep_search_request_id=None,
+            )
+        )
+
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        command_palette=next_palette,
+        pending_file_search_request_id=request_id,
+        pending_grep_search_request_id=None,
+        next_request_id=request_id + 1,
+    )
+    return finalize(
+        next_state,
+        RunFileSearchEffect(
+            request_id=request_id,
+            root_path=state.current_path,
+            query=stripped_query,
+            show_hidden=state.show_hidden,
+        ),
+    )
+
+
+def handle_set_grep_search_field(
+    state: AppState,
+    field,
+    value: str,
+) -> ReduceResult:
+    next_palette = replace(
+        replace_grep_field(state.command_palette, field=field, value=value),
+        grep_search_error_message=None,
+        cursor_index=0,
+    )
+    stripped_query = next_palette.grep_search_keyword.strip()
+    if not stripped_query:
+        return sync_grep_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grep_search_results=(),
+                    grep_search_error_message=None,
+                ),
+                pending_grep_search_request_id=None,
+                pending_child_pane_request_id=None,
+            )
+        )
+
+    try:
+        include_globs, exclude_globs = validate_grep_search_filters(
+            next_palette.grep_search_include_extensions,
+            next_palette.grep_search_exclude_extensions,
+        )
+    except ValueError as error:
+        return sync_grep_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    next_palette,
+                    grep_search_results=(),
+                    grep_search_error_message=str(error),
+                ),
+                pending_grep_search_request_id=None,
+                pending_child_pane_request_id=None,
+            )
+        )
+
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        command_palette=next_palette,
+        pending_grep_search_request_id=request_id,
+        next_request_id=request_id + 1,
+    )
+    return finalize(
+        next_state,
+        RunGrepSearchEffect(
+            request_id=request_id,
+            root_path=state.current_path,
+            query=stripped_query,
+            show_hidden=state.show_hidden,
+            include_globs=include_globs,
+            exclude_globs=exclude_globs,
+        ),
+    )
+
+
+def handle_submit_file_search_palette(
+    state: AppState,
+    reduce_state,
+) -> ReduceResult:
+    results = state.command_palette.file_search_results
+    message = state.command_palette.file_search_error_message or "No matching files"
+    if not results:
+        return notify(state, level="warning", message=message)
+
+    selected_result = results[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    return request_palette_snapshot(
+        state,
+        reduce_state,
+        path=str(Path(selected_result.path).parent),
+        cursor_path=selected_result.path,
+    )
+
+
+def handle_submit_grep_search_palette(
+    state: AppState,
+    reduce_state,
+) -> ReduceResult:
+    results = state.command_palette.grep_search_results
+    message = state.command_palette.grep_search_error_message or "No matching lines"
+    if not results:
+        return notify(state, level="warning", message=message)
+
+    selected_result = results[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    return request_palette_snapshot(
+        state,
+        reduce_state,
+        path=str(Path(selected_result.path).parent),
+        cursor_path=selected_result.path,
+    )
+
+
+def handle_open_grep_result_in_editor(
+    state: AppState,
+    reduce_state,
+) -> ReduceResult:
+    del reduce_state
+    results = state.command_palette.grep_search_results
+    message = state.command_palette.grep_search_error_message or "No matching lines"
+    if not results:
+        return notify(state, level="warning", message=message)
+
+    selected_result = results[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    return run_external_launch_request(
+        replace(state, notification=None),
+        ExternalLaunchRequest(
+            kind="open_editor",
+            path=selected_result.path,
+            line_number=selected_result.line_number,
+        ),
+    )
+
+
+def handle_open_find_result_in_editor(
+    state: AppState,
+    reduce_state,
+) -> ReduceResult:
+    del reduce_state
+    results = state.command_palette.file_search_results
+    message = state.command_palette.file_search_error_message or "No matching files"
+    if not results:
+        return notify(state, level="warning", message=message)
+
+    selected_result = results[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    return run_external_launch_request(
+        replace(state, notification=None),
+        ExternalLaunchRequest(kind="open_editor", path=selected_result.path, line_number=None),
+    )
+
+
+def handle_file_search_completed(
+    state: AppState,
+    action: FileSearchCompleted,
+) -> ReduceResult:
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "replace_in_found_files"
+    ):
+        return handle_rff_file_search_completed(state, action)
+
+    if not matches_search_completion(
+        state,
+        request_id=action.request_id,
+        pending_request_id=state.pending_file_search_request_id,
+        source="file_search",
+        query=action.query,
+    ):
+        return finalize(state)
+
+    cache_query = ""
+    cache_results = ()
+    if not is_regex_file_search_query(action.query):
+        cache_query = action.query.casefold()
+        cache_results = action.results
+
+    return sync_file_search_preview(
+        replace(
+            state,
+            command_palette=replace(
+                state.command_palette,
+                file_search_results=action.results,
+                file_search_error_message=None,
+                cursor_index=0,
+                file_search_cache_query=cache_query,
+                file_search_cache_results=cache_results,
+                file_search_cache_root_path=state.current_path,
+                file_search_cache_show_hidden=state.show_hidden,
+            ),
+            pending_file_search_request_id=None,
+        )
+    )
+
+
+def handle_file_search_failed(
+    state: AppState,
+    action: FileSearchFailed,
+) -> ReduceResult:
+    if action.request_id != state.pending_file_search_request_id:
+        return finalize(state)
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "replace_in_found_files"
+    ):
+        if action.invalid_query:
+            return sync_find_replace_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        rff_file_results=(),
+                        rff_file_error_message=action.message,
+                        rff_preview_results=(),
+                        rff_total_match_count=0,
+                    ),
+                    pending_file_search_request_id=None,
+                )
+            )
+        return finalize(
+            replace(
+                state,
+                notification=NotificationState(level="error", message=action.message),
+                pending_file_search_request_id=None,
+            )
+        )
+
+    if state.command_palette is not None and action.invalid_query:
+        return sync_file_search_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    state.command_palette,
+                    file_search_results=(),
+                    file_search_error_message=action.message,
+                ),
+                pending_file_search_request_id=None,
+            )
+        )
+
+    return finalize(
+        replace(
+            state,
+            notification=NotificationState(level="error", message=action.message),
+            pending_file_search_request_id=None,
+        )
+    )
+
+
+def handle_grep_search_completed(
+    state: AppState,
+    action: GrepSearchCompleted,
+) -> ReduceResult:
+    if action.request_id != state.pending_grep_search_request_id:
+        return finalize(state)
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "replace_in_grep_files"
+    ):
+        return handle_grf_grep_search_completed(state, action)
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "grep_replace_selected"
+    ):
+        return handle_grs_grep_search_completed(state, action)
+
+    if state.command_palette is None or state.command_palette.source != "grep_search":
+        return finalize(state)
+
+    return sync_grep_preview(
+        replace(
+            state,
+            command_palette=replace(
+                state.command_palette,
+                grep_search_results=filter_grep_results_by_filename(
+                    action.results,
+                    state.command_palette.grep_search_filename_filter,
+                ),
+                grep_search_error_message=None,
+                cursor_index=0,
+            ),
+            pending_grep_search_request_id=None,
+        )
+    )
+
+
+def handle_grep_search_failed(
+    state: AppState,
+    action: GrepSearchFailed,
+) -> ReduceResult:
+    if action.request_id != state.pending_grep_search_request_id:
+        return finalize(state)
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "replace_in_grep_files"
+    ):
+        if action.invalid_query:
+            return sync_grep_replace_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        grf_grep_results=(),
+                        grf_grep_error_message=action.message,
+                        grf_preview_results=(),
+                        grf_total_match_count=0,
+                        cursor_index=0,
+                    ),
+                    pending_grep_search_request_id=None,
+                )
+            )
+        return notify(
+            replace(state, pending_grep_search_request_id=None),
+            level="error",
+            message=action.message,
+        )
+
+    if (
+        state.command_palette is not None
+        and state.command_palette.source == "grep_replace_selected"
+    ):
+        if action.invalid_query:
+            return sync_grep_replace_selected_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        state.command_palette,
+                        grs_grep_results=(),
+                        grs_grep_error_message=action.message,
+                        grs_preview_results=(),
+                        grs_total_match_count=0,
+                        cursor_index=0,
+                    ),
+                    pending_grep_search_request_id=None,
+                )
+            )
+        return notify(
+            replace(state, pending_grep_search_request_id=None),
+            level="error",
+            message=action.message,
+        )
+
+    if state.command_palette is not None and action.invalid_query:
+        return sync_grep_preview(
+            replace(
+                state,
+                command_palette=replace(
+                    state.command_palette,
+                    grep_search_results=(),
+                    grep_search_error_message=action.message,
+                    cursor_index=0,
+                ),
+                pending_grep_search_request_id=None,
+                pending_child_pane_request_id=None,
+            )
+        )
+
+    return notify(
+        replace(state, pending_grep_search_request_id=None),
+        level="error",
+        message=action.message,
+    )
+
+
+def selected_file_search_result(state: AppState) -> FileSearchResultState | None:
+    if state.command_palette is None or state.command_palette.source != "file_search":
+        return None
+    results = state.command_palette.file_search_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def selected_grep_result(state: AppState) -> GrepSearchResultState | None:
+    if state.command_palette is None or state.command_palette.source != "grep_search":
+        return None
+    results = state.command_palette.grep_search_results
+    if not results:
+        return None
+    return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
+
+
+def matches_file_search_preview(
+    state: AppState,
+    result: FileSearchResultState,
+) -> bool:
+    return (
+        state.child_pane.mode == "preview"
+        and state.child_pane.preview_path == result.path
+        and state.child_pane.preview_title is None
+        and state.child_pane.preview_start_line is None
+        and state.child_pane.preview_highlight_line is None
+    )
+
+
+def sync_file_search_preview(state: AppState) -> ReduceResult:
+    selected_result = selected_file_search_result(state)
+    if selected_result is None or not state.config.display.show_preview:
+        return finalize(replace(state, pending_child_pane_request_id=None))
+
+    if state.pending_child_pane_request_id is None and matches_file_search_preview(
+        state,
+        selected_result,
+    ):
+        return finalize(state)
+
+    request_id = state.next_request_id
+    return finalize(
+        replace(
+            state,
+            pending_child_pane_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        LoadChildPaneSnapshotEffect(
+            request_id=request_id,
+            current_path=state.current_path,
+            cursor_path=selected_result.path,
+            preview_max_bytes=state.config.display.preview_max_kib * 1024,
+        ),
+    )
+
+
+def matches_grep_preview(
+    state: AppState,
+    result: GrepSearchResultState,
+) -> bool:
+    return (
+        state.child_pane.mode == "preview"
+        and state.child_pane.preview_path == result.path
+        and state.child_pane.preview_highlight_line == result.line_number
+    )
+
+
+def sync_grep_preview(state: AppState) -> ReduceResult:
+    selected_result = selected_grep_result(state)
+    if selected_result is None or not state.config.display.show_preview:
+        return finalize(replace(state, pending_child_pane_request_id=None))
+
+    if state.pending_child_pane_request_id is None and matches_grep_preview(state, selected_result):
+        return finalize(state)
+
+    request_id = state.next_request_id
+    return finalize(
+        replace(
+            state,
+            pending_child_pane_request_id=request_id,
+            next_request_id=request_id + 1,
+        ),
+        LoadChildPaneSnapshotEffect(
+            request_id=request_id,
+            current_path=state.current_path,
+            cursor_path=selected_result.path,
+            preview_max_bytes=state.config.display.preview_max_kib * 1024,
+            grep_result=selected_result,
+            grep_context_lines=state.config.display.grep_preview_context_lines,
+        ),
+    )

--- a/src/zivo/state/reducer_palette_shared.py
+++ b/src/zivo/state/reducer_palette_shared.py
@@ -1,0 +1,313 @@
+"""Shared helpers for command palette reducers."""
+
+import re
+from dataclasses import replace
+from pathlib import Path
+
+from .actions import RequestBrowserSnapshot
+from .effects import ReduceResult
+from .models import (
+    AppState,
+    CommandPaletteState,
+    FindReplaceFieldId,
+    GrepReplaceFieldId,
+    GrepReplaceSelectedFieldId,
+    GrepSearchFieldId,
+    GrepSearchResultState,
+    NotificationState,
+    ReplaceFieldId,
+    ReplacePreviewResultState,
+)
+from .reducer_common import ReducerFn, finalize, is_regex_file_search_query
+from .selectors import select_visible_current_entry_states
+
+GREP_SEARCH_FIELDS: tuple[GrepSearchFieldId, ...] = ("keyword", "filename", "include", "exclude")
+REPLACE_FIELDS: tuple[ReplaceFieldId, ...] = ("find", "replace")
+FIND_REPLACE_FIELDS: tuple[FindReplaceFieldId, ...] = ("filename", "find", "replace")
+GREP_REPLACE_FIELDS: tuple[GrepReplaceFieldId, ...] = (
+    "keyword",
+    "replace",
+    "filename",
+    "include",
+    "exclude",
+)
+GREP_REPLACE_SELECTED_FIELDS: tuple[GrepReplaceSelectedFieldId, ...] = ("keyword", "replace")
+
+_EXTENSION_SEPARATOR_RE = re.compile(r"[\s,]+")
+_VALID_EXTENSION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]*")
+
+
+def grep_field_value(
+    palette: CommandPaletteState,
+    field: GrepSearchFieldId,
+) -> str:
+    if field == "keyword":
+        return palette.grep_search_keyword
+    if field == "filename":
+        return palette.grep_search_filename_filter
+    if field == "include":
+        return palette.grep_search_include_extensions
+    return palette.grep_search_exclude_extensions
+
+
+def replace_grep_field(
+    palette: CommandPaletteState,
+    *,
+    field: GrepSearchFieldId,
+    value: str,
+) -> CommandPaletteState:
+    if field == "keyword":
+        return replace(palette, query=value, grep_search_keyword=value)
+    if field == "filename":
+        return replace(palette, grep_search_filename_filter=value)
+    if field == "include":
+        return replace(palette, grep_search_include_extensions=value)
+    return replace(palette, grep_search_exclude_extensions=value)
+
+
+def replace_field_value(
+    palette: CommandPaletteState,
+    field: ReplaceFieldId,
+) -> str:
+    if field == "find":
+        return palette.replace_find_text
+    return palette.replace_replacement_text
+
+
+def replace_replace_field(
+    palette: CommandPaletteState,
+    *,
+    field: ReplaceFieldId,
+    value: str,
+) -> CommandPaletteState:
+    if field == "find":
+        return replace(palette, replace_find_text=value)
+    return replace(palette, replace_replacement_text=value)
+
+
+def grf_field_value(
+    palette: CommandPaletteState,
+    field: GrepReplaceFieldId,
+) -> str:
+    if field == "keyword":
+        return palette.grf_keyword
+    if field == "replace":
+        return palette.grf_replacement_text
+    if field == "filename":
+        return palette.grf_filename_filter
+    if field == "include":
+        return palette.grf_include_extensions
+    return palette.grf_exclude_extensions
+
+
+def replace_grf_field(
+    palette: CommandPaletteState,
+    *,
+    field: GrepReplaceFieldId,
+    value: str,
+) -> CommandPaletteState:
+    if field == "keyword":
+        return replace(palette, query=value, grf_keyword=value)
+    if field == "replace":
+        return replace(palette, grf_replacement_text=value)
+    if field == "filename":
+        return replace(palette, grf_filename_filter=value)
+    if field == "include":
+        return replace(palette, grf_include_extensions=value)
+    return replace(palette, grf_exclude_extensions=value)
+
+
+def grs_field_value(
+    palette: CommandPaletteState,
+    field: GrepReplaceSelectedFieldId,
+) -> str:
+    if field == "keyword":
+        return palette.grs_keyword or palette.query
+    return palette.grs_replacement_text
+
+
+def replace_grs_field(
+    palette: CommandPaletteState,
+    *,
+    field: GrepReplaceSelectedFieldId,
+    value: str,
+) -> CommandPaletteState:
+    if field == "keyword":
+        return replace(palette, grs_keyword=value)
+    return replace(palette, grs_replacement_text=value)
+
+
+def normalize_grep_extension_filters(
+    raw_value: str,
+    *,
+    label: str,
+) -> tuple[str, ...]:
+    normalized_globs: list[str] = []
+    seen: set[str] = set()
+    for token in _EXTENSION_SEPARATOR_RE.split(raw_value.strip()):
+        if not token:
+            continue
+        normalized_token = token.strip().lstrip(".").casefold()
+        if not normalized_token or not _VALID_EXTENSION_RE.fullmatch(normalized_token):
+            raise ValueError(f"Invalid {label} extension: {token}")
+        glob = f"*.{normalized_token}"
+        if glob not in seen:
+            seen.add(glob)
+            normalized_globs.append(glob)
+    return tuple(normalized_globs)
+
+
+def filter_grep_results_by_filename(
+    results: tuple[GrepSearchResultState, ...],
+    filename_query: str,
+) -> tuple[GrepSearchResultState, ...]:
+    if not filename_query.strip():
+        return results
+    if is_regex_file_search_query(filename_query):
+        pattern = re.compile(filename_query[3:], re.IGNORECASE)
+        return tuple(result for result in results if pattern.search(result.display_path))
+    lowered = filename_query.casefold()
+    return tuple(result for result in results if lowered in result.display_path.casefold())
+
+
+def notify(
+    state: AppState,
+    *,
+    level: str,
+    message: str,
+) -> ReduceResult:
+    return finalize(
+        replace(
+            state,
+            notification=NotificationState(level=level, message=message),
+        )
+    )
+
+
+def enter_palette(
+    state: AppState,
+    *,
+    source: str = "commands",
+    history_results: tuple[str, ...] = (),
+) -> AppState:
+    return replace(
+        state,
+        ui_mode="PALETTE",
+        notification=None,
+        pending_input=None,
+        command_palette=CommandPaletteState(
+            source=source,
+            history_results=history_results,
+        ),
+        pending_file_search_request_id=None,
+        pending_grep_search_request_id=None,
+        pending_replace_preview_request_id=None,
+        pending_replace_apply_request_id=None,
+        delete_confirmation=None,
+        name_conflict=None,
+        attribute_inspection=None,
+    )
+
+
+def restore_browsing_from_palette(
+    state: AppState,
+    *,
+    clear_name_conflict: bool = False,
+) -> AppState:
+    next_state = replace(
+        state,
+        ui_mode="BROWSING",
+        notification=None,
+        command_palette=None,
+        pending_file_search_request_id=None,
+        pending_grep_search_request_id=None,
+        pending_replace_preview_request_id=None,
+        pending_replace_apply_request_id=None,
+        attribute_inspection=None,
+    )
+    if clear_name_conflict:
+        next_state = replace(next_state, name_conflict=None)
+    return next_state
+
+
+def request_palette_snapshot(
+    state: AppState,
+    reduce_state: ReducerFn,
+    *,
+    path: str,
+    cursor_path: str | None = None,
+) -> ReduceResult:
+    return reduce_state(
+        restore_browsing_from_palette(state),
+        RequestBrowserSnapshot(path, cursor_path=cursor_path, blocking=True),
+    )
+
+
+def matches_search_completion(
+    state: AppState,
+    *,
+    request_id: int,
+    pending_request_id: int | None,
+    source: str,
+    query: str,
+) -> bool:
+    return (
+        request_id == pending_request_id
+        and state.command_palette is not None
+        and state.command_palette.source == source
+        and state.command_palette.query.strip() == query
+    )
+
+
+def selected_current_file_paths(state: AppState) -> tuple[str, ...]:
+    selected_paths = tuple(
+        entry.path
+        for entry in select_visible_current_entry_states(state)
+        if entry.path in state.current_pane.selected_paths and entry.kind == "file"
+    )
+    if state.current_pane.selected_paths:
+        return selected_paths
+
+    entry = next(
+        (
+            candidate
+            for candidate in select_visible_current_entry_states(state)
+            if candidate.path == state.current_pane.cursor_path
+        ),
+        None,
+    )
+    if entry is None or entry.kind != "file":
+        return ()
+    return (entry.path,)
+
+
+def build_replace_preview_results(
+    state: AppState,
+    changed_entries,
+) -> tuple[ReplacePreviewResultState, ...]:
+    return tuple(
+        ReplacePreviewResultState(
+            path=entry.path,
+            display_path=str(Path(entry.path).name)
+            if Path(entry.path).parent == Path(state.current_path)
+            else str(Path(entry.path).relative_to(state.current_path)),
+            diff_text=entry.diff_text,
+            match_count=entry.match_count,
+            first_match_line_number=entry.first_match_line_number,
+            first_match_before=entry.first_match_before,
+            first_match_after=entry.first_match_after,
+        )
+        for entry in changed_entries
+    )
+
+
+def matches_replace_preview(
+    state: AppState,
+    result: ReplacePreviewResultState,
+) -> bool:
+    return (
+        state.child_pane.mode == "preview"
+        and state.child_pane.preview_title == "Replace Preview"
+        and state.child_pane.preview_path == result.path
+        and state.child_pane.preview_content == result.diff_text
+    )

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -18,10 +18,6 @@ from zivo.models import (
     PasteRequest,
     PasteSummary,
     RenameRequest,
-    TextReplacePreviewEntry,
-    TextReplacePreviewResult,
-    TextReplaceRequest,
-    TextReplaceResult,
     TrashRestoreRecord,
     UndoDeletePathStep,
     UndoEntry,
@@ -40,29 +36,18 @@ from zivo.state import (
     ArchiveExtractProgressState,
     ArchivePreparationCompleted,
     ArchivePreparationFailed,
-    AttributeInspectionState,
-    BeginBookmarkSearch,
-    BeginCommandPalette,
     BeginCreateInput,
     BeginDeleteTargets,
     BeginEmptyTrash,
     BeginExtractArchiveInput,
-    BeginFileSearch,
     BeginFilterInput,
-    BeginFindAndReplace,
-    BeginGoToPath,
-    BeginGrepReplace,
-    BeginGrepReplaceSelected,
-    BeginGrepSearch,
     BeginHistorySearch,
     BeginRenameInput,
-    BeginTextReplace,
     BeginZipCompressInput,
     BrowserSnapshot,
     BrowserSnapshotFailed,
     BrowserSnapshotLoaded,
     CancelArchiveExtractConfirmation,
-    CancelCommandPalette,
     CancelDeleteConfirmation,
     CancelEmptyTrashConfirmation,
     CancelFilterInput,
@@ -77,7 +62,6 @@ from zivo.state import (
     ClipboardPasteNeedsResolution,
     CloseCurrentTab,
     CloseSplitTerminalEffect,
-    CommandPaletteState,
     ConfigEditorState,
     ConfigSaveCompleted,
     ConfigSaveFailed,
@@ -91,15 +75,12 @@ from zivo.state import (
     CurrentPaneDeltaState,
     CutTargets,
     CycleConfigEditorValue,
-    CycleFindReplaceField,
-    CycleReplaceField,
     DeleteConfirmationState,
     DirectoryEntryState,
     DirectorySizeCacheEntry,
     DirectorySizeDeltaState,
     DirectorySizesFailed,
     DirectorySizesLoaded,
-    DismissAttributeDialog,
     DismissConfigEditor,
     DismissNameConflict,
     EmptyTrashConfirmationState,
@@ -108,30 +89,21 @@ from zivo.state import (
     ExternalLaunchFailed,
     FileMutationCompleted,
     FileMutationFailed,
-    FileSearchCompleted,
-    FileSearchFailed,
-    FileSearchResultState,
     FocusSplitTerminal,
     GoBack,
     GoForward,
     GoToHomeDirectory,
     GoToParentDirectory,
-    GrepSearchCompleted,
-    GrepSearchFailed,
-    GrepSearchResultState,
     HistoryState,
     JumpCursor,
     LoadBrowserSnapshotEffect,
     LoadChildPaneSnapshotEffect,
-    MoveCommandPaletteCursor,
     MoveConfigEditorCursor,
     MoveCursor,
     MoveCursorAndSelectRange,
     MoveCursorByPage,
     NameConflictState,
     NotificationState,
-    OpenFindResultInEditor,
-    OpenGrepResultInEditor,
     OpenNewTab,
     OpenPathInEditor,
     OpenPathWithDefaultApp,
@@ -143,7 +115,6 @@ from zivo.state import (
     PendingKeySequenceState,
     ReloadDirectory,
     RemoveBookmark,
-    ReplacePreviewResultState,
     RequestBrowserSnapshot,
     RequestDirectorySizes,
     ResolvePasteConflict,
@@ -154,41 +125,25 @@ from zivo.state import (
     RunDirectorySizeEffect,
     RunExternalLaunchEffect,
     RunFileMutationEffect,
-    RunFileSearchEffect,
-    RunGrepSearchEffect,
-    RunTextReplaceApplyEffect,
-    RunTextReplacePreviewEffect,
     RunUndoEffect,
     RunZipCompressEffect,
     RunZipCompressPreparationEffect,
     SaveConfigEditor,
     SelectAllVisibleEntries,
     SendSplitTerminalInput,
-    SetCommandPaletteQuery,
     SetCursorPath,
     SetFilterQuery,
-    SetFindReplaceField,
-    SetGrepReplaceField,
-    SetGrepReplaceSelectedField,
-    SetGrepSearchField,
     SetNotification,
     SetPendingInputValue,
     SetPendingKeySequence,
-    SetReplaceField,
     SetSort,
     SetTerminalHeight,
     SetUiMode,
-    ShowAttributes,
     SplitTerminalExited,
     SplitTerminalOutputReceived,
     SplitTerminalStarted,
     StartSplitTerminalEffect,
-    SubmitCommandPalette,
     SubmitPendingInput,
-    TextReplaceApplied,
-    TextReplaceApplyFailed,
-    TextReplacePreviewCompleted,
-    TextReplacePreviewFailed,
     ToggleHiddenFiles,
     ToggleSelection,
     ToggleSelectionAndAdvance,
@@ -240,7 +195,6 @@ def test_set_ui_mode_updates_only_mode() -> None:
     assert next_state.current_pane == state.current_pane
     assert next_state.filter == state.filter
 
-
 def test_request_directory_sizes_marks_paths_pending_and_emits_effect() -> None:
     state = build_initial_app_state()
 
@@ -260,7 +214,6 @@ def test_request_directory_sizes_marks_paths_pending_and_emits_effect() -> None:
         ),
     )
 
-
 def test_request_browser_snapshot_clears_directory_size_cache() -> None:
     state = replace(
         build_initial_app_state(),
@@ -277,7 +230,6 @@ def test_request_browser_snapshot_clears_directory_size_cache() -> None:
 
     assert next_state.directory_size_cache == ()
     assert next_state.pending_directory_size_request_id is None
-
 
 def test_directory_sizes_loaded_updates_cache_when_request_matches() -> None:
     state = replace(
@@ -304,7 +256,6 @@ def test_directory_sizes_loaded_updates_cache_when_request_matches() -> None:
         revision=1,
     )
     assert next_state.pending_directory_size_request_id is None
-
 
 def test_directory_sizes_loaded_marks_partial_failures() -> None:
     state = replace(
@@ -342,7 +293,6 @@ def test_directory_sizes_loaded_marks_partial_failures() -> None:
     )
     assert next_state.pending_directory_size_request_id is None
 
-
 def test_directory_sizes_failed_marks_requested_paths_failed() -> None:
     state = replace(
         build_initial_app_state(),
@@ -374,7 +324,6 @@ def test_directory_sizes_failed_marks_requested_paths_failed() -> None:
     )
     assert next_state.pending_directory_size_request_id is None
 
-
 def test_non_directory_size_action_clears_transient_directory_size_delta() -> None:
     state = replace(
         build_initial_app_state(),
@@ -392,7 +341,6 @@ def test_non_directory_size_action_clears_transient_directory_size_delta() -> No
     assert result.state.notification == NotificationState(level="info", message="Ready")
     assert result.state.directory_size_delta == DirectorySizeDeltaState(revision=4)
 
-
 def test_toggle_selection_sets_transient_current_pane_delta() -> None:
     state = build_initial_app_state()
     path = "/home/tadashi/develop/zivo/README.md"
@@ -405,7 +353,6 @@ def test_toggle_selection_sets_transient_current_pane_delta() -> None:
         revision=1,
     )
 
-
 def test_cut_targets_sets_transient_current_pane_delta() -> None:
     state = build_initial_app_state()
     path = "/home/tadashi/develop/zivo/docs"
@@ -417,7 +364,6 @@ def test_cut_targets_sets_transient_current_pane_delta() -> None:
         changed_paths=(path,),
         revision=1,
     )
-
 
 def test_move_cursor_and_select_range_sets_transient_current_pane_delta() -> None:
     state = build_initial_app_state()
@@ -442,7 +388,6 @@ def test_move_cursor_and_select_range_sets_transient_current_pane_delta() -> Non
         revision=1,
     )
 
-
 def test_non_selection_action_clears_transient_current_pane_delta() -> None:
     state = replace(
         build_initial_app_state(),
@@ -460,7 +405,6 @@ def test_non_selection_action_clears_transient_current_pane_delta() -> None:
     assert result.state.notification == NotificationState(level="info", message="Ready")
     assert result.state.current_pane_delta == CurrentPaneDeltaState(revision=4)
 
-
 def test_toggle_selection_uses_absolute_paths() -> None:
     state = build_initial_app_state()
     path = "/home/tadashi/develop/zivo/README.md"
@@ -470,7 +414,6 @@ def test_toggle_selection_uses_absolute_paths() -> None:
 
     assert selected_state.current_pane.selected_paths == frozenset({path})
     assert cleared_state.current_pane.selected_paths == frozenset()
-
 
 def test_clear_selection_empties_selection() -> None:
     state = build_initial_app_state()
@@ -483,7 +426,6 @@ def test_clear_selection_empties_selection() -> None:
 
     assert next_state.current_pane.selected_paths == frozenset()
 
-
 def test_set_filter_query_returns_new_state_without_mutating_input() -> None:
     state = build_initial_app_state()
 
@@ -493,7 +435,6 @@ def test_set_filter_query_returns_new_state_without_mutating_input() -> None:
     assert next_state.filter.active is True
     assert state.filter.query == ""
     assert state.filter.active is False
-
 
 def test_set_sort_returns_new_state_without_mutating_input() -> None:
     state = build_initial_app_state()
@@ -510,7 +451,6 @@ def test_set_sort_returns_new_state_without_mutating_input() -> None:
     assert state.sort.descending is False
     assert state.sort.directories_first is True
 
-
 def test_set_sort_keeps_cursor_on_same_visible_path() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, SetCursorPath("/home/tadashi/develop/zivo/README.md"))
@@ -521,7 +461,6 @@ def test_set_sort_keeps_cursor_on_same_visible_path() -> None:
     )
 
     assert next_state.current_pane.cursor_path == "/home/tadashi/develop/zivo/README.md"
-
 
 def test_set_sort_normalizes_cursor_to_first_visible_path_when_hidden() -> None:
     state = build_initial_app_state()
@@ -534,14 +473,12 @@ def test_set_sort_normalizes_cursor_to_first_visible_path_when_hidden() -> None:
 
     assert next_state.current_pane.cursor_path == "/home/tadashi/develop/zivo/pyproject.toml"
 
-
 def test_set_cursor_path_ignores_unknown_path() -> None:
     state = build_initial_app_state()
 
     next_state = _reduce_state(state, SetCursorPath("/missing"))
 
     assert next_state == state
-
 
 def test_enter_cursor_directory_requests_blocking_snapshot_when_child_pane_is_stale() -> None:
     state = replace(
@@ -564,7 +501,6 @@ def test_enter_cursor_directory_requests_blocking_snapshot_when_child_pane_is_st
             blocking=True,
         ),
     )
-
 
 def test_enter_cursor_directory_promotes_matching_child_pane() -> None:
     state = replace(
@@ -632,7 +568,6 @@ def test_enter_cursor_directory_promotes_matching_child_pane() -> None:
         ),
     )
 
-
 def test_enter_cursor_directory_with_active_filter_falls_back_to_snapshot() -> None:
     state = replace(
         build_initial_app_state(),
@@ -662,7 +597,6 @@ def test_enter_cursor_directory_with_active_filter_falls_back_to_snapshot() -> N
         ),
     )
 
-
 def test_enter_cursor_directory_with_stale_child_pane_falls_back_to_snapshot() -> None:
     state = replace(
         build_initial_app_state(),
@@ -691,7 +625,6 @@ def test_enter_cursor_directory_with_stale_child_pane_falls_back_to_snapshot() -
         ),
     )
 
-
 def test_go_to_parent_directory_restores_cursor_to_previous_child() -> None:
     state = build_initial_app_state()
 
@@ -703,7 +636,6 @@ def test_go_to_parent_directory_restores_cursor_to_previous_child() -> None:
     assert result.effects[0].path == "/home/tadashi/develop"
     assert result.effects[0].cursor_path == "/home/tadashi/develop/zivo"
     assert result.effects[0].blocking is True
-
 
 def test_go_to_parent_directory_uses_current_path_parent() -> None:
     state = build_initial_app_state()
@@ -740,7 +672,6 @@ def test_go_to_parent_directory_uses_current_path_parent() -> None:
     assert result.effects[0].path == "/tmp/work"
     assert result.effects[0].cursor_path == "/tmp/work/project"
 
-
 def test_go_to_home_directory_navigates_to_home() -> None:
     state = build_initial_app_state()
 
@@ -752,7 +683,6 @@ def test_go_to_home_directory_navigates_to_home() -> None:
     # Home directory path will be expanded and resolved
     assert result.effects[0].blocking is True
     assert str(Path.home()) in result.effects[0].path
-
 
 def test_reload_directory_requests_snapshot_with_current_cursor() -> None:
     state = build_initial_app_state()
@@ -775,7 +705,6 @@ def test_reload_directory_requests_snapshot_with_current_cursor() -> None:
             cursor,
         )
     )
-
 
 def test_open_path_with_default_app_emits_external_launch_effect() -> None:
     state = replace(
@@ -803,7 +732,6 @@ def test_open_path_with_default_app_emits_external_launch_effect() -> None:
         ),
     )
 
-
 def test_open_path_in_editor_emits_external_launch_effect() -> None:
     state = replace(
         build_initial_app_state(),
@@ -829,7 +757,6 @@ def test_open_path_in_editor_emits_external_launch_effect() -> None:
             ),
         ),
     )
-
 
 def test_open_path_in_editor_with_line_number_emits_external_launch_effect() -> None:
     state = replace(
@@ -858,81 +785,6 @@ def test_open_path_in_editor_with_line_number_emits_external_launch_effect() -> 
         ),
     )
 
-
-def test_open_find_result_in_editor_emits_external_launch_effect() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="readme",
-            file_search_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-            cursor_index=0,
-        ),
-    )
-
-    result = reduce_app_state(state, OpenFindResultInEditor())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.next_request_id == 2
-    assert result.state.command_palette == state.command_palette
-    assert result.effects == (
-        RunExternalLaunchEffect(
-            request_id=1,
-            request=ExternalLaunchRequest(
-                kind="open_editor",
-                path="/home/tadashi/develop/zivo/README.md",
-                line_number=None,
-            ),
-        ),
-    )
-
-
-def test_open_grep_result_in_editor_keeps_palette_state() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="reduce_app_state",
-            grep_search_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/src/zivo/state/reducer.py",
-                    display_path="src/zivo/state/reducer.py",
-                    line_number=15,
-                    line_text=(
-                        "def reduce_app_state("
-                        "state: AppState, action: Action"
-                        ") -> ReduceResult:"
-                    ),
-                ),
-            ),
-            cursor_index=0,
-        ),
-    )
-
-    result = reduce_app_state(state, OpenGrepResultInEditor())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.next_request_id == 2
-    assert result.state.command_palette == state.command_palette
-    assert result.effects == (
-        RunExternalLaunchEffect(
-            request_id=1,
-            request=ExternalLaunchRequest(
-                kind="open_editor",
-                path="/home/tadashi/develop/zivo/src/zivo/state/reducer.py",
-                line_number=15,
-            ),
-        ),
-    )
-
-
 def test_open_terminal_at_path_emits_external_launch_effect() -> None:
     state = build_initial_app_state()
 
@@ -952,7 +804,6 @@ def test_open_terminal_at_path_emits_external_launch_effect() -> None:
         ),
     )
 
-
 def test_begin_filter_input_switches_mode_without_mutating_query() -> None:
     state = build_initial_app_state()
 
@@ -960,7 +811,6 @@ def test_begin_filter_input_switches_mode_without_mutating_query() -> None:
 
     assert next_state.ui_mode == "FILTER"
     assert next_state.filter == state.filter
-
 
 def test_begin_rename_input_sets_initial_value_from_target_name() -> None:
     state = build_initial_app_state()
@@ -975,14 +825,12 @@ def test_begin_rename_input_sets_initial_value_from_target_name() -> None:
         target_path="/home/tadashi/develop/zivo/docs",
     )
 
-
 def test_begin_rename_input_ignores_unknown_path() -> None:
     state = build_initial_app_state()
 
     next_state = _reduce_state(state, BeginRenameInput("/tmp/missing"))
 
     assert next_state == state
-
 
 def test_begin_create_input_sets_mode_and_kind() -> None:
     state = build_initial_app_state()
@@ -995,64 +843,6 @@ def test_begin_create_input_sets_mode_and_kind() -> None:
         value="",
         create_kind="dir",
     )
-
-
-def test_begin_command_palette_sets_mode_and_empty_query() -> None:
-    state = build_initial_app_state()
-
-    next_state = _reduce_state(state, BeginCommandPalette())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.query == ""
-    assert next_state.command_palette.cursor_index == 0
-
-
-def test_begin_command_palette_keeps_current_cursor_path() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        SetCursorPath("/home/tadashi/develop/zivo/tests"),
-    )
-
-    next_state = _reduce_state(state, BeginCommandPalette())
-
-    assert next_state.current_pane.cursor_path == "/home/tadashi/develop/zivo/tests"
-
-
-def test_move_command_palette_cursor_clamps_to_visible_commands() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-
-    next_state = _reduce_state(state, MoveCommandPaletteCursor(delta=20))
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.cursor_index == 20
-
-
-def test_set_command_palette_query_resets_cursor() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, MoveCommandPaletteCursor(delta=3))
-
-    next_state = _reduce_state(state, SetCommandPaletteQuery("dir"))
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.query == "dir"
-    assert next_state.command_palette.cursor_index == 0
-
-
-def test_submit_command_palette_runs_create_file_flow() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("create file"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "CREATE"
-    assert next_state.command_palette is None
-    assert next_state.pending_input == PendingInputState(
-        prompt="New file: ",
-        value="",
-        create_kind="file",
-    )
-
 
 def test_begin_extract_archive_input_sets_default_destination() -> None:
     archive_path = "/home/tadashi/develop/zivo/archive.tar.gz"
@@ -1070,7 +860,6 @@ def test_begin_extract_archive_input_sets_default_destination() -> None:
         extract_source_path=archive_path,
     )
 
-
 def test_begin_zip_compress_input_sets_default_destination() -> None:
     source_path = "/home/tadashi/develop/zivo/README.md"
     expected_value = str(Path("/home/tadashi/develop/zivo/README.zip").resolve())
@@ -1087,343 +876,6 @@ def test_begin_zip_compress_input_sets_default_destination() -> None:
         zip_source_paths=(source_path,),
     )
 
-
-def test_submit_command_palette_begins_extract_archive_flow() -> None:
-    archive_path = "/home/tadashi/develop/zivo/archive.zip"
-    state = replace(
-        build_initial_app_state(),
-        current_pane=replace(
-            build_initial_app_state().current_pane,
-            entries=(
-                DirectoryEntryState(archive_path, "archive.zip", "file"),
-                *build_initial_app_state().current_pane.entries[1:],
-            ),
-            cursor_path=archive_path,
-        ),
-    )
-    state = _reduce_state(state, BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("extract"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "EXTRACT"
-    assert next_state.pending_input is not None
-    expected_dest = str(Path("/home/tadashi/develop/zivo/archive").resolve())
-    assert next_state.pending_input.value == expected_dest
-    assert next_state.pending_input.extract_source_path == archive_path
-
-
-def test_submit_command_palette_begins_zip_compress_flow() -> None:
-    state = replace(
-        build_initial_app_state(),
-        current_pane=replace(
-            build_initial_app_state().current_pane,
-            selected_paths=frozenset(
-                {
-                    "/home/tadashi/develop/zivo/docs",
-                    "/home/tadashi/develop/zivo/src",
-                }
-            ),
-        ),
-    )
-    state = _reduce_state(state, BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("compress"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "ZIP"
-    assert next_state.pending_input is not None
-    expected_zip = str(Path("/home/tadashi/develop/zivo/zivo.zip").resolve())
-    assert next_state.pending_input.value == expected_zip
-    assert next_state.pending_input.zip_source_paths == (
-        "/home/tadashi/develop/zivo/docs",
-        "/home/tadashi/develop/zivo/src",
-    )
-
-
-def test_begin_file_search_enters_find_file_mode() -> None:
-    next_state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette == CommandPaletteState(source="file_search")
-
-
-def test_begin_grep_search_enters_grep_mode() -> None:
-    next_state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette == CommandPaletteState(source="grep_search")
-
-
-def test_begin_history_search_enters_history_mode() -> None:
-    state = build_initial_app_state()
-    state = replace(
-        state,
-        history=HistoryState(
-            back=("/tmp/a", "/tmp/b"),
-            forward=("/tmp/c",),
-            visited_all=("/home/tadashi/develop/zivo", "/tmp/a", "/tmp/b", "/tmp/c"),
-        ),
-    )
-    next_state = _reduce_state(state, BeginHistorySearch())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.source == "history"
-    assert next_state.command_palette.history_results == (
-        "/home/tadashi/develop/zivo",
-        "/tmp/a",
-        "/tmp/b",
-        "/tmp/c",
-    )
-
-
-def test_begin_history_search_with_empty_history() -> None:
-    next_state = _reduce_state(build_initial_app_state(), BeginHistorySearch())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.source == "history"
-    assert next_state.command_palette.history_results == ()
-
-
-def test_begin_bookmark_search_enters_bookmarks_mode() -> None:
-    next_state = _reduce_state(build_initial_app_state(), BeginBookmarkSearch())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette == CommandPaletteState(source="bookmarks")
-
-
-def test_begin_go_to_path_enters_palette_mode() -> None:
-    next_state = _reduce_state(build_initial_app_state(), BeginGoToPath())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.command_palette == CommandPaletteState(source="go_to_path")
-
-
-def test_submit_history_palette_navigates_to_selected_directory() -> None:
-    state = build_initial_app_state()
-    state = replace(
-        state,
-        ui_mode="PALETTE",
-        command_palette=CommandPaletteState(
-            source="history",
-            history_results=("/tmp/a", "/tmp/b", "/tmp/c"),
-            cursor_index=1,
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.command_palette is None
-    assert any(
-        isinstance(e, LoadBrowserSnapshotEffect) and e.path == "/tmp/b"
-        for e in result.effects
-    )
-
-
-def test_submit_history_palette_with_empty_history_shows_warning() -> None:
-    state = build_initial_app_state()
-    state = replace(
-        state,
-        ui_mode="PALETTE",
-        command_palette=CommandPaletteState(
-            source="history",
-            history_results=(),
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.notification is not None
-    assert result.state.notification.message == "No directory history"
-
-
-def test_submit_bookmarks_palette_navigates_to_selected_directory(tmp_path) -> None:
-    bookmarked_path = tmp_path / "project"
-    bookmarked_path.mkdir()
-    state = build_initial_app_state(
-        config=AppConfig(bookmarks=BookmarkConfig(paths=(str(bookmarked_path),)))
-    )
-    state = replace(
-        state,
-        ui_mode="PALETTE",
-        command_palette=CommandPaletteState(source="bookmarks"),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.command_palette is None
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path=str(bookmarked_path),
-            cursor_path=None,
-            blocking=True,
-        ),
-    )
-
-
-def test_submit_bookmarks_palette_with_invalid_path_shows_error() -> None:
-    state = build_initial_app_state(
-        config=AppConfig(bookmarks=BookmarkConfig(paths=("/tmp/does-not-exist",)))
-    )
-    state = replace(
-        state,
-        ui_mode="PALETTE",
-        command_palette=CommandPaletteState(source="bookmarks"),
-    )
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.notification == NotificationState(
-        level="error",
-        message="Bookmarked path does not exist or is not a directory",
-    )
-
-
-def test_set_command_palette_query_updates_go_to_path_candidates(tmp_path) -> None:
-    state = _reduce_state(
-        replace(build_initial_app_state(), current_path=str(tmp_path)),
-        BeginGoToPath(),
-    )
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "downloads").mkdir()
-
-    next_state = _reduce_state(
-        state,
-        SetCommandPaletteQuery("do"),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.go_to_path_candidates == (
-        str(tmp_path / "docs"),
-        str(tmp_path / "downloads"),
-    )
-
-
-def test_set_command_palette_query_resolves_relative_go_to_path_candidates(tmp_path) -> None:
-    state = _reduce_state(
-        replace(build_initial_app_state(), current_path=str(tmp_path)),
-        BeginGoToPath(),
-    )
-    (tmp_path / "projects").mkdir()
-    (tmp_path / "projects" / "zivo").mkdir()
-
-    next_state = _reduce_state(state, SetCommandPaletteQuery("projects/z"))
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.go_to_path_candidates == (
-        str(tmp_path / "projects" / "zivo"),
-    )
-
-
-def test_submit_go_to_path_palette_requests_snapshot(tmp_path) -> None:
-    state = _reduce_state(
-        replace(build_initial_app_state(), current_path=str(tmp_path)),
-        BeginGoToPath(),
-    )
-    target_path = tmp_path / "docs"
-    target_path.mkdir()
-    state = _reduce_state(
-        state,
-        SetCommandPaletteQuery("do"),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BUSY"
-    assert result.state.command_palette is None
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path=str(target_path),
-            cursor_path=None,
-            blocking=True,
-        ),
-    )
-
-
-def test_submit_go_to_path_palette_uses_selected_candidate(tmp_path) -> None:
-    state = _reduce_state(
-        replace(build_initial_app_state(), current_path=str(tmp_path)),
-        BeginGoToPath(),
-    )
-    (tmp_path / "alpha").mkdir()
-    (tmp_path / "beta").mkdir()
-    state = _reduce_state(state, SetCommandPaletteQuery(""))
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query=str(tmp_path),
-            go_to_path_candidates=(str(tmp_path / "alpha"), str(tmp_path / "beta")),
-            cursor_index=1,
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path=str(tmp_path / "beta"),
-            cursor_path=None,
-            blocking=True,
-        ),
-    )
-
-
-def test_submit_go_to_path_palette_with_trailing_separator_uses_query_directory(tmp_path) -> None:
-    state = _reduce_state(
-        replace(build_initial_app_state(), current_path=str(tmp_path)),
-        BeginGoToPath(),
-    )
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "api").mkdir()
-    state = _reduce_state(state, SetCommandPaletteQuery("docs/"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path=str(tmp_path / "docs"),
-            cursor_path=None,
-            blocking=True,
-        ),
-    )
-
-def test_submit_go_to_path_palette_with_invalid_directory_shows_error() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGoToPath())
-    state = _reduce_state(
-        state,
-        SetCommandPaletteQuery("/path/that/does/not/exist"),
-    )
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.notification == NotificationState(
-        level="error",
-        message="Path does not exist or is not a directory",
-    )
-    state = _reduce_state(
-        build_initial_app_state(config_path="/tmp/zivo/config.toml"),
-        BeginCommandPalette(),
-    )
-    state = _reduce_state(state, SetCommandPaletteQuery("config"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "CONFIG"
-    assert next_state.command_palette is None
-    assert next_state.config_editor == ConfigEditorState(
-        path="/tmp/zivo/config.toml",
-        draft=next_state.config,
-    )
-
-
 def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
@@ -1438,7 +890,6 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
 
     assert next_state.config_editor is not None
     assert next_state.config_editor.cursor_index == 15
-
 
 def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:
     state = replace(
@@ -1457,7 +908,6 @@ def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> N
     assert next_state.config_editor.draft.editor.command == "nvim"
     assert next_state.config_editor.dirty is True
 
-
 def test_cycle_config_editor_value_updates_draft_and_dirty_state() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
@@ -1474,7 +924,6 @@ def test_cycle_config_editor_value_updates_draft_and_dirty_state() -> None:
     assert next_state.config_editor is not None
     assert next_state.config_editor.draft.display.show_hidden_files is True
     assert next_state.config_editor.dirty is True
-
 
 def test_cycle_config_editor_split_terminal_position_updates_draft() -> None:
     original_state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
@@ -1493,7 +942,6 @@ def test_cycle_config_editor_split_terminal_position_updates_draft() -> None:
     assert next_state.config_editor is not None
     assert next_state.config_editor.draft.display.split_terminal_position == "right"
     assert next_state.config_editor.dirty is True
-
 
 def test_cycle_config_editor_split_terminal_position_reaches_overlay() -> None:
     original_state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
@@ -1519,7 +967,6 @@ def test_cycle_config_editor_split_terminal_position_reaches_overlay() -> None:
     assert next_state.config_editor.draft.display.split_terminal_position == "overlay"
     assert next_state.config_editor.dirty is True
 
-
 def test_cycle_config_editor_theme_updates_draft_and_dirty_state() -> None:
     original_state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
     state = replace(
@@ -1538,7 +985,6 @@ def test_cycle_config_editor_theme_updates_draft_and_dirty_state() -> None:
     assert next_state.config_editor.draft.display.theme == "textual-light"
     assert next_state.config.display.theme == "textual-dark"
     assert next_state.config_editor.dirty is True
-
 
 def test_cycle_config_editor_theme_supports_all_builtin_themes() -> None:
     base_state = build_initial_app_state()
@@ -1562,7 +1008,6 @@ def test_cycle_config_editor_theme_supports_all_builtin_themes() -> None:
     assert next_state.config_editor.draft.display.theme == "textual-ansi"
     assert next_state.config_editor.dirty is True
 
-
 def test_cycle_config_editor_directory_size_visibility_updates_draft_and_dirty_state() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
@@ -1579,7 +1024,6 @@ def test_cycle_config_editor_directory_size_visibility_updates_draft_and_dirty_s
     assert next_state.config_editor is not None
     assert next_state.config_editor.draft.display.show_directory_sizes is False
     assert next_state.config_editor.dirty is True
-
 
 def test_cycle_config_editor_preview_visibility_updates_draft_and_dirty_state() -> None:
     state = replace(
@@ -1598,7 +1042,6 @@ def test_cycle_config_editor_preview_visibility_updates_draft_and_dirty_state() 
     assert next_state.config_editor.draft.display.show_preview is False
     assert next_state.config_editor.dirty is True
 
-
 def test_cycle_config_editor_preview_syntax_theme_updates_draft_and_dirty_state() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
@@ -1616,7 +1059,6 @@ def test_cycle_config_editor_preview_syntax_theme_updates_draft_and_dirty_state(
     assert next_state.config_editor.draft.display.preview_syntax_theme == "abap"
     assert next_state.config_editor.dirty is True
 
-
 def test_cycle_config_editor_preview_max_kib_updates_draft_and_dirty_state() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
@@ -1633,7 +1075,6 @@ def test_cycle_config_editor_preview_max_kib_updates_draft_and_dirty_state() -> 
     assert next_state.config_editor is not None
     assert next_state.config_editor.draft.display.preview_max_kib == 128
     assert next_state.config_editor.dirty is True
-
 
 def test_save_config_editor_emits_config_save_effect() -> None:
     state = replace(
@@ -1661,7 +1102,6 @@ def test_save_config_editor_emits_config_save_effect() -> None:
         ),
     )
 
-
 def test_add_bookmark_emits_config_save_effect() -> None:
     state = build_initial_app_state(config_path="/tmp/zivo/config.toml")
 
@@ -1678,7 +1118,6 @@ def test_add_bookmark_emits_config_save_effect() -> None:
         ),
     )
 
-
 def test_add_bookmark_ignores_duplicate_path() -> None:
     state = build_initial_app_state(
         config=AppConfig(bookmarks=BookmarkConfig(paths=("/home/tadashi/develop/zivo",)))
@@ -1690,7 +1129,6 @@ def test_add_bookmark_ignores_duplicate_path() -> None:
         level="info",
         message="Directory is already bookmarked",
     )
-
 
 def test_remove_bookmark_emits_config_save_effect() -> None:
     state = build_initial_app_state(
@@ -1714,7 +1152,6 @@ def test_remove_bookmark_emits_config_save_effect() -> None:
             ),
         ),
     )
-
 
 def test_config_save_completed_updates_runtime_state_and_clears_dirty_flag() -> None:
     state = replace(
@@ -1746,7 +1183,6 @@ def test_config_save_completed_updates_runtime_state_and_clears_dirty_flag() -> 
     assert next_state.confirm_delete is False
     assert next_state.config_editor is not None
     assert next_state.config_editor.dirty is False
-
 
 def test_config_save_completed_clears_preview_when_disabled() -> None:
     path = "/home/tadashi/develop/zivo/README.md"
@@ -1791,7 +1227,6 @@ def test_config_save_completed_clears_preview_when_disabled() -> None:
         entries=(),
     )
     assert next_state.pending_child_pane_request_id is None
-
 
 def test_config_save_completed_requests_preview_when_enabled() -> None:
     path = "/home/tadashi/develop/zivo/README.md"
@@ -1844,7 +1279,6 @@ def test_config_save_completed_requests_preview_when_enabled() -> None:
         ),
     )
 
-
 def test_config_save_failed_sets_error_notification() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
@@ -1858,7 +1292,6 @@ def test_config_save_failed_sets_error_notification() -> None:
         level="error",
         message="Failed to save config: disk full",
     )
-
 
 def test_dismiss_config_editor_returns_to_browsing() -> None:
     state = replace(
@@ -1875,232 +1308,6 @@ def test_dismiss_config_editor_returns_to_browsing() -> None:
     assert next_state.ui_mode == "BROWSING"
     assert next_state.config_editor is None
 
-
-def test_submit_command_palette_runs_copy_path_flow() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("copy"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BROWSING"
-    assert result.state.command_palette is None
-    assert result.state.next_request_id == 2
-    assert result.effects == (
-        RunExternalLaunchEffect(
-            request_id=1,
-            request=ExternalLaunchRequest(
-                kind="copy_paths",
-                paths=("/home/tadashi/develop/zivo/docs",),
-            ),
-        ),
-    )
-
-
-def test_submit_command_palette_opens_attribute_dialog_for_single_target() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("attr"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "DETAIL"
-    assert next_state.command_palette is None
-    assert next_state.attribute_inspection is not None
-    assert next_state.attribute_inspection.name == "docs"
-    assert next_state.attribute_inspection.kind == "dir"
-    assert next_state.attribute_inspection.path == "/home/tadashi/develop/zivo/docs"
-    assert next_state.attribute_inspection.permissions_mode is None
-
-
-def test_dismiss_attribute_dialog_returns_to_browsing() -> None:
-    initial_state = build_initial_app_state()
-    state = replace(
-        initial_state,
-        ui_mode="DETAIL",
-        attribute_inspection=AttributeInspectionState(
-            name="docs",
-            kind="dir",
-            path="/home/tadashi/develop/zivo/docs",
-        ),
-    )
-
-    next_state = _reduce_state(state, DismissAttributeDialog())
-
-    assert next_state.ui_mode == "BROWSING"
-    assert next_state.attribute_inspection is None
-
-
-def test_submit_command_palette_opens_current_directory_in_file_manager() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("manager"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BROWSING"
-    assert result.state.command_palette is None
-    assert result.state.next_request_id == 2
-    assert result.effects == (
-        RunExternalLaunchEffect(
-            request_id=1,
-            request=ExternalLaunchRequest(
-                kind="open_file",
-                path="/home/tadashi/develop/zivo",
-            ),
-        ),
-    )
-
-
-def test_submit_command_palette_warns_when_query_has_no_match() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("zzz"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.notification == NotificationState(
-        level="warning",
-        message="No matching command",
-    )
-
-
-def test_submit_command_palette_toggles_hidden_files() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("hidden"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.ui_mode == "BROWSING"
-    assert next_state.command_palette is None
-    assert next_state.show_hidden is True
-    assert next_state.notification == NotificationState(
-        level="info",
-        message="Hidden files shown",
-    )
-
-
-def test_submit_command_palette_runs_open_terminal_flow() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("open terminal"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BROWSING"
-    assert result.state.command_palette is None
-    assert result.state.next_request_id == 2
-    assert result.effects == (
-        RunExternalLaunchEffect(
-            request_id=1,
-            request=ExternalLaunchRequest(
-                kind="open_terminal",
-                path="/home/tadashi/develop/zivo",
-            ),
-        ),
-    )
-
-
-def test_submit_command_palette_begins_file_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("find files"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "file_search"
-
-
-def test_submit_command_palette_begins_grep_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("grep search"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "grep_search"
-
-
-def test_submit_command_palette_begins_history_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("history search"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "history"
-
-
-def test_submit_command_palette_begins_bookmark_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("show bookmarks"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "bookmarks"
-
-
-def test_submit_command_palette_adds_current_directory_bookmark() -> None:
-    state = _reduce_state(
-        build_initial_app_state(config_path="/tmp/zivo/config.toml"),
-        BeginCommandPalette(),
-    )
-    state = _reduce_state(state, SetCommandPaletteQuery("bookmark this directory"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.command_palette is None
-    assert result.effects == (
-        RunConfigSaveEffect(
-            request_id=1,
-            path="/tmp/zivo/config.toml",
-            config=AppConfig(
-                bookmarks=BookmarkConfig(paths=("/home/tadashi/develop/zivo",))
-            ),
-        ),
-    )
-
-
-def test_show_attributes_enters_detail_mode_for_single_target() -> None:
-    state = build_initial_app_state()
-
-    result = reduce_app_state(state, ShowAttributes())
-
-    assert result.state.ui_mode == "DETAIL"
-    assert result.state.attribute_inspection == AttributeInspectionState(
-        name="docs",
-        kind="dir",
-        path="/home/tadashi/develop/zivo/docs",
-        size_bytes=None,
-        modified_at=state.current_pane.entries[0].modified_at,
-        hidden=False,
-        permissions_mode=state.current_pane.entries[0].permissions_mode,
-    )
-
-
-def test_show_attributes_warns_without_single_target() -> None:
-    state = replace(
-        build_initial_app_state(),
-        current_pane=replace(
-            build_initial_app_state().current_pane,
-            selected_paths=frozenset(
-                {
-                    "/home/tadashi/develop/zivo/docs",
-                    "/home/tadashi/develop/zivo/src",
-                }
-            ),
-        ),
-    )
-
-    next_state = _reduce_state(state, ShowAttributes())
-
-    assert next_state.notification == NotificationState(
-        level="warning",
-        message="Show attributes requires a single target",
-    )
-
-
 def test_copy_paths_to_clipboard_emits_external_launch_effect() -> None:
     result = reduce_app_state(build_initial_app_state(), CopyPathsToClipboard())
 
@@ -2114,102 +1321,6 @@ def test_copy_paths_to_clipboard_emits_external_launch_effect() -> None:
             ),
         ),
     )
-
-
-def test_submit_command_palette_removes_current_directory_bookmark() -> None:
-    state = _reduce_state(
-        build_initial_app_state(
-            config_path="/tmp/zivo/config.toml",
-            config=AppConfig(
-                bookmarks=BookmarkConfig(paths=("/home/tadashi/develop/zivo", "/home/tadashi/src"))
-            ),
-        ),
-        BeginCommandPalette(),
-    )
-    state = _reduce_state(state, SetCommandPaletteQuery("remove bookmark"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.command_palette is None
-    assert result.effects == (
-        RunConfigSaveEffect(
-            request_id=1,
-            path="/tmp/zivo/config.toml",
-            config=AppConfig(
-                bookmarks=BookmarkConfig(paths=("/home/tadashi/src",))
-            ),
-        ),
-    )
-
-
-def test_submit_command_palette_goes_back() -> None:
-    state = replace(
-        _reduce_state(build_initial_app_state(), BeginCommandPalette()),
-        history=HistoryState(
-            back=("/home/tadashi/downloads",),
-            forward=(),
-        ),
-    )
-    state = _reduce_state(state, SetCommandPaletteQuery("go back"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BUSY"
-    assert result.state.command_palette is None
-    assert len(result.effects) == 1
-    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
-    assert result.effects[0].path == "/home/tadashi/downloads"
-
-
-def test_submit_command_palette_go_forward_is_unavailable_without_history() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("go forward"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "PALETTE"
-    assert result.state.command_palette is not None
-    assert result.state.notification == NotificationState(
-        level="warning",
-        message="Go forward is not available yet",
-    )
-
-
-def test_submit_command_palette_reloads_directory() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("reload directory"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.command_palette is None
-    assert len(result.effects) == 1
-    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
-
-
-def test_submit_command_palette_goes_to_home_directory() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("go to home directory"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BUSY"
-    assert result.state.command_palette is None
-    assert len(result.effects) == 1
-    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
-
-
-def test_submit_command_palette_toggles_split_terminal() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("split terminal"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BROWSING"
-    assert result.state.command_palette is None
-    assert result.state.split_terminal.visible is True
-    assert len(result.effects) == 1
-    assert isinstance(result.effects[0], StartSplitTerminalEffect)
-
 
 def test_open_path_in_editor_allows_non_browser_file_path() -> None:
     result = reduce_app_state(
@@ -2228,7 +1339,6 @@ def test_open_path_in_editor_allows_non_browser_file_path() -> None:
         ),
     )
 
-
 def test_toggle_split_terminal_starts_embedded_session() -> None:
     result = reduce_app_state(build_initial_app_state(), ToggleSplitTerminal())
 
@@ -2242,30 +1352,6 @@ def test_toggle_split_terminal_starts_embedded_session() -> None:
             cwd="/home/tadashi/develop/zivo",
         ),
     )
-
-
-def test_submit_command_palette_begins_rename_with_single_target() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("rename"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "RENAME"
-    assert result.state.command_palette is None
-    assert result.state.pending_input is not None
-    assert result.state.pending_input.prompt == "Rename: "
-
-
-def test_submit_command_palette_deletes_targets() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("trash"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "CONFIRM"
-    assert result.state.command_palette is None
-    assert result.state.delete_confirmation is not None
-
 
 def test_toggle_split_terminal_closes_active_session() -> None:
     state = replace(
@@ -2284,7 +1370,6 @@ def test_toggle_split_terminal_closes_active_session() -> None:
     assert result.state.split_terminal.visible is False
     assert result.effects == (CloseSplitTerminalEffect(session_id=7),)
 
-
 def test_focus_split_terminal_switches_focus_target() -> None:
     state = replace(
         build_initial_app_state(),
@@ -2300,13 +1385,11 @@ def test_focus_split_terminal_switches_focus_target() -> None:
 
     assert next_state.split_terminal.focus_target == "terminal"
 
-
 def test_toggle_split_terminal_opens_with_terminal_focus() -> None:
     result = reduce_app_state(build_initial_app_state(), ToggleSplitTerminal())
 
     assert result.state.split_terminal.visible is True
     assert result.state.split_terminal.focus_target == "terminal"
-
 
 def test_send_split_terminal_input_emits_write_effect() -> None:
     state = replace(
@@ -2324,7 +1407,6 @@ def test_send_split_terminal_input_emits_write_effect() -> None:
     assert result.effects == (
         WriteSplitTerminalInputEffect(session_id=5, data="ls\n"),
     )
-
 
 def test_split_terminal_started_marks_session_running() -> None:
     state = replace(
@@ -2348,7 +1430,6 @@ def test_split_terminal_started_marks_session_running() -> None:
         message="Split terminal opened",
     )
 
-
 def test_split_terminal_output_received_does_not_mutate_reducer_state() -> None:
     state = replace(
         build_initial_app_state(),
@@ -2364,7 +1445,6 @@ def test_split_terminal_output_received_does_not_mutate_reducer_state() -> None:
     next_state = _reduce_state(state, SplitTerminalOutputReceived(session_id=5, data=" world"))
 
     assert next_state == state
-
 
 def test_split_terminal_exited_resets_state_and_notifies() -> None:
     state = replace(
@@ -2386,73 +1466,6 @@ def test_split_terminal_exited_resets_state_and_notifies() -> None:
         level="info",
         message="Split terminal closed (exit 0)",
     )
-
-
-def test_submit_command_palette_uses_selected_paths_for_copy_path() -> None:
-    initial_state = build_initial_app_state()
-    state = replace(
-        initial_state,
-        current_pane=replace(
-            initial_state.current_pane,
-            selected_paths=frozenset(
-                {
-                    "/home/tadashi/develop/zivo/docs",
-                    "/home/tadashi/develop/zivo/src",
-                }
-            ),
-        ),
-    )
-    state = _reduce_state(state, BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("copy"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.effects == (
-        RunExternalLaunchEffect(
-            request_id=1,
-            request=ExternalLaunchRequest(
-                kind="copy_paths",
-                paths=(
-                    "/home/tadashi/develop/zivo/docs",
-                    "/home/tadashi/develop/zivo/src",
-                ),
-            ),
-        ),
-    )
-
-
-def test_submit_command_palette_select_all_uses_visible_entries() -> None:
-    initial_state = build_initial_app_state()
-    state = replace(
-        initial_state,
-        current_pane=PaneState(
-            directory_path="/home/tadashi/develop/zivo",
-            entries=(
-                DirectoryEntryState(
-                    "/home/tadashi/develop/zivo/.env",
-                    ".env",
-                    "file",
-                    hidden=True,
-                ),
-                DirectoryEntryState("/home/tadashi/develop/zivo/docs", "docs", "dir"),
-                DirectoryEntryState("/home/tadashi/develop/zivo/src", "src", "dir"),
-            ),
-            cursor_path="/home/tadashi/develop/zivo/docs",
-        ),
-        filter=replace(initial_state.filter, query="s", active=True),
-    )
-    state = _reduce_state(state, BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery("select all"))
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.current_pane.selected_paths == frozenset(
-        {
-            "/home/tadashi/develop/zivo/docs",
-            "/home/tadashi/develop/zivo/src",
-        }
-    )
-
 
 def test_select_all_visible_entries_replaces_selection_with_visible_paths() -> None:
     initial_state = build_initial_app_state()
@@ -2497,984 +1510,6 @@ def test_select_all_visible_entries_replaces_selection_with_visible_paths() -> N
         }
     )
 
-
-def test_set_command_palette_query_starts_file_search_effect() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-
-    result = reduce_app_state(state, SetCommandPaletteQuery("read"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "file_search"
-    assert result.state.command_palette.query == "read"
-    assert result.state.pending_file_search_request_id == 1
-    assert result.effects == (
-        RunFileSearchEffect(
-            request_id=1,
-            root_path="/home/tadashi/develop/zivo",
-            query="read",
-            show_hidden=False,
-        ),
-    )
-
-
-def test_set_command_palette_query_starts_grep_search_effect() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-
-    result = reduce_app_state(state, SetCommandPaletteQuery("todo"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "grep_search"
-    assert result.state.command_palette.query == "todo"
-    assert result.state.pending_grep_search_request_id == 1
-    assert result.effects == (
-        RunGrepSearchEffect(
-            request_id=1,
-            root_path="/home/tadashi/develop/zivo",
-            query="todo",
-            show_hidden=False,
-            include_globs=(),
-            exclude_globs=(),
-        ),
-    )
-
-
-def test_set_grep_search_field_builds_include_and_exclude_globs() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
-
-    result = reduce_app_state(state, SetGrepSearchField(field="include", value="py, ts"))
-    result = reduce_app_state(result.state, SetGrepSearchField(field="exclude", value=".log"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.grep_search_include_extensions == "py, ts"
-    assert result.state.command_palette.grep_search_exclude_extensions == ".log"
-    assert result.effects == (
-        RunGrepSearchEffect(
-            request_id=3,
-            root_path="/home/tadashi/develop/zivo",
-            query="todo",
-            show_hidden=False,
-            include_globs=("*.py", "*.ts"),
-            exclude_globs=("*.log",),
-        ),
-    )
-
-
-def test_set_grep_search_filename_filter_updates_palette_and_requests_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
-
-    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="readme"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.grep_search_filename_filter == "readme"
-    assert result.effects == (
-        RunGrepSearchEffect(
-            request_id=2,
-            root_path="/home/tadashi/develop/zivo",
-            query="todo",
-            show_hidden=False,
-            include_globs=(),
-            exclude_globs=(),
-        ),
-    )
-
-
-def test_grep_search_completed_filters_results_by_filename() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grep_search_keyword="todo",
-            grep_search_filename_filter="readme",
-        ),
-        pending_grep_search_request_id=4,
-    )
-    results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-            line_number=1,
-            line_text="TODO",
-        ),
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/docs/guide.md",
-            display_path="docs/guide.md",
-            line_number=2,
-            line_text="TODO",
-        ),
-    )
-
-    result = reduce_app_state(
-        state,
-        GrepSearchCompleted(request_id=4, query="todo", results=results),
-    )
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.grep_search_results == (results[0],)
-    assert result.state.pending_grep_search_request_id is None
-
-
-def test_grep_search_completed_filters_results_by_filename_regex() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grep_search_keyword="todo",
-            grep_search_filename_filter="re:^docs/.+\\.md$",
-        ),
-        pending_grep_search_request_id=4,
-    )
-    results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-            line_number=1,
-            line_text="TODO",
-        ),
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/docs/guide.md",
-            display_path="docs/guide.md",
-            line_number=2,
-            line_text="TODO",
-        ),
-    )
-
-    result = reduce_app_state(
-        state,
-        GrepSearchCompleted(request_id=4, query="todo", results=results),
-    )
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.grep_search_results == (results[1],)
-
-
-def test_set_grep_search_field_rejects_conflicting_extensions() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
-    state = _reduce_state(state, SetGrepSearchField(field="include", value="py"))
-
-    result = reduce_app_state(state, SetGrepSearchField(field="exclude", value=".py"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.grep_search_results == ()
-    assert (
-        result.state.command_palette.grep_search_error_message
-        == "Extensions cannot be included and excluded at the same time: py"
-    )
-    assert result.state.pending_grep_search_request_id is None
-    assert result.effects == ()
-
-
-def test_set_grep_search_field_rejects_invalid_extension_input() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
-
-    result = reduce_app_state(state, SetGrepSearchField(field="include", value="*.py"))
-
-    assert result.state.command_palette is not None
-    assert (
-        result.state.command_palette.grep_search_error_message
-        == "Invalid include extension: *.py"
-    )
-    assert result.effects == ()
-
-
-def test_set_grep_search_field_clears_results_when_keyword_becomes_empty() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="todo",
-            grep_search_keyword="todo",
-            grep_search_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="TODO",
-                ),
-            ),
-        ),
-        pending_grep_search_request_id=4,
-        pending_child_pane_request_id=7,
-    )
-
-    result = reduce_app_state(state, SetGrepSearchField(field="keyword", value=""))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.grep_search_results == ()
-    assert result.state.command_palette.grep_search_error_message is None
-    assert result.state.pending_grep_search_request_id is None
-    assert result.state.pending_child_pane_request_id is None
-    assert result.effects == ()
-
-
-def test_begin_text_replace_enters_replace_mode() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
-    )
-
-    assert state.ui_mode == "PALETTE"
-    assert state.command_palette is not None
-    assert state.command_palette.source == "replace_text"
-    assert state.command_palette.replace_target_paths == (
-        "/home/tadashi/develop/zivo/README.md",
-    )
-
-
-def test_set_replace_field_starts_preview_effect() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
-    )
-
-    result = reduce_app_state(state, SetReplaceField(field="find", value="todo"))
-
-    assert result.state.command_palette is not None
-    assert result.state.pending_replace_preview_request_id == 1
-    assert result.effects == (
-        RunTextReplacePreviewEffect(
-            request_id=1,
-            request=TextReplaceRequest(
-                paths=("/home/tadashi/develop/zivo/README.md",),
-                find_text="todo",
-                replace_text="",
-            ),
-        ),
-    )
-
-
-def test_cycle_replace_field_switches_active_input() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
-    )
-
-    next_state = _reduce_state(state, CycleReplaceField(delta=1))
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.replace_active_field == "replace"
-
-
-def test_text_replace_preview_completed_updates_palette_results() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
-    )
-    state = replace(
-        state,
-        pending_replace_preview_request_id=4,
-        command_palette=replace(
-            state.command_palette,
-            replace_find_text="todo",
-        ),
-    )
-
-    next_state = _reduce_state(
-        state,
-        TextReplacePreviewCompleted(
-            request_id=4,
-            result=TextReplacePreviewResult(
-                request=TextReplaceRequest(
-                    paths=("/home/tadashi/develop/zivo/README.md",),
-                    find_text="todo",
-                    replace_text="done",
-                ),
-                changed_entries=(
-                    TextReplacePreviewEntry(
-                        path="/home/tadashi/develop/zivo/README.md",
-                        diff_text="--- before\n+++ after\n@@\n-todo item\n+done item\n",
-                        match_count=2,
-                        first_match_line_number=12,
-                        first_match_before="todo item",
-                        first_match_after="done item",
-                    ),
-                ),
-                total_match_count=2,
-                diff_text="--- before\n+++ after\n@@\n-todo item\n+done item\n",
-            ),
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.replace_total_match_count == 2
-    assert next_state.command_palette.replace_preview_results[0].display_path == "README.md"
-    assert next_state.command_palette.replace_preview_results[0].diff_text == (
-        "--- before\n+++ after\n@@\n-todo item\n+done item\n"
-    )
-    assert next_state.child_pane.preview_title == "Replace Preview"
-    assert next_state.child_pane.preview_content == (
-        "--- before\n+++ after\n@@\n-todo item\n+done item\n"
-    )
-    assert next_state.child_pane.preview_path == "/home/tadashi/develop/zivo/README.md"
-    assert next_state.pending_replace_preview_request_id is None
-
-
-def test_move_palette_cursor_updates_replace_preview_diff() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(
-            target_paths=(
-                "/home/tadashi/develop/zivo/README.md",
-                "/home/tadashi/develop/zivo/docs/notes.md",
-            )
-        ),
-    )
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            replace_preview_results=(
-                ReplacePreviewResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    diff_text="--- README\n+++ README\n@@\n-todo\n+done\n",
-                    match_count=1,
-                    first_match_line_number=1,
-                    first_match_before="todo",
-                    first_match_after="done",
-                ),
-                ReplacePreviewResultState(
-                    path="/home/tadashi/develop/zivo/docs/notes.md",
-                    display_path="docs/notes.md",
-                    diff_text="--- notes\n+++ notes\n@@\n-todo\n+done\n",
-                    match_count=1,
-                    first_match_line_number=2,
-                    first_match_before="todo",
-                    first_match_after="done",
-                ),
-            ),
-            replace_total_match_count=2,
-        ),
-        child_pane=PaneState(
-            directory_path=state.current_path,
-            entries=(),
-            mode="preview",
-            preview_path="/home/tadashi/develop/zivo/README.md",
-            preview_title="Replace Preview",
-            preview_content="--- README\n+++ README\n@@\n-todo\n+done\n",
-        ),
-    )
-
-    result = reduce_app_state(state, MoveCommandPaletteCursor(delta=1))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.cursor_index == 1
-    assert result.state.child_pane.preview_path == "/home/tadashi/develop/zivo/docs/notes.md"
-    assert result.state.child_pane.preview_content == (
-        "--- notes\n+++ notes\n@@\n-todo\n+done\n"
-    )
-
-
-def test_text_replace_preview_failed_sets_inline_error_for_invalid_regex() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
-    )
-    state = replace(state, pending_replace_preview_request_id=4)
-
-    next_state = _reduce_state(
-        state,
-        TextReplacePreviewFailed(
-            request_id=4,
-            message="missing )",
-            invalid_query=True,
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.replace_error_message == "missing )"
-    assert next_state.pending_replace_preview_request_id is None
-
-
-def test_submit_command_palette_applies_replace_when_preview_exists() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
-    )
-    state = replace(
-        state,
-        next_request_id=8,
-        command_palette=replace(
-            state.command_palette,
-            replace_find_text="todo",
-            replace_replacement_text="done",
-            replace_preview_results=(
-                ReplacePreviewResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    diff_text="--- before\n+++ after\n@@\n-todo item\n+done item\n",
-                    match_count=2,
-                    first_match_line_number=12,
-                    first_match_before="todo item",
-                    first_match_after="done item",
-                ),
-            ),
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.pending_replace_apply_request_id == 8
-    assert result.state.ui_mode == "BROWSING"
-    assert result.effects == (
-        RunTextReplaceApplyEffect(
-            request_id=8,
-            request=TextReplaceRequest(
-                paths=("/home/tadashi/develop/zivo/README.md",),
-                find_text="todo",
-                replace_text="done",
-            ),
-        ),
-    )
-
-
-def test_text_replace_applied_refreshes_current_directory() -> None:
-    state = replace(
-        build_initial_app_state(),
-        pending_replace_apply_request_id=6,
-        current_path="/home/tadashi/develop/zivo",
-        current_pane=replace(
-            build_initial_app_state().current_pane,
-            cursor_path="/home/tadashi/develop/zivo/README.md",
-        ),
-    )
-
-    result = reduce_app_state(
-        state,
-        TextReplaceApplied(
-            request_id=6,
-            result=TextReplaceResult(
-                request=TextReplaceRequest(
-                    paths=("/home/tadashi/develop/zivo/README.md",),
-                    find_text="todo",
-                    replace_text="done",
-                ),
-                changed_paths=("/home/tadashi/develop/zivo/README.md",),
-                total_match_count=3,
-                message="Replaced 3 match(es) in 1 file(s)",
-            ),
-        ),
-    )
-
-    assert result.state.post_reload_notification == NotificationState(
-        level="info",
-        message="Replaced 3 match(es) in 1 file(s)",
-    )
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path="/home/tadashi/develop/zivo",
-            cursor_path="/home/tadashi/develop/zivo/README.md",
-            blocking=True,
-            invalidate_paths=browser_snapshot_invalidation_paths(
-                "/home/tadashi/develop/zivo",
-                "/home/tadashi/develop/zivo/README.md",
-            ),
-        ),
-    )
-
-
-def test_text_replace_apply_failed_sets_error_notification() -> None:
-    state = replace(
-        build_initial_app_state(),
-        pending_replace_apply_request_id=3,
-    )
-
-    next_state = _reduce_state(
-        state,
-        TextReplaceApplyFailed(request_id=3, message="permission denied"),
-    )
-
-    assert next_state.pending_replace_apply_request_id is None
-    assert next_state.notification == NotificationState(
-        level="error",
-        message="permission denied",
-    )
-
-
-def test_run_replace_text_command_uses_cursor_file_when_nothing_is_selected() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = replace(
-        state,
-        command_palette=replace(state.command_palette, query="replace text"),
-        current_pane=replace(
-            state.current_pane,
-            selected_paths=frozenset(),
-            cursor_path="/home/tadashi/develop/zivo/README.md",
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "replace_text"
-    assert result.state.command_palette.replace_target_paths == (
-        "/home/tadashi/develop/zivo/README.md",
-    )
-
-
-def test_set_command_palette_query_reuses_completed_file_search_results_for_prefix_extension(
-) -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="read",
-            file_search_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/docs/readings.txt",
-                    display_path="docs/readings.txt",
-                ),
-            ),
-            file_search_cache_query="read",
-            file_search_cache_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/docs/readings.txt",
-                    display_path="docs/readings.txt",
-                ),
-            ),
-            file_search_cache_root_path="/home/tadashi/develop/zivo",
-            file_search_cache_show_hidden=False,
-        ),
-        pending_file_search_request_id=4,
-        next_request_id=5,
-    )
-
-    result = reduce_app_state(state, SetCommandPaletteQuery("readm"))
-
-    assert result.effects == (
-        LoadChildPaneSnapshotEffect(
-            request_id=5,
-            current_path="/home/tadashi/develop/zivo",
-            cursor_path="/home/tadashi/develop/zivo/README.md",
-        ),
-    )
-    assert result.state.pending_file_search_request_id is None
-    assert result.state.pending_child_pane_request_id == 5
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.file_search_results == (
-        FileSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-        ),
-    )
-    assert result.state.next_request_id == 6
-
-
-def test_set_command_palette_query_runs_new_search_when_query_is_not_prefix_extension() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="read",
-            file_search_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-            file_search_cache_query="read",
-            file_search_cache_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-            file_search_cache_root_path="/home/tadashi/develop/zivo",
-            file_search_cache_show_hidden=False,
-        ),
-        next_request_id=4,
-    )
-
-    result = reduce_app_state(state, SetCommandPaletteQuery("rea"))
-
-    assert result.state.pending_file_search_request_id == 4
-    assert result.effects == (
-        RunFileSearchEffect(
-            request_id=4,
-            root_path="/home/tadashi/develop/zivo",
-            query="rea",
-            show_hidden=False,
-        ),
-    )
-
-
-def test_set_command_palette_query_runs_new_search_for_regex_queries() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="read",
-            file_search_cache_query="read",
-            file_search_cache_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-            file_search_cache_root_path="/home/tadashi/develop/zivo",
-            file_search_cache_show_hidden=False,
-        ),
-        next_request_id=4,
-    )
-
-    result = reduce_app_state(state, SetCommandPaletteQuery(r"re:^README\.md$"))
-
-    assert result.state.pending_file_search_request_id == 4
-    assert result.effects == (
-        RunFileSearchEffect(
-            request_id=4,
-            root_path="/home/tadashi/develop/zivo",
-            query=r"re:^README\.md$",
-            show_hidden=False,
-        ),
-    )
-
-
-def test_file_search_completed_updates_palette_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    search_state = replace(
-        state,
-        command_palette=replace(state.command_palette, query="read"),
-        pending_file_search_request_id=4,
-    )
-
-    next_state = _reduce_state(
-        search_state,
-        FileSearchCompleted(
-            request_id=4,
-            query="read",
-            results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.file_search_results == (
-        FileSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-        ),
-    )
-    assert next_state.command_palette.file_search_cache_query == "read"
-    assert next_state.command_palette.file_search_cache_root_path == "/home/tadashi/develop/zivo"
-    assert next_state.command_palette.file_search_cache_show_hidden is False
-    assert next_state.pending_file_search_request_id is None
-
-
-def test_file_search_completed_does_not_cache_regex_queries() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    search_state = replace(
-        state,
-        command_palette=replace(state.command_palette, query=r"re:^README\.md$"),
-        pending_file_search_request_id=4,
-    )
-
-    next_state = _reduce_state(
-        search_state,
-        FileSearchCompleted(
-            request_id=4,
-            query=r"re:^README\.md$",
-            results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.file_search_results == (
-        FileSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-        ),
-    )
-    assert next_state.command_palette.file_search_cache_query == ""
-    assert next_state.command_palette.file_search_cache_results == ()
-
-
-def test_file_search_failed_sets_inline_error_for_invalid_regex() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    search_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="re:[",
-            file_search_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-        pending_file_search_request_id=4,
-    )
-
-    next_state = _reduce_state(
-        search_state,
-        FileSearchFailed(
-            request_id=4,
-            query="re:[",
-            message="Invalid regex: unterminated character set",
-            invalid_query=True,
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.file_search_results == ()
-    assert (
-        next_state.command_palette.file_search_error_message
-        == "Invalid regex: unterminated character set"
-    )
-    assert next_state.notification is None
-    assert next_state.pending_file_search_request_id is None
-
-
-def test_submit_command_palette_uses_inline_error_message_when_present() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="re:[",
-            file_search_error_message="Invalid regex: unterminated character set",
-        ),
-    )
-
-    next_state = _reduce_state(state, SubmitCommandPalette())
-
-    assert next_state.notification == NotificationState(
-        level="warning",
-        message="Invalid regex: unterminated character set",
-    )
-
-
-def test_submit_command_palette_file_search_result_requests_snapshot() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="read",
-            file_search_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/docs/README.md",
-                    display_path="docs/README.md",
-                ),
-            ),
-            cursor_index=0,
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BUSY"
-    assert result.state.command_palette is None
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path="/home/tadashi/develop/zivo/docs",
-            cursor_path="/home/tadashi/develop/zivo/docs/README.md",
-            blocking=True,
-        ),
-    )
-
-
-def test_grep_search_completed_updates_palette_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    search_state = replace(
-        state,
-        command_palette=replace(state.command_palette, query="todo"),
-        pending_grep_search_request_id=4,
-    )
-
-    next_state = _reduce_state(
-        search_state,
-        GrepSearchCompleted(
-            request_id=4,
-            query="todo",
-            results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/src/zivo/app.py",
-                    display_path="src/zivo/app.py",
-                    line_number=42,
-                    line_text="TODO: update palette",
-                ),
-            ),
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.grep_search_results == (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/src/zivo/app.py",
-            display_path="src/zivo/app.py",
-            line_number=42,
-            line_text="TODO: update palette",
-        ),
-    )
-    assert next_state.pending_grep_search_request_id is None
-
-
-def test_grep_search_completed_requests_context_preview() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    search_state = replace(
-        state,
-        command_palette=replace(state.command_palette, query="todo"),
-        pending_grep_search_request_id=4,
-    )
-    grep_result = GrepSearchResultState(
-        path="/home/tadashi/develop/zivo/src/zivo/app.py",
-        display_path="src/zivo/app.py",
-        line_number=42,
-        line_text="TODO: update palette",
-    )
-
-    result = reduce_app_state(
-        search_state,
-        GrepSearchCompleted(
-            request_id=4,
-            query="todo",
-            results=(grep_result,),
-        ),
-    )
-
-    assert result.state.pending_child_pane_request_id == 1
-    assert result.effects == (
-        LoadChildPaneSnapshotEffect(
-            request_id=1,
-            current_path="/home/tadashi/develop/zivo",
-            cursor_path="/home/tadashi/develop/zivo/src/zivo/app.py",
-            grep_result=grep_result,
-            grep_context_lines=3,
-        ),
-    )
-
-
-def test_grep_search_completed_skips_context_preview_when_preview_disabled() -> None:
-    grep_result = GrepSearchResultState(
-        path="/home/tadashi/develop/zivo/src/zivo/app.py",
-        display_path="src/zivo/app.py",
-        line_number=42,
-        line_text="TODO: update palette",
-    )
-    search_state = replace(
-        _reduce_state(build_initial_app_state(), BeginGrepSearch()),
-        config=replace(
-            build_initial_app_state().config,
-            display=replace(build_initial_app_state().config.display, show_preview=False),
-        ),
-        command_palette=replace(
-            _reduce_state(build_initial_app_state(), BeginGrepSearch()).command_palette,
-            query="todo",
-        ),
-        pending_grep_search_request_id=4,
-    )
-
-    result = reduce_app_state(
-        search_state,
-        GrepSearchCompleted(
-            request_id=4,
-            query="todo",
-            results=(grep_result,),
-        ),
-    )
-
-    assert result.state.config.display.show_preview is False
-    assert result.state.pending_child_pane_request_id is None
-    assert result.effects == ()
-
-
-def test_grep_search_failed_sets_inline_error_for_invalid_regex() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    search_state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="re:[",
-            grep_search_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/src/zivo/app.py",
-                    display_path="src/zivo/app.py",
-                    line_number=42,
-                    line_text="TODO: update palette",
-                ),
-            ),
-        ),
-        pending_grep_search_request_id=4,
-    )
-
-    next_state = _reduce_state(
-        search_state,
-        GrepSearchFailed(
-            request_id=4,
-            query="re:[",
-            message="regex parse error",
-            invalid_query=True,
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.grep_search_results == ()
-    assert next_state.command_palette.grep_search_error_message == "regex parse error"
-    assert next_state.pending_grep_search_request_id is None
-
-
-def test_submit_command_palette_grep_result_requests_snapshot() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            query="todo",
-            grep_search_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/src/zivo/app.py",
-                    display_path="src/zivo/app.py",
-                    line_number=42,
-                    line_text="TODO: update palette",
-                ),
-            ),
-            cursor_index=0,
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.ui_mode == "BUSY"
-    assert result.effects == (
-        LoadBrowserSnapshotEffect(
-            request_id=1,
-            path="/home/tadashi/develop/zivo/src/zivo",
-            cursor_path="/home/tadashi/develop/zivo/src/zivo/app.py",
-            blocking=True,
-        ),
-    )
-
-
 def test_toggle_hidden_files_normalizes_cursor_and_selection() -> None:
     hidden_path = "/home/tadashi/develop/zivo/.env"
     visible_path = "/home/tadashi/develop/zivo/docs"
@@ -3504,65 +1539,6 @@ def test_toggle_hidden_files_normalizes_cursor_and_selection() -> None:
         message="Hidden files hidden",
     )
 
-
-def test_cancel_command_palette_returns_to_browsing() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-
-    next_state = _reduce_state(state, CancelCommandPalette())
-
-    assert next_state.ui_mode == "BROWSING"
-    assert next_state.command_palette is None
-
-
-def test_cancel_grep_command_palette_restores_current_cursor_preview() -> None:
-    path = "/home/tadashi/develop/zivo/README.md"
-    grep_result = GrepSearchResultState(
-        path=path,
-        display_path="README.md",
-        line_number=3,
-        line_text="TODO: update docs",
-    )
-    state = replace(
-        _reduce_state(build_initial_app_state(), BeginGrepSearch()),
-        current_pane=replace(build_initial_app_state().current_pane, cursor_path=path),
-        command_palette=CommandPaletteState(
-            source="grep_search",
-            query="todo",
-            grep_search_results=(grep_result,),
-        ),
-        child_pane=PaneState(
-            directory_path="/home/tadashi/develop/zivo",
-            entries=(),
-            mode="preview",
-            preview_path=path,
-            preview_title="Preview: README.md:3",
-            preview_content="TODO: update docs\n",
-            preview_start_line=3,
-            preview_highlight_line=3,
-        ),
-    )
-
-    result = reduce_app_state(state, CancelCommandPalette())
-
-    assert result.state.ui_mode == "BROWSING"
-    assert result.state.pending_child_pane_request_id == 1
-    assert result.effects == (
-        LoadChildPaneSnapshotEffect(
-            request_id=1,
-            current_path="/home/tadashi/develop/zivo",
-            cursor_path=path,
-        ),
-        RunDirectorySizeEffect(
-            request_id=2,
-            paths=(
-                "/home/tadashi/develop/zivo/docs",
-                "/home/tadashi/develop/zivo/src",
-                "/home/tadashi/develop/zivo/tests",
-            ),
-        ),
-    )
-
-
 def test_begin_delete_targets_single_runs_file_mutation() -> None:
     state = build_initial_app_state(confirm_delete=False)
 
@@ -3579,7 +1555,6 @@ def test_begin_delete_targets_single_runs_file_mutation() -> None:
         ),
     )
 
-
 def test_begin_delete_targets_single_enters_confirm_mode_when_enabled() -> None:
     state = build_initial_app_state(confirm_delete=True)
 
@@ -3593,14 +1568,12 @@ def test_begin_delete_targets_single_enters_confirm_mode_when_enabled() -> None:
         paths=("/home/tadashi/develop/zivo/docs",)
     )
 
-
 def test_begin_delete_targets_with_empty_paths_keeps_state() -> None:
     state = build_initial_app_state()
 
     next_state = _reduce_state(state, BeginDeleteTargets(()))
 
     assert next_state == state
-
 
 def test_begin_delete_targets_multiple_enters_confirm_mode() -> None:
     state = build_initial_app_state()
@@ -3623,7 +1596,6 @@ def test_begin_delete_targets_multiple_enters_confirm_mode() -> None:
         )
     )
 
-
 def test_cancel_pending_input_returns_to_browsing() -> None:
     state = replace(
         build_initial_app_state(),
@@ -3635,7 +1607,6 @@ def test_cancel_pending_input_returns_to_browsing() -> None:
 
     assert next_state.ui_mode == "BROWSING"
     assert next_state.pending_input is None
-
 
 def test_confirm_delete_targets_runs_file_mutation() -> None:
     state = replace(
@@ -3666,7 +1637,6 @@ def test_confirm_delete_targets_runs_file_mutation() -> None:
         ),
     )
 
-
 def test_cancel_delete_confirmation_returns_to_browsing_with_warning() -> None:
     state = replace(
         build_initial_app_state(),
@@ -3680,7 +1650,6 @@ def test_cancel_delete_confirmation_returns_to_browsing_with_warning() -> None:
 
     assert next_state.ui_mode == "BROWSING"
     assert next_state.notification == NotificationState(level="warning", message="Delete cancelled")
-
 
 def test_begin_permanent_delete_targets_enters_confirm_mode_when_delete_confirmation_disabled(
 ) -> None:
@@ -3696,7 +1665,6 @@ def test_begin_permanent_delete_targets_enters_confirm_mode_when_delete_confirma
         paths=("/home/tadashi/develop/zivo/docs",),
         mode="permanent",
     )
-
 
 def test_confirm_permanent_delete_targets_runs_file_mutation() -> None:
     state = replace(
@@ -3722,7 +1690,6 @@ def test_confirm_permanent_delete_targets_runs_file_mutation() -> None:
         ),
     )
 
-
 def test_cancel_permanent_delete_confirmation_returns_to_browsing_with_warning() -> None:
     state = replace(
         build_initial_app_state(),
@@ -3740,7 +1707,6 @@ def test_cancel_permanent_delete_confirmation_returns_to_browsing_with_warning()
         level="warning",
         message="Permanent delete cancelled",
     )
-
 
 def test_submit_pending_extract_starts_archive_preparation() -> None:
     source_path = "/home/tadashi/develop/zivo/archive.zip"
@@ -3768,7 +1734,6 @@ def test_submit_pending_extract_starts_archive_preparation() -> None:
             ),
         ),
     )
-
 
 def test_submit_pending_zip_compress_starts_preparation() -> None:
     dest_path = "/tmp/output.zip"
@@ -3803,7 +1768,6 @@ def test_submit_pending_zip_compress_starts_preparation() -> None:
         ),
     )
 
-
 def test_submit_pending_extract_resolves_relative_destination_from_archive_parent() -> None:
     source_path = "/home/tadashi/develop/zivo/docs/archive.tar.bz2"
     state = replace(
@@ -3827,7 +1791,6 @@ def test_submit_pending_extract_resolves_relative_destination_from_archive_paren
             ),
         ),
     )
-
 
 def test_archive_preparation_with_conflicts_enters_confirm_mode() -> None:
     request = ExtractArchiveRequest(
@@ -3865,7 +1828,6 @@ def test_archive_preparation_with_conflicts_enters_confirm_mode() -> None:
         total_entries=7,
     )
 
-
 def test_zip_compress_preparation_with_existing_destination_enters_confirm_mode() -> None:
     request = CreateZipArchiveRequest(
         source_paths=("/home/tadashi/develop/zivo/docs",),
@@ -3900,7 +1862,6 @@ def test_zip_compress_preparation_with_existing_destination_enters_confirm_mode(
         total_entries=7,
     )
 
-
 def test_confirm_archive_extract_runs_extract_effect() -> None:
     request = ExtractArchiveRequest(
         source_path="/home/tadashi/develop/zivo/archive.zip",
@@ -3932,7 +1893,6 @@ def test_confirm_archive_extract_runs_extract_effect() -> None:
         ),
     )
 
-
 def test_confirm_zip_compress_runs_effect() -> None:
     request = CreateZipArchiveRequest(
         source_paths=("/home/tadashi/develop/zivo/docs",),
@@ -3962,7 +1922,6 @@ def test_confirm_zip_compress_runs_effect() -> None:
             request=request,
         ),
     )
-
 
 def test_cancel_archive_extract_confirmation_returns_to_extract_mode() -> None:
     request = ExtractArchiveRequest(
@@ -3994,7 +1953,6 @@ def test_cancel_archive_extract_confirmation_returns_to_extract_mode() -> None:
         message="Extraction cancelled",
     )
 
-
 def test_cancel_zip_compress_confirmation_returns_to_zip_mode() -> None:
     request = CreateZipArchiveRequest(
         source_paths=("/home/tadashi/develop/zivo/docs",),
@@ -4024,7 +1982,6 @@ def test_cancel_zip_compress_confirmation_returns_to_zip_mode() -> None:
         message="Zip compression cancelled",
     )
 
-
 def test_archive_extract_progress_updates_notification() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4052,7 +2009,6 @@ def test_archive_extract_progress_updates_notification() -> None:
         message="Extracting archive 2/5: notes.txt",
     )
 
-
 def test_zip_compress_progress_updates_notification() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4079,7 +2035,6 @@ def test_zip_compress_progress_updates_notification() -> None:
         level="info",
         message="Compressing as zip 2/5: readme.txt",
     )
-
 
 def test_archive_extract_completed_requests_snapshot_for_destination_parent() -> None:
     dest_parent = str(Path("/tmp/output").resolve())
@@ -4124,7 +2079,6 @@ def test_archive_extract_completed_requests_snapshot_for_destination_parent() ->
         ),
     )
 
-
 def test_zip_compress_completed_requests_snapshot_for_destination_parent() -> None:
     dest_parent = str(Path("/tmp").resolve())
     dest_path = str(Path("/tmp/output.zip").resolve())
@@ -4168,7 +2122,6 @@ def test_zip_compress_completed_requests_snapshot_for_destination_parent() -> No
         ),
     )
 
-
 def test_archive_extract_failed_returns_to_extract_mode() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4192,7 +2145,6 @@ def test_archive_extract_failed_returns_to_extract_mode() -> None:
         level="error",
         message="Unsupported archive member type: link",
     )
-
 
 def test_zip_compress_failed_returns_to_zip_mode() -> None:
     state = replace(
@@ -4218,7 +2170,6 @@ def test_zip_compress_failed_returns_to_zip_mode() -> None:
         message="Destination path already exists as a directory",
     )
 
-
 def test_archive_preparation_failed_returns_to_extract_mode() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4243,7 +2194,6 @@ def test_archive_preparation_failed_returns_to_extract_mode() -> None:
         message="Unsupported archive format: archive.rar",
     )
 
-
 def test_set_pending_input_value_updates_current_value() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4255,7 +2205,6 @@ def test_set_pending_input_value_updates_current_value() -> None:
 
     assert next_state.pending_input is not None
     assert next_state.pending_input.value == "notes.txt"
-
 
 def test_submit_pending_input_rejects_duplicate_name() -> None:
     state = replace(
@@ -4278,7 +2227,6 @@ def test_submit_pending_input_rejects_duplicate_name() -> None:
         name="README.md",
     )
 
-
 def test_submit_pending_input_treats_unchanged_rename_as_noop() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4295,7 +2243,6 @@ def test_submit_pending_input_treats_unchanged_rename_as_noop() -> None:
     assert next_state.ui_mode == "BROWSING"
     assert next_state.pending_input is None
     assert next_state.notification == NotificationState(level="info", message="Name unchanged")
-
 
 def test_submit_pending_input_emits_file_mutation_effect() -> None:
     state = replace(
@@ -4322,7 +2269,6 @@ def test_submit_pending_input_emits_file_mutation_effect() -> None:
         ),
     )
 
-
 def test_submit_pending_input_emits_create_effect() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4347,7 +2293,6 @@ def test_submit_pending_input_emits_create_effect() -> None:
         ),
     )
 
-
 def test_submit_pending_input_name_conflict_enters_confirm_mode_for_rename() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4366,7 +2311,6 @@ def test_submit_pending_input_name_conflict_enters_confirm_mode_for_rename() -> 
     assert result.state.name_conflict == NameConflictState(kind="rename", name="src")
     assert result.effects == ()
 
-
 def test_submit_pending_input_name_conflict_enters_confirm_mode_for_create_dir() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4384,7 +2328,6 @@ def test_submit_pending_input_name_conflict_enters_confirm_mode_for_create_dir()
     assert result.state.name_conflict == NameConflictState(kind="create_dir", name="docs")
     assert result.effects == ()
 
-
 def test_confirm_filter_input_returns_to_browsing() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, SetUiMode("FILTER"))
@@ -4392,7 +2335,6 @@ def test_confirm_filter_input_returns_to_browsing() -> None:
     next_state = _reduce_state(state, ConfirmFilterInput())
 
     assert next_state.ui_mode == "BROWSING"
-
 
 def test_cancel_filter_input_clears_query() -> None:
     state = build_initial_app_state()
@@ -4405,7 +2347,6 @@ def test_cancel_filter_input_clears_query() -> None:
     assert next_state.filter.query == ""
     assert next_state.filter.active is False
 
-
 def test_cancel_filter_input_clears_query_from_browsing() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, SetFilterQuery("readme"))
@@ -4416,7 +2357,6 @@ def test_cancel_filter_input_clears_query_from_browsing() -> None:
     assert next_state.filter.query == ""
     assert next_state.filter.active is False
 
-
 def test_copy_targets_updates_clipboard_state() -> None:
     state = build_initial_app_state()
 
@@ -4424,7 +2364,6 @@ def test_copy_targets_updates_clipboard_state() -> None:
 
     assert next_state.clipboard.mode == "copy"
     assert next_state.clipboard.paths == ("/home/tadashi/develop/zivo/docs",)
-
 
 def test_copy_targets_warns_when_empty() -> None:
     state = build_initial_app_state()
@@ -4434,7 +2373,6 @@ def test_copy_targets_warns_when_empty() -> None:
     assert next_state.notification == NotificationState(level="warning", message="Nothing to copy")
     assert next_state.clipboard.mode == "none"
 
-
 def test_cut_targets_warns_when_empty() -> None:
     state = build_initial_app_state()
 
@@ -4442,7 +2380,6 @@ def test_cut_targets_warns_when_empty() -> None:
 
     assert next_state.notification == NotificationState(level="warning", message="Nothing to cut")
     assert next_state.clipboard.mode == "none"
-
 
 def test_paste_clipboard_emits_paste_effect_and_sets_busy() -> None:
     state = _reduce_state(
@@ -4462,7 +2399,6 @@ def test_paste_clipboard_emits_paste_effect_and_sets_busy() -> None:
     )
     assert result.effects[0].request.destination_dir == "/home/tadashi/develop/zivo"
 
-
 def test_paste_clipboard_warns_when_empty() -> None:
     state = build_initial_app_state()
 
@@ -4474,12 +2410,10 @@ def test_paste_clipboard_warns_when_empty() -> None:
     )
     assert next_state.ui_mode == "BROWSING"
 
-
 def test_undo_last_operation_warns_when_stack_is_empty() -> None:
     next_state = _reduce_state(build_initial_app_state(), UndoLastOperation())
 
     assert next_state.notification == NotificationState(level="warning", message="Nothing to undo")
-
 
 def test_paste_needs_resolution_enters_confirm_mode() -> None:
     state = _reduce_state(
@@ -4508,7 +2442,6 @@ def test_paste_needs_resolution_enters_confirm_mode() -> None:
     assert next_state.ui_mode == "CONFIRM"
     assert isinstance(next_state.paste_conflict, PasteConflictState)
     assert next_state.paste_conflict.first_conflict == conflict
-
 
 def test_paste_needs_resolution_uses_configured_default_resolution() -> None:
     state = _reduce_state(
@@ -4547,7 +2480,6 @@ def test_paste_needs_resolution_uses_configured_default_resolution() -> None:
         ),
     )
 
-
 def test_paste_needs_resolution_ignores_stale_request() -> None:
     state = _reduce_state(
         build_initial_app_state(),
@@ -4573,7 +2505,6 @@ def test_paste_needs_resolution_ignores_stale_request() -> None:
     )
 
     assert next_state == requested
-
 
 def test_resolve_paste_conflict_restarts_paste_with_resolution() -> None:
     conflict = PasteConflict(
@@ -4613,7 +2544,6 @@ def test_resolve_paste_conflict_restarts_paste_with_resolution() -> None:
             ),
         ),
     )
-
 
 def test_clipboard_paste_completed_for_cut_clears_clipboard_and_requests_reload() -> None:
     state = _reduce_state(
@@ -4672,7 +2602,6 @@ def test_clipboard_paste_completed_for_cut_clears_clipboard_and_requests_reload(
         ),
     )
 
-
 def test_clipboard_paste_completed_pushes_copy_undo_entry() -> None:
     state = replace(build_initial_app_state(), pending_paste_request_id=4)
 
@@ -4703,7 +2632,6 @@ def test_clipboard_paste_completed_pushes_copy_undo_entry() -> None:
         ),
     )
 
-
 def test_clipboard_paste_completed_skips_undo_for_overwrite() -> None:
     state = replace(build_initial_app_state(), pending_paste_request_id=4)
 
@@ -4733,7 +2661,6 @@ def test_clipboard_paste_completed_skips_undo_for_overwrite() -> None:
         level="info",
         message="Copied 1 item(s), undo unavailable for overwritten items",
     )
-
 
 def test_file_mutation_completed_requests_reload_with_result_cursor() -> None:
     state = replace(
@@ -4813,7 +2740,6 @@ def test_file_mutation_completed_requests_reload_with_result_cursor() -> None:
             ),
         ),
     )
-
 
 def test_delete_file_mutation_completed_requests_reload_without_deleted_cursor() -> None:
     state = replace(
@@ -4898,7 +2824,6 @@ def test_delete_file_mutation_completed_requests_reload_without_deleted_cursor()
         ),
     )
 
-
 def test_undo_last_operation_runs_effect() -> None:
     entry = UndoEntry(kind="paste_copy", steps=(UndoDeletePathStep(path="/tmp/copied"),))
     state = replace(build_initial_app_state(), undo_stack=(entry,), next_request_id=6)
@@ -4909,7 +2834,6 @@ def test_undo_last_operation_runs_effect() -> None:
     assert result.state.pending_undo_request_id == 6
     assert result.state.ui_mode == "BUSY"
     assert result.effects == (RunUndoEffect(request_id=6, entry=entry),)
-
 
 def test_undo_completed_pops_stack_and_requests_reload() -> None:
     entry = UndoEntry(kind="paste_copy", steps=(UndoDeletePathStep(path="/tmp/copied"),))
@@ -4974,7 +2898,6 @@ def test_undo_completed_pops_stack_and_requests_reload() -> None:
         message="permission denied",
     )
 
-
 def test_file_mutation_failed_keeps_input_value_and_returns_error() -> None:
     state = replace(
         build_initial_app_state(),
@@ -4997,7 +2920,6 @@ def test_file_mutation_failed_keeps_input_value_and_returns_error() -> None:
         message="permission denied",
     )
 
-
 def test_delete_file_mutation_failed_returns_to_browsing() -> None:
     state = replace(
         build_initial_app_state(),
@@ -5012,7 +2934,6 @@ def test_delete_file_mutation_failed_returns_to_browsing() -> None:
         level="error",
         message="trash failed",
     )
-
 
 def test_clipboard_paste_failed_returns_to_browsing_and_clears_dialog_state() -> None:
     conflict = PasteConflict(
@@ -5047,7 +2968,6 @@ def test_clipboard_paste_failed_returns_to_browsing_and_clears_dialog_state() ->
     assert next_state.name_conflict is None
     assert next_state.notification == NotificationState(level="error", message="paste failed")
 
-
 def test_external_launch_failed_sets_error_notification() -> None:
     state = build_initial_app_state()
 
@@ -5064,7 +2984,6 @@ def test_external_launch_failed_sets_error_notification() -> None:
         level="error",
         message="Failed to open /tmp/zivo/README.md: permission denied",
     )
-
 
 def test_external_launch_completed_sets_copy_notification() -> None:
     state = build_initial_app_state()
@@ -5085,7 +3004,6 @@ def test_external_launch_completed_sets_copy_notification() -> None:
         message="Copied 2 paths to system clipboard",
     )
 
-
 def test_dismiss_name_conflict_restores_rename_mode_and_keeps_input() -> None:
     state = replace(
         build_initial_app_state(),
@@ -5103,7 +3021,6 @@ def test_dismiss_name_conflict_restores_rename_mode_and_keeps_input() -> None:
     assert next_state.ui_mode == "RENAME"
     assert next_state.pending_input == state.pending_input
     assert next_state.name_conflict is None
-
 
 def test_dismiss_name_conflict_restores_create_mode_and_keeps_input() -> None:
     state = replace(
@@ -5123,7 +3040,6 @@ def test_dismiss_name_conflict_restores_create_mode_and_keeps_input() -> None:
     assert next_state.pending_input == state.pending_input
     assert next_state.name_conflict is None
 
-
 def test_cancel_paste_conflict_returns_to_browsing_with_warning() -> None:
     state = replace(build_initial_app_state(), ui_mode="CONFIRM")
 
@@ -5131,7 +3047,6 @@ def test_cancel_paste_conflict_returns_to_browsing_with_warning() -> None:
 
     assert next_state.ui_mode == "BROWSING"
     assert next_state.notification == NotificationState(level="warning", message="Paste cancelled")
-
 
 def test_toggle_selection_and_advance_moves_cursor_to_next_visible_entry() -> None:
     state = build_initial_app_state()
@@ -5167,7 +3082,6 @@ def test_toggle_selection_and_advance_moves_cursor_to_next_visible_entry() -> No
             ),
         ),
     )
-
 
 def test_move_cursor_and_select_range_sets_anchor_and_selects_contiguous_entries() -> None:
     state = build_initial_app_state()
@@ -5208,7 +3122,6 @@ def test_move_cursor_and_select_range_sets_anchor_and_selects_contiguous_entries
         ),
     )
 
-
 def test_move_cursor_and_select_range_reuses_anchor_when_shrinking_selection() -> None:
     visible_paths = (
         "/home/tadashi/develop/zivo/docs",
@@ -5239,7 +3152,6 @@ def test_move_cursor_and_select_range_reuses_anchor_when_shrinking_selection() -
         }
     )
     assert result.state.current_pane.selection_anchor_path == "/home/tadashi/develop/zivo/docs"
-
 
 def test_move_cursor_clears_range_selection_anchor() -> None:
     visible_paths = (
@@ -5273,7 +3185,6 @@ def test_move_cursor_clears_range_selection_anchor() -> None:
     )
     assert result.state.current_pane.selection_anchor_path is None
 
-
 def test_request_browser_snapshot_returns_effect_and_updates_pending_request() -> None:
     state = build_initial_app_state()
 
@@ -5286,7 +3197,6 @@ def test_request_browser_snapshot_returns_effect_and_updates_pending_request() -
     assert result.effects[0].path == "/tmp/example"
     assert result.effects[0].request_id == 1
 
-
 def test_browser_snapshot_failed_ignores_stale_request() -> None:
     state = build_initial_app_state()
     requested = reduce_app_state(state, RequestBrowserSnapshot("/tmp/example")).state
@@ -5297,7 +3207,6 @@ def test_browser_snapshot_failed_ignores_stale_request() -> None:
     )
 
     assert next_state == requested
-
 
 def test_browser_snapshot_loaded_ignores_stale_request() -> None:
     state = build_initial_app_state()
@@ -5315,7 +3224,6 @@ def test_browser_snapshot_loaded_ignores_stale_request() -> None:
     )
 
     assert next_state == state
-
 
 def test_browser_snapshot_loaded_applies_snapshot_and_clears_error() -> None:
     state = build_initial_app_state()
@@ -5340,7 +3248,6 @@ def test_browser_snapshot_loaded_applies_snapshot_and_clears_error() -> None:
     assert next_state.current_path == "/tmp/example"
     assert next_state.notification is None
     assert next_state.pending_browser_snapshot_request_id is None
-
 
 def test_browser_snapshot_loaded_preserves_remaining_selection_on_reload() -> None:
     state = build_initial_app_state()
@@ -5379,7 +3286,6 @@ def test_browser_snapshot_loaded_preserves_remaining_selection_on_reload() -> No
     assert next_state.current_pane.selected_paths == frozenset(
         {"/home/tadashi/develop/zivo/docs"}
     )
-
 
 def test_browser_snapshot_loaded_clears_selection_when_directory_changes() -> None:
     state = build_initial_app_state()
@@ -5420,7 +3326,6 @@ def test_browser_snapshot_loaded_clears_selection_when_directory_changes() -> No
 
     assert next_state.current_pane.selected_paths == frozenset()
 
-
 def test_browser_snapshot_failed_sets_error_notification() -> None:
     state = build_initial_app_state()
     requested = reduce_app_state(state, RequestBrowserSnapshot("/tmp/example")).state
@@ -5435,7 +3340,6 @@ def test_browser_snapshot_failed_sets_error_notification() -> None:
         message="load failed",
     )
     assert next_state.pending_browser_snapshot_request_id is None
-
 
 def test_move_cursor_emits_child_snapshot_effect_only_when_target_changes() -> None:
     state = build_initial_app_state()
@@ -5496,7 +3400,6 @@ def test_move_cursor_emits_child_snapshot_effect_only_when_target_changes() -> N
         ),
     )
 
-
 def test_set_cursor_path_to_file_requests_child_pane_preview() -> None:
     state = build_initial_app_state()
 
@@ -5519,7 +3422,6 @@ def test_set_cursor_path_to_file_requests_child_pane_preview() -> None:
             ),
         ),
     )
-
 
 def test_set_cursor_path_to_file_clears_child_pane_when_preview_disabled() -> None:
     state = replace(
@@ -5555,7 +3457,6 @@ def test_set_cursor_path_to_file_clears_child_pane_when_preview_disabled() -> No
         ),
     )
 
-
 def test_child_pane_snapshot_loaded_ignores_stale_request() -> None:
     state = build_initial_app_state()
     requested = reduce_app_state(state, SetCursorPath("/home/tadashi/develop/zivo/src")).state
@@ -5569,7 +3470,6 @@ def test_child_pane_snapshot_loaded_ignores_stale_request() -> None:
     )
 
     assert next_state == requested
-
 
 def test_child_pane_snapshot_loaded_clears_grep_preview_when_file_preview_disabled() -> None:
     path = "/home/tadashi/develop/zivo/README.md"
@@ -5605,7 +3505,6 @@ def test_child_pane_snapshot_loaded_clears_grep_preview_when_file_preview_disabl
     )
     assert next_state.pending_child_pane_request_id is None
 
-
 def test_child_pane_snapshot_failed_ignores_stale_request() -> None:
     state = build_initial_app_state()
     requested = reduce_app_state(state, SetCursorPath("/home/tadashi/develop/zivo/src")).state
@@ -5616,7 +3515,6 @@ def test_child_pane_snapshot_failed_ignores_stale_request() -> None:
     )
 
     assert next_state == requested
-
 
 def test_child_pane_snapshot_failure_sets_error_and_clears_entries() -> None:
     state = build_initial_app_state()
@@ -5670,7 +3568,6 @@ class TestSetTerminalHeight:
 
         assert next_state is state
 
-
 def test_jump_cursor_start() -> None:
     state = build_initial_app_state()
     visible_paths = (
@@ -5690,7 +3587,6 @@ def test_jump_cursor_start() -> None:
             cursor_path="/home/tadashi/develop/zivo/docs",
         ),
     )
-
 
 def test_jump_cursor_end() -> None:
     state = build_initial_app_state()
@@ -5719,7 +3615,6 @@ def test_jump_cursor_end() -> None:
         ),
     )
 
-
 def test_jump_cursor_end_repositions_viewport_window() -> None:
     path = "/tmp/zivo-viewport-jump"
     entries = _viewport_test_entries(path, 20)
@@ -5740,14 +3635,12 @@ def test_jump_cursor_end_repositions_viewport_window() -> None:
     assert result.state.current_pane.cursor_path == entries[-1].path
     assert result.state.current_pane_window_start == 15
 
-
 def test_jump_cursor_empty_paths() -> None:
     state = build_initial_app_state()
 
     result = reduce_app_state(state, JumpCursor(position="start", visible_paths=()))
 
     assert result.state is state
-
 
 def test_jump_cursor_with_filter() -> None:
     state = build_initial_app_state()
@@ -5763,7 +3656,6 @@ def test_jump_cursor_with_filter() -> None:
     )
 
     assert result.state.current_pane.cursor_path == "/home/tadashi/develop/zivo/src"
-
 
 def test_move_cursor_page_down_repositions_viewport_window() -> None:
     path = "/tmp/zivo-viewport-page"
@@ -5785,7 +3677,6 @@ def test_move_cursor_page_down_repositions_viewport_window() -> None:
     assert result.state.current_pane.cursor_path == entries[5].path
     assert result.state.current_pane_window_start == 2
 
-
 def test_set_filter_query_resets_viewport_window_when_cursor_leaves_visible_entries() -> None:
     path = "/tmp/zivo-viewport-filter"
     entries = _viewport_test_entries(path, 20)
@@ -5805,7 +3696,6 @@ def test_set_filter_query_resets_viewport_window_when_cursor_leaves_visible_entr
 
     assert next_state.filter.query == "item_0"
     assert next_state.current_pane_window_start == 0
-
 
 def test_toggle_hidden_files_clamps_viewport_window_start() -> None:
     path = "/tmp/zivo-viewport-hidden"
@@ -5828,7 +3718,6 @@ def test_toggle_hidden_files_clamps_viewport_window_start() -> None:
     assert next_state.show_hidden is False
     assert next_state.current_pane.cursor_path == entries[0].path
     assert next_state.current_pane_window_start == 0
-
 
 def test_set_sort_keeps_cursor_visible_when_viewport_order_changes() -> None:
     path = "/tmp/zivo-viewport-sort"
@@ -5853,14 +3742,12 @@ def test_set_sort_keeps_cursor_visible_when_viewport_order_changes() -> None:
     assert next_state.current_pane.cursor_path == entries[0].path
     assert next_state.current_pane_window_start == 15
 
-
 def test_go_back_does_nothing_when_back_stack_is_empty() -> None:
     state = build_initial_app_state()
 
     result = reduce_app_state(state, GoBack())
 
     assert result.state == state
-
 
 def test_go_back_requests_snapshot_from_back_stack() -> None:
     state = replace(
@@ -5878,14 +3765,12 @@ def test_go_back_requests_snapshot_from_back_stack() -> None:
     assert len(result.effects) == 1
     assert result.effects[0].path == "/home/tadashi/downloads"
 
-
 def test_go_forward_does_nothing_when_forward_stack_is_empty() -> None:
     state = build_initial_app_state()
 
     result = reduce_app_state(state, GoForward())
 
     assert result.state == state
-
 
 def test_go_forward_requests_snapshot_from_forward_stack() -> None:
     state = replace(
@@ -5902,7 +3787,6 @@ def test_go_forward_requests_snapshot_from_forward_stack() -> None:
     assert result.state.ui_mode == "BUSY"
     assert len(result.effects) == 1
     assert result.effects[0].path == "/home/tadashi/downloads"
-
 
 def test_browser_snapshot_loaded_records_history_on_path_change() -> None:
     state = build_initial_app_state()
@@ -5929,7 +3813,6 @@ def test_browser_snapshot_loaded_records_history_on_path_change() -> None:
     assert next_state.history.back == (initial_path,)
     assert next_state.history.forward == ()
     assert next_state.history.visited_all == (initial_path, "/tmp/example")
-
 
 def test_browser_snapshot_loaded_clears_forward_on_new_navigation() -> None:
     initial_path = build_initial_app_state().current_path
@@ -5961,7 +3844,6 @@ def test_browser_snapshot_loaded_clears_forward_on_new_navigation() -> None:
     assert next_state.history.forward == ()
     assert next_state.history.back == ("/home/tadashi", initial_path)
 
-
 def test_browser_snapshot_loaded_does_not_record_history_on_reload() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, RequestBrowserSnapshot(state.current_path))
@@ -5984,7 +3866,6 @@ def test_browser_snapshot_loaded_does_not_record_history_on_reload() -> None:
 
     assert next_state.history.back == ()
     assert next_state.history.forward == ()
-
 
 def test_go_back_then_snapshot_loaded_updates_history_correctly() -> None:
     initial_path = "/home/tadashi"
@@ -6022,7 +3903,6 @@ def test_go_back_then_snapshot_loaded_updates_history_correctly() -> None:
     assert loaded_result.history.back == ()
     assert loaded_result.history.forward == (second_path,)
 
-
 def test_go_forward_then_snapshot_loaded_updates_history_correctly() -> None:
     initial_path = "/home/tadashi"
     forward_path = "/home/tadashi/develop"
@@ -6058,7 +3938,6 @@ def test_go_forward_then_snapshot_loaded_updates_history_correctly() -> None:
     assert loaded_result.current_path == forward_path
     assert loaded_result.history.back == (initial_path,)
     assert loaded_result.history.forward == ()
-
 
 def test_all_visited_directories_enumerable() -> None:
     state = build_initial_app_state()
@@ -6105,7 +3984,6 @@ def test_all_visited_directories_enumerable() -> None:
         "/tmp/first",
         "/tmp/second",
     )
-
 
 def test_history_search_deduplicates_duplicates() -> None:
     state = build_initial_app_state()
@@ -6169,7 +4047,6 @@ def test_history_search_deduplicates_duplicates() -> None:
         "/tmp/second",
     )
 
-
 def test_browser_snapshot_loaded_clears_filter_when_directory_changes() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, SetFilterQuery("readme"))
@@ -6191,7 +4068,6 @@ def test_browser_snapshot_loaded_clears_filter_when_directory_changes() -> None:
 
     assert next_state.filter.query == ""
     assert next_state.filter.active is False
-
 
 def test_browser_snapshot_loaded_preserves_filter_on_reload() -> None:
     state = build_initial_app_state()
@@ -6215,7 +4091,6 @@ def test_browser_snapshot_loaded_preserves_filter_on_reload() -> None:
 
     assert next_state.filter.query == "readme"
     assert next_state.filter.active is True
-
 
 def test_browser_snapshot_loaded_exits_filter_mode_on_directory_change() -> None:
     state = build_initial_app_state()
@@ -6241,7 +4116,6 @@ def test_browser_snapshot_loaded_exits_filter_mode_on_directory_change() -> None
     assert next_state.filter.query == ""
     assert next_state.filter.active is False
 
-
 def test_move_cursor_by_page_down() -> None:
     state = build_initial_app_state()
     visible_paths = (
@@ -6265,7 +4139,6 @@ def test_move_cursor_by_page_down() -> None:
             cursor_path="/home/tadashi/develop/zivo/README.md",
         ),
     )
-
 
 def test_move_cursor_by_page_up() -> None:
     state = build_initial_app_state()
@@ -6291,7 +4164,6 @@ def test_move_cursor_by_page_up() -> None:
         ),
     )
 
-
 def test_move_cursor_by_page_down_clamps_to_last_entry() -> None:
     state = build_initial_app_state()
     visible_paths = (
@@ -6306,7 +4178,6 @@ def test_move_cursor_by_page_down_clamps_to_last_entry() -> None:
     )
 
     assert result.state.current_pane.cursor_path == "/home/tadashi/develop/zivo/tests"
-
 
 def test_move_cursor_by_page_up_clamps_to_first_entry() -> None:
     state = build_initial_app_state()
@@ -6323,7 +4194,6 @@ def test_move_cursor_by_page_up_clamps_to_first_entry() -> None:
 
     assert result.state.current_pane.cursor_path == "/home/tadashi/develop/zivo/docs"
 
-
 def test_move_cursor_by_page_empty_paths() -> None:
     state = build_initial_app_state()
 
@@ -6333,7 +4203,6 @@ def test_move_cursor_by_page_empty_paths() -> None:
 
     assert result.state is state
     assert result.effects == ()
-
 
 def test_open_new_tab_clones_path_but_resets_filter_and_selection() -> None:
     state = replace(
@@ -6359,7 +4228,6 @@ def test_open_new_tab_clones_path_but_resets_filter_and_selection() -> None:
         {"/home/tadashi/develop/zivo/docs"}
     )
 
-
 def test_activate_tabs_restores_per_tab_filter_state() -> None:
     state = _reduce_state(build_initial_app_state(), OpenNewTab())
     state = _reduce_state(state, SetFilterQuery("read"))
@@ -6372,7 +4240,6 @@ def test_activate_tabs_restores_per_tab_filter_state() -> None:
     assert state.active_tab_index == 1
     assert state.filter.query == "read"
 
-
 def test_close_current_tab_warns_when_only_one_tab_remains() -> None:
     next_state = _reduce_state(build_initial_app_state(), CloseCurrentTab())
 
@@ -6380,7 +4247,6 @@ def test_close_current_tab_warns_when_only_one_tab_remains() -> None:
         level="warning",
         message="Cannot close the last tab",
     )
-
 
 def test_browser_snapshot_loaded_updates_inactive_tab_only() -> None:
     state = _reduce_state(build_initial_app_state(), OpenNewTab())
@@ -6419,7 +4285,6 @@ def test_browser_snapshot_loaded_updates_inactive_tab_only() -> None:
     loaded = _reduce_state(loaded, ActivateNextTab())
     assert loaded.current_path == "/tmp/project"
 
-
 def test_begin_empty_trash_enters_confirm_mode(monkeypatch) -> None:
     monkeypatch.setattr("platform.system", lambda: "Darwin")
 
@@ -6432,7 +4297,6 @@ def test_begin_empty_trash_enters_confirm_mode(monkeypatch) -> None:
     assert next_state.empty_trash_confirmation.platform == "darwin"
     assert next_state.command_palette is None
     assert next_state.pending_input is None
-
 
 def test_cancel_empty_trash_confirmation_returns_to_browsing() -> None:
     state = replace(
@@ -6447,7 +4311,6 @@ def test_cancel_empty_trash_confirmation_returns_to_browsing() -> None:
     assert next_state.empty_trash_confirmation is None
     assert next_state.notification is None
 
-
 def test_set_pending_key_sequence_updates_state() -> None:
     state = build_initial_app_state()
 
@@ -6460,22 +4323,6 @@ def test_set_pending_key_sequence_updates_state() -> None:
         keys=("y",),
         possible_next_keys=("y",),
     )
-
-
-def test_begin_command_palette_clears_pending_key_sequence() -> None:
-    state = replace(
-        build_initial_app_state(),
-        pending_key_sequence=PendingKeySequenceState(
-            keys=("y",),
-            possible_next_keys=("y",),
-        ),
-    )
-
-    next_state = _reduce_state(state, BeginCommandPalette())
-
-    assert next_state.ui_mode == "PALETTE"
-    assert next_state.pending_key_sequence is None
-
 
 def test_confirm_empty_trash_shows_notification_on_success(monkeypatch) -> None:
     from unittest.mock import MagicMock
@@ -6515,7 +4362,6 @@ def test_confirm_empty_trash_shows_notification_on_success(monkeypatch) -> None:
     assert next_state.notification is not None
     assert next_state.notification.level == "info"
 
-
 def test_submit_pending_input_case_only_rename_emits_mutation() -> None:
     """Case-only rename (docs -> Docs) should proceed, not show 'Name unchanged'."""
     state = replace(
@@ -6541,7 +4387,6 @@ def test_submit_pending_input_case_only_rename_emits_mutation() -> None:
         ),
     )
 
-
 def test_submit_pending_input_case_insensitive_conflict_on_macos(monkeypatch) -> None:
     """On macOS, renaming to a case-different existing name should conflict."""
     import zivo.state.reducer_common as rc
@@ -6561,7 +4406,6 @@ def test_submit_pending_input_case_insensitive_conflict_on_macos(monkeypatch) ->
 
     assert result.state.ui_mode == "CONFIRM"
     assert result.state.name_conflict == NameConflictState(kind="rename", name="Src")
-
 
 def test_submit_pending_input_case_sensitive_no_conflict_on_linux(monkeypatch) -> None:
     """On Linux, renaming to a case-different existing name should NOT conflict."""
@@ -6583,7 +4427,6 @@ def test_submit_pending_input_case_sensitive_no_conflict_on_linux(monkeypatch) -
     assert result.state.ui_mode == "BUSY"
     assert result.effects != ()
 
-
 def test_submit_pending_input_rejects_colon_in_name_on_macos(monkeypatch) -> None:
     """On macOS, names containing ':' should be rejected."""
     import zivo.state.reducer_common as rc
@@ -6604,7 +4447,6 @@ def test_submit_pending_input_rejects_colon_in_name_on_macos(monkeypatch) -> Non
     assert next_state.notification is not None
     assert next_state.notification.level == "error"
     assert "colons" in next_state.notification.message
-
 
 def test_submit_pending_input_allows_colon_in_name_on_linux(monkeypatch) -> None:
     """On Linux, names containing ':' should not be rejected."""
@@ -6632,896 +4474,3 @@ def test_submit_pending_input_allows_colon_in_name_on_linux(monkeypatch) -> None
 # Find-and-replace (replace_in_found_files) tests
 # ---------------------------------------------------------------------------
 
-
-def test_begin_find_and_replace_enters_rff_mode() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    assert state.ui_mode == "PALETTE"
-    assert state.command_palette is not None
-    assert state.command_palette.source == "replace_in_found_files"
-    assert state.command_palette.rff_active_field == "filename"
-
-
-def test_set_rff_filename_field_starts_file_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    result = reduce_app_state(state, SetFindReplaceField(field="filename", value="readme"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.rff_filename_query == "readme"
-    assert result.state.pending_file_search_request_id == 1
-    assert result.effects == (
-        RunFileSearchEffect(
-            request_id=1,
-            root_path="/home/tadashi/develop/zivo",
-            query="readme",
-            show_hidden=False,
-        ),
-    )
-
-
-def test_set_rff_filename_clear_triggers_no_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    result = reduce_app_state(
-        state,
-        SetFindReplaceField(field="filename", value=""),
-    )
-
-    assert result.state.command_palette is not None
-    assert result.state.pending_file_search_request_id is None
-    assert result.effects == ()
-
-
-def test_set_rff_find_field_with_file_results_starts_preview() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            rff_filename_query="readme",
-            rff_file_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    result = reduce_app_state(state, SetFindReplaceField(field="find", value="todo"))
-
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.rff_find_text == "todo"
-    assert result.state.pending_replace_preview_request_id == 1
-    assert result.effects == (
-        RunTextReplacePreviewEffect(
-            request_id=1,
-            request=TextReplaceRequest(
-                paths=("/home/tadashi/develop/zivo/README.md",),
-                find_text="todo",
-                replace_text="",
-            ),
-        ),
-    )
-
-
-def test_set_rff_find_field_without_file_results_no_preview() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    result = reduce_app_state(state, SetFindReplaceField(field="find", value="todo"))
-
-    assert result.state.command_palette is not None
-    assert result.state.pending_replace_preview_request_id is None
-    assert result.effects == ()
-
-
-def test_cycle_find_replace_field_cycles_through_three_fields() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    assert state.command_palette is not None
-    assert state.command_palette.rff_active_field == "filename"
-
-    state = _reduce_state(state, CycleFindReplaceField(delta=1))
-    assert state.command_palette is not None
-    assert state.command_palette.rff_active_field == "find"
-
-    state = _reduce_state(state, CycleFindReplaceField(delta=1))
-    assert state.command_palette is not None
-    assert state.command_palette.rff_active_field == "replace"
-
-    state = _reduce_state(state, CycleFindReplaceField(delta=1))
-    assert state.command_palette is not None
-    assert state.command_palette.rff_active_field == "filename"
-
-
-def test_cycle_find_replace_field_reverse() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    state = _reduce_state(state, CycleFindReplaceField(delta=-1))
-    assert state.command_palette is not None
-    assert state.command_palette.rff_active_field == "replace"
-
-
-def test_rff_file_search_completed_stores_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-    state = replace(
-        state,
-        pending_file_search_request_id=3,
-        command_palette=replace(
-            state.command_palette,
-            rff_filename_query="readme",
-        ),
-    )
-
-    next_state = _reduce_state(
-        state,
-        FileSearchCompleted(
-            request_id=3,
-            query="readme",
-            results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.rff_file_results == (
-        FileSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-        ),
-    )
-    assert next_state.pending_file_search_request_id is None
-
-
-def test_rff_file_search_completed_auto_triggers_preview_when_find_text_present() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-    state = replace(
-        state,
-        pending_file_search_request_id=3,
-        command_palette=replace(
-            state.command_palette,
-            rff_filename_query="readme",
-            rff_find_text="todo",
-        ),
-    )
-
-    result = reduce_app_state(
-        state,
-        FileSearchCompleted(
-            request_id=3,
-            query="readme",
-            results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    assert result.state.pending_replace_preview_request_id is not None
-    assert len(result.effects) == 1
-    assert isinstance(result.effects[0], RunTextReplacePreviewEffect)
-
-
-def test_rff_preview_completed_stores_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-    state = replace(
-        state,
-        pending_replace_preview_request_id=4,
-        command_palette=replace(
-            state.command_palette,
-            rff_find_text="todo",
-            rff_replacement_text="done",
-            rff_file_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    next_state = _reduce_state(
-        state,
-        TextReplacePreviewCompleted(
-            request_id=4,
-            result=TextReplacePreviewResult(
-                request=TextReplaceRequest(
-                    paths=("/home/tadashi/develop/zivo/README.md",),
-                    find_text="todo",
-                    replace_text="done",
-                ),
-                changed_entries=(
-                    TextReplacePreviewEntry(
-                        path="/home/tadashi/develop/zivo/README.md",
-                        diff_text="-todo\n+done",
-                        match_count=1,
-                        first_match_line_number=5,
-                        first_match_before="todo",
-                        first_match_after="done",
-                    ),
-                ),
-                total_match_count=1,
-                diff_text="-todo\n+done",
-            ),
-        ),
-    )
-
-    assert next_state.command_palette is not None
-    assert next_state.command_palette.rff_total_match_count == 1
-    assert len(next_state.command_palette.rff_preview_results) == 1
-    assert next_state.command_palette.rff_preview_results[0].display_path == "README.md"
-    assert next_state.child_pane.preview_title == "Replace Preview"
-    assert next_state.pending_replace_preview_request_id is None
-
-
-def test_submit_rff_palette_warns_when_no_find_text() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.notification == NotificationState(
-        level="warning",
-        message="Find text is required",
-    )
-
-
-def test_submit_rff_palette_warns_when_no_preview_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            rff_find_text="todo",
-            rff_file_results=(
-                FileSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                ),
-            ),
-        ),
-    )
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.notification is not None
-    assert result.state.notification.level == "warning"
-
-
-def test_cancel_rff_returns_to_browsing() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
-    assert state.ui_mode == "PALETTE"
-
-    state = _reduce_state(state, CancelCommandPalette())
-    assert state.ui_mode == "BROWSING"
-    assert state.command_palette is None
-
-
-# ---------------------------------------------------------------------------
-# Grep replace (grf) tests
-# ---------------------------------------------------------------------------
-
-
-def test_begin_grep_replace_enters_grf_mode() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    assert state.ui_mode == "PALETTE"
-    assert state.command_palette is not None
-    assert state.command_palette.source == "replace_in_grep_files"
-    assert state.command_palette.grf_active_field == "keyword"
-
-
-def test_set_grf_keyword_field_starts_grep_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    result = reduce_app_state(state, SetGrepReplaceField(field="keyword", value="todo"))
-
-    assert result.state.pending_grep_search_request_id is not None
-    assert result.state.command_palette.grf_keyword == "todo"
-    effects = [e for e in result.effects if isinstance(e, RunGrepSearchEffect)]
-    assert len(effects) == 1
-    assert effects[0].query == "todo"
-
-
-def test_set_grf_keyword_clear_triggers_no_search() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = _reduce_state(state, SetGrepReplaceField(field="keyword", value="todo"))
-    result = reduce_app_state(state, SetGrepReplaceField(field="keyword", value=""))
-
-    assert result.state.pending_grep_search_request_id is None
-    assert result.state.command_palette.grf_grep_results == ()
-
-
-def test_set_grf_replace_field_with_grep_results_starts_preview() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_keyword="todo",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-    )
-    result = reduce_app_state(state, SetGrepReplaceField(field="replace", value="done"))
-
-    assert result.state.pending_replace_preview_request_id is not None
-    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
-    assert len(effects) == 1
-    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/README.md",)
-    assert effects[0].request.find_text == "todo"
-
-
-def test_set_grf_replace_field_without_grep_results_no_preview() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    result = reduce_app_state(state, SetGrepReplaceField(field="replace", value="done"))
-
-    assert result.state.pending_replace_preview_request_id is None
-    assert result.state.command_palette.grf_preview_results == ()
-
-
-def test_grf_grep_search_completed_stores_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(state.command_palette, grf_keyword="todo"),
-        pending_grep_search_request_id=10,
-        next_request_id=11,
-    )
-    results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-            line_number=1,
-            line_text="todo item",
-        ),
-    )
-    result = reduce_app_state(
-        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
-    )
-
-    assert result.state.command_palette.grf_grep_results == results
-    assert result.state.pending_grep_search_request_id is None
-
-
-def test_grf_grep_search_completed_auto_triggers_preview_when_replace_text_present() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-        ),
-        pending_grep_search_request_id=10,
-        next_request_id=11,
-    )
-    results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-            line_number=1,
-            line_text="todo item",
-        ),
-    )
-    result = reduce_app_state(
-        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
-    )
-
-    assert result.state.command_palette.grf_grep_results == results
-    assert result.state.pending_replace_preview_request_id is not None
-    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
-    assert len(effects) == 1
-
-
-def test_grf_preview_completed_stores_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-        pending_replace_preview_request_id=10,
-        next_request_id=11,
-    )
-    preview_result = TextReplacePreviewResult(
-        request=TextReplaceRequest(
-            paths=("/home/tadashi/develop/zivo/README.md",),
-            find_text="todo",
-            replace_text="done",
-        ),
-        changed_entries=(
-            TextReplacePreviewEntry(
-                path="/home/tadashi/develop/zivo/README.md",
-                diff_text="- todo + done",
-                match_count=1,
-                first_match_line_number=1,
-                first_match_before="todo",
-                first_match_after="done",
-            ),
-        ),
-        total_match_count=1,
-        skipped_paths=(),
-    )
-    result = reduce_app_state(
-        state, TextReplacePreviewCompleted(request_id=10, result=preview_result)
-    )
-
-    assert len(result.state.command_palette.grf_preview_results) == 1
-    assert result.state.command_palette.grf_total_match_count == 1
-    assert result.state.pending_replace_preview_request_id is None
-
-
-def test_submit_grf_palette_warns_when_no_replace_text() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_keyword="todo",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-    )
-    result = reduce_app_state(state, SubmitCommandPalette())
-    assert result.state.notification is not None
-    assert result.state.notification.level == "warning"
-
-
-def test_submit_grf_palette_warns_when_no_preview_results() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-    )
-    result = reduce_app_state(state, SubmitCommandPalette())
-    assert result.state.notification is not None
-    assert result.state.notification.level == "warning"
-
-
-def test_cancel_grf_returns_to_browsing() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    assert state.ui_mode == "PALETTE"
-
-    state = _reduce_state(state, CancelCommandPalette())
-    assert state.ui_mode == "BROWSING"
-    assert state.command_palette is None
-
-
-def test_submit_command_palette_begins_grep_replace() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
-    state = _reduce_state(state, SetCommandPaletteQuery(query="replace text in grep"))
-
-    result = reduce_app_state(state, SubmitCommandPalette())
-    assert result.state.command_palette is not None
-    assert result.state.command_palette.source == "replace_in_grep_files"
-
-
-def test_grf_grep_search_completed_deduplicates_file_paths() -> None:
-    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-        ),
-        pending_grep_search_request_id=10,
-        next_request_id=11,
-    )
-    results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-            line_number=1,
-            line_text="todo item 1",
-        ),
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/README.md",
-            display_path="README.md",
-            line_number=5,
-            line_text="todo item 2",
-        ),
-    )
-    result = reduce_app_state(
-        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
-    )
-
-    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
-    assert len(effects) == 1
-    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/README.md",)
-
-
-# ---------------------------------------------------------------------------
-# Grep replace selected (grs) tests
-# ---------------------------------------------------------------------------
-
-
-def test_begin_grep_replace_selected_enters_grs_mode() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(
-            target_paths=("/home/tadashi/develop/zivo/a.py", "/home/tadashi/develop/zivo/b.py")
-        ),
-    )
-    assert state.ui_mode == "PALETTE"
-    assert state.command_palette is not None
-    assert state.command_palette.source == "grep_replace_selected"
-    assert state.command_palette.grs_active_field == "keyword"
-    assert state.command_palette.grs_target_paths == (
-        "/home/tadashi/develop/zivo/a.py",
-        "/home/tadashi/develop/zivo/b.py",
-    )
-
-
-def test_set_grs_keyword_field_starts_grep_search() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    result = reduce_app_state(
-        state, SetGrepReplaceSelectedField(field="keyword", value="todo")
-    )
-
-    assert result.state.pending_grep_search_request_id is not None
-    assert result.state.command_palette.grs_keyword == "todo"
-    effects = [e for e in result.effects if isinstance(e, RunGrepSearchEffect)]
-    assert len(effects) == 1
-    assert effects[0].query == "todo"
-
-
-def test_set_grs_keyword_clear_triggers_no_search() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = _reduce_state(state, SetGrepReplaceSelectedField(field="keyword", value="todo"))
-    result = reduce_app_state(state, SetGrepReplaceSelectedField(field="keyword", value=""))
-
-    assert result.state.pending_grep_search_request_id is None
-    assert result.state.command_palette.grs_grep_results == ()
-
-
-def test_grs_grep_search_completed_filters_to_target_paths() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(
-            target_paths=("/home/tadashi/develop/zivo/a.py", "/home/tadashi/develop/zivo/c.py")
-        ),
-    )
-    state = replace(
-        state,
-        command_palette=replace(state.command_palette, grs_keyword="todo"),
-        pending_grep_search_request_id=10,
-        next_request_id=11,
-    )
-    all_results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/a.py",
-            display_path="a.py",
-            line_number=1,
-            line_text="todo in a",
-        ),
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/b.py",
-            display_path="b.py",
-            line_number=3,
-            line_text="todo in b",
-        ),
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/c.py",
-            display_path="c.py",
-            line_number=5,
-            line_text="todo in c",
-        ),
-    )
-    result = reduce_app_state(
-        state, GrepSearchCompleted(request_id=10, query="todo", results=all_results)
-    )
-
-    assert len(result.state.command_palette.grs_grep_results) == 2
-    assert result.state.command_palette.grs_grep_results[0].path == (
-        "/home/tadashi/develop/zivo/a.py"
-    )
-    assert result.state.command_palette.grs_grep_results[1].path == (
-        "/home/tadashi/develop/zivo/c.py"
-    )
-    assert result.state.pending_grep_search_request_id is None
-
-
-def test_grs_grep_search_completed_auto_triggers_preview_when_replace_text_present() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_keyword="todo",
-            grs_replacement_text="done",
-        ),
-        pending_grep_search_request_id=10,
-        next_request_id=11,
-    )
-    results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/a.py",
-            display_path="a.py",
-            line_number=1,
-            line_text="todo item",
-        ),
-    )
-    result = reduce_app_state(
-        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
-    )
-
-    assert result.state.command_palette.grs_grep_results == results
-    assert result.state.pending_replace_preview_request_id is not None
-    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
-    assert len(effects) == 1
-    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/a.py",)
-
-
-def test_set_grs_replace_field_with_grep_results_starts_preview() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_keyword="todo",
-            grs_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/a.py",
-                    display_path="a.py",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-    )
-    result = reduce_app_state(
-        state, SetGrepReplaceSelectedField(field="replace", value="done")
-    )
-
-    assert result.state.pending_replace_preview_request_id is not None
-    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
-    assert len(effects) == 1
-    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/a.py",)
-    assert effects[0].request.find_text == "todo"
-
-
-def test_set_grs_replace_field_without_grep_results_no_preview() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    result = reduce_app_state(
-        state, SetGrepReplaceSelectedField(field="replace", value="done")
-    )
-
-    assert result.state.pending_replace_preview_request_id is None
-    assert result.state.command_palette.grs_preview_results == ()
-
-
-def test_grs_preview_completed_stores_results() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_keyword="todo",
-            grs_replacement_text="done",
-            grs_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/a.py",
-                    display_path="a.py",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-        pending_replace_preview_request_id=10,
-        next_request_id=11,
-    )
-    preview_result = TextReplacePreviewResult(
-        request=TextReplaceRequest(
-            paths=("/home/tadashi/develop/zivo/a.py",),
-            find_text="todo",
-            replace_text="done",
-        ),
-        changed_entries=(
-            TextReplacePreviewEntry(
-                path="/home/tadashi/develop/zivo/a.py",
-                diff_text="- todo + done",
-                match_count=1,
-                first_match_line_number=1,
-                first_match_before="todo",
-                first_match_after="done",
-            ),
-        ),
-        total_match_count=1,
-        skipped_paths=(),
-    )
-    result = reduce_app_state(
-        state, TextReplacePreviewCompleted(request_id=10, result=preview_result)
-    )
-
-    assert len(result.state.command_palette.grs_preview_results) == 1
-    assert result.state.command_palette.grs_total_match_count == 1
-    assert result.state.pending_replace_preview_request_id is None
-
-
-def test_submit_grs_palette_applies_replacement() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_keyword="todo",
-            grs_replacement_text="done",
-            grs_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/a.py",
-                    display_path="a.py",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-            grs_preview_results=(
-                ReplacePreviewResultState(
-                    path="/home/tadashi/develop/zivo/a.py",
-                    display_path="a.py",
-                    diff_text="- todo + done",
-                    match_count=1,
-                    first_match_line_number=1,
-                    first_match_before="todo",
-                    first_match_after="done",
-                ),
-            ),
-            grs_total_match_count=1,
-        ),
-    )
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    effects = [e for e in result.effects if isinstance(e, RunTextReplaceApplyEffect)]
-    assert len(effects) == 1
-    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/a.py",)
-    assert effects[0].request.find_text == "todo"
-    assert effects[0].request.replace_text == "done"
-    assert result.state.command_palette is None
-
-
-def test_submit_grs_palette_warns_when_no_keyword() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.notification is not None
-    assert result.state.notification.level == "warning"
-
-
-def test_submit_grs_palette_warns_when_no_preview_results() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = replace(
-        state,
-        command_palette=replace(
-            state.command_palette,
-            grs_keyword="todo",
-            grs_replacement_text="done",
-            grs_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/a.py",
-                    display_path="a.py",
-                    line_number=1,
-                    line_text="todo item",
-                ),
-            ),
-        ),
-    )
-    result = reduce_app_state(state, SubmitCommandPalette())
-
-    assert result.state.notification is not None
-    assert result.state.notification.level == "warning"
-
-
-def test_cancel_grs_returns_to_browsing() -> None:
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    assert state.ui_mode == "PALETTE"
-
-    state = _reduce_state(state, CancelCommandPalette())
-    assert state.ui_mode == "BROWSING"
-    assert state.command_palette is None
-
-
-def test_grs_grep_search_completed_filters_non_target_results() -> None:
-    """Verify that grep results not in target_paths are excluded."""
-    state = _reduce_state(
-        build_initial_app_state(),
-        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
-    )
-    state = replace(
-        state,
-        command_palette=replace(state.command_palette, grs_keyword="todo"),
-        pending_grep_search_request_id=10,
-        next_request_id=11,
-    )
-    all_results = (
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/a.py",
-            display_path="a.py",
-            line_number=1,
-            line_text="todo in a",
-        ),
-        GrepSearchResultState(
-            path="/home/tadashi/develop/zivo/b.py",
-            display_path="b.py",
-            line_number=3,
-            line_text="todo in b",
-        ),
-    )
-    result = reduce_app_state(
-        state, GrepSearchCompleted(request_id=10, query="todo", results=all_results)
-    )
-
-    assert len(result.state.command_palette.grs_grep_results) == 1
-    assert result.state.command_palette.grs_grep_results[0].path == (
-        "/home/tadashi/develop/zivo/a.py"
-    )
-    # Preview is triggered even with empty replace text to show find matches
-    assert result.state.pending_replace_preview_request_id is not None

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -1,0 +1,806 @@
+from dataclasses import replace
+from pathlib import Path
+
+from tests.state_test_helpers import reduce_state
+from zivo.models import (
+    AppConfig,
+    BookmarkConfig,
+    ExternalLaunchRequest,
+)
+from zivo.state import (
+    AttributeInspectionState,
+    BeginBookmarkSearch,
+    BeginCommandPalette,
+    BeginGoToPath,
+    BeginHistorySearch,
+    CancelCommandPalette,
+    CommandPaletteState,
+    ConfigEditorState,
+    DirectoryEntryState,
+    DismissAttributeDialog,
+    HistoryState,
+    LoadBrowserSnapshotEffect,
+    MoveCommandPaletteCursor,
+    NotificationState,
+    PaneState,
+    PendingInputState,
+    PendingKeySequenceState,
+    RunConfigSaveEffect,
+    RunExternalLaunchEffect,
+    SetCommandPaletteQuery,
+    SetCursorPath,
+    ShowAttributes,
+    StartSplitTerminalEffect,
+    SubmitCommandPalette,
+    build_initial_app_state,
+    reduce_app_state,
+)
+
+
+def _reduce_state(state, action):
+    return reduce_state(state, action)
+
+
+def _viewport_test_entries(
+    path: str,
+    count: int,
+    *,
+    hidden_indexes: frozenset[int] = frozenset(),
+) -> tuple[DirectoryEntryState, ...]:
+    return tuple(
+        DirectoryEntryState(
+            f"{path}/item_{index:02d}",
+            f"item_{index:02d}",
+            "file",
+            hidden=index in hidden_indexes,
+        )
+        for index in range(count)
+    )
+
+
+def test_begin_command_palette_sets_mode_and_empty_query() -> None:
+    state = build_initial_app_state()
+
+    next_state = _reduce_state(state, BeginCommandPalette())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.query == ""
+    assert next_state.command_palette.cursor_index == 0
+
+def test_begin_command_palette_keeps_current_cursor_path() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        SetCursorPath("/home/tadashi/develop/zivo/tests"),
+    )
+
+    next_state = _reduce_state(state, BeginCommandPalette())
+
+    assert next_state.current_pane.cursor_path == "/home/tadashi/develop/zivo/tests"
+
+def test_move_command_palette_cursor_clamps_to_visible_commands() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+
+    next_state = _reduce_state(state, MoveCommandPaletteCursor(delta=20))
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.cursor_index == 20
+
+def test_set_command_palette_query_resets_cursor() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, MoveCommandPaletteCursor(delta=3))
+
+    next_state = _reduce_state(state, SetCommandPaletteQuery("dir"))
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.query == "dir"
+    assert next_state.command_palette.cursor_index == 0
+
+def test_submit_command_palette_runs_create_file_flow() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("create file"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "CREATE"
+    assert next_state.command_palette is None
+    assert next_state.pending_input == PendingInputState(
+        prompt="New file: ",
+        value="",
+        create_kind="file",
+    )
+
+def test_submit_command_palette_begins_extract_archive_flow() -> None:
+    archive_path = "/home/tadashi/develop/zivo/archive.zip"
+    state = replace(
+        build_initial_app_state(),
+        current_pane=replace(
+            build_initial_app_state().current_pane,
+            entries=(
+                DirectoryEntryState(archive_path, "archive.zip", "file"),
+                *build_initial_app_state().current_pane.entries[1:],
+            ),
+            cursor_path=archive_path,
+        ),
+    )
+    state = _reduce_state(state, BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("extract"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "EXTRACT"
+    assert next_state.pending_input is not None
+    expected_dest = str(Path("/home/tadashi/develop/zivo/archive").resolve())
+    assert next_state.pending_input.value == expected_dest
+    assert next_state.pending_input.extract_source_path == archive_path
+
+def test_submit_command_palette_begins_zip_compress_flow() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_pane=replace(
+            build_initial_app_state().current_pane,
+            selected_paths=frozenset(
+                {
+                    "/home/tadashi/develop/zivo/docs",
+                    "/home/tadashi/develop/zivo/src",
+                }
+            ),
+        ),
+    )
+    state = _reduce_state(state, BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("compress"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "ZIP"
+    assert next_state.pending_input is not None
+    expected_zip = str(Path("/home/tadashi/develop/zivo/zivo.zip").resolve())
+    assert next_state.pending_input.value == expected_zip
+    assert next_state.pending_input.zip_source_paths == (
+        "/home/tadashi/develop/zivo/docs",
+        "/home/tadashi/develop/zivo/src",
+    )
+
+def test_begin_history_search_enters_history_mode() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        history=HistoryState(
+            back=("/tmp/a", "/tmp/b"),
+            forward=("/tmp/c",),
+            visited_all=("/home/tadashi/develop/zivo", "/tmp/a", "/tmp/b", "/tmp/c"),
+        ),
+    )
+    next_state = _reduce_state(state, BeginHistorySearch())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.source == "history"
+    assert next_state.command_palette.history_results == (
+        "/home/tadashi/develop/zivo",
+        "/tmp/a",
+        "/tmp/b",
+        "/tmp/c",
+    )
+
+def test_begin_history_search_with_empty_history() -> None:
+    next_state = _reduce_state(build_initial_app_state(), BeginHistorySearch())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.source == "history"
+    assert next_state.command_palette.history_results == ()
+
+def test_begin_bookmark_search_enters_bookmarks_mode() -> None:
+    next_state = _reduce_state(build_initial_app_state(), BeginBookmarkSearch())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette == CommandPaletteState(source="bookmarks")
+
+def test_begin_go_to_path_enters_palette_mode() -> None:
+    next_state = _reduce_state(build_initial_app_state(), BeginGoToPath())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette == CommandPaletteState(source="go_to_path")
+
+def test_submit_history_palette_navigates_to_selected_directory() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="history",
+            history_results=("/tmp/a", "/tmp/b", "/tmp/c"),
+            cursor_index=1,
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert any(
+        isinstance(e, LoadBrowserSnapshotEffect) and e.path == "/tmp/b"
+        for e in result.effects
+    )
+
+def test_submit_history_palette_with_empty_history_shows_warning() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="history",
+            history_results=(),
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.notification is not None
+    assert result.state.notification.message == "No directory history"
+
+def test_submit_bookmarks_palette_navigates_to_selected_directory(tmp_path) -> None:
+    bookmarked_path = tmp_path / "project"
+    bookmarked_path.mkdir()
+    state = build_initial_app_state(
+        config=AppConfig(bookmarks=BookmarkConfig(paths=(str(bookmarked_path),)))
+    )
+    state = replace(
+        state,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="bookmarks"),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path=str(bookmarked_path),
+            cursor_path=None,
+            blocking=True,
+        ),
+    )
+
+def test_submit_bookmarks_palette_with_invalid_path_shows_error() -> None:
+    state = build_initial_app_state(
+        config=AppConfig(bookmarks=BookmarkConfig(paths=("/tmp/does-not-exist",)))
+    )
+    state = replace(
+        state,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(source="bookmarks"),
+    )
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.notification == NotificationState(
+        level="error",
+        message="Bookmarked path does not exist or is not a directory",
+    )
+
+def test_set_command_palette_query_updates_go_to_path_candidates(tmp_path) -> None:
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path=str(tmp_path)),
+        BeginGoToPath(),
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "downloads").mkdir()
+
+    next_state = _reduce_state(
+        state,
+        SetCommandPaletteQuery("do"),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.go_to_path_candidates == (
+        str(tmp_path / "docs"),
+        str(tmp_path / "downloads"),
+    )
+
+def test_set_command_palette_query_resolves_relative_go_to_path_candidates(tmp_path) -> None:
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path=str(tmp_path)),
+        BeginGoToPath(),
+    )
+    (tmp_path / "projects").mkdir()
+    (tmp_path / "projects" / "zivo").mkdir()
+
+    next_state = _reduce_state(state, SetCommandPaletteQuery("projects/z"))
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.go_to_path_candidates == (
+        str(tmp_path / "projects" / "zivo"),
+    )
+
+def test_submit_go_to_path_palette_requests_snapshot(tmp_path) -> None:
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path=str(tmp_path)),
+        BeginGoToPath(),
+    )
+    target_path = tmp_path / "docs"
+    target_path.mkdir()
+    state = _reduce_state(
+        state,
+        SetCommandPaletteQuery("do"),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.state.command_palette is None
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path=str(target_path),
+            cursor_path=None,
+            blocking=True,
+        ),
+    )
+
+def test_submit_go_to_path_palette_uses_selected_candidate(tmp_path) -> None:
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path=str(tmp_path)),
+        BeginGoToPath(),
+    )
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "beta").mkdir()
+    state = _reduce_state(state, SetCommandPaletteQuery(""))
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query=str(tmp_path),
+            go_to_path_candidates=(str(tmp_path / "alpha"), str(tmp_path / "beta")),
+            cursor_index=1,
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path=str(tmp_path / "beta"),
+            cursor_path=None,
+            blocking=True,
+        ),
+    )
+
+def test_submit_go_to_path_palette_with_trailing_separator_uses_query_directory(tmp_path) -> None:
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path=str(tmp_path)),
+        BeginGoToPath(),
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "api").mkdir()
+    state = _reduce_state(state, SetCommandPaletteQuery("docs/"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path=str(tmp_path / "docs"),
+            cursor_path=None,
+            blocking=True,
+        ),
+    )
+
+def test_submit_go_to_path_palette_with_invalid_directory_shows_error() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGoToPath())
+    state = _reduce_state(
+        state,
+        SetCommandPaletteQuery("/path/that/does/not/exist"),
+    )
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.notification == NotificationState(
+        level="error",
+        message="Path does not exist or is not a directory",
+    )
+    state = _reduce_state(
+        build_initial_app_state(config_path="/tmp/zivo/config.toml"),
+        BeginCommandPalette(),
+    )
+    state = _reduce_state(state, SetCommandPaletteQuery("config"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "CONFIG"
+    assert next_state.command_palette is None
+    assert next_state.config_editor == ConfigEditorState(
+        path="/tmp/zivo/config.toml",
+        draft=next_state.config,
+    )
+
+def test_submit_command_palette_runs_copy_path_flow() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("copy"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.command_palette is None
+    assert result.state.next_request_id == 2
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=1,
+            request=ExternalLaunchRequest(
+                kind="copy_paths",
+                paths=("/home/tadashi/develop/zivo/docs",),
+            ),
+        ),
+    )
+
+def test_submit_command_palette_opens_attribute_dialog_for_single_target() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("attr"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "DETAIL"
+    assert next_state.command_palette is None
+    assert next_state.attribute_inspection is not None
+    assert next_state.attribute_inspection.name == "docs"
+    assert next_state.attribute_inspection.kind == "dir"
+    assert next_state.attribute_inspection.path == "/home/tadashi/develop/zivo/docs"
+    assert next_state.attribute_inspection.permissions_mode is None
+
+def test_dismiss_attribute_dialog_returns_to_browsing() -> None:
+    initial_state = build_initial_app_state()
+    state = replace(
+        initial_state,
+        ui_mode="DETAIL",
+        attribute_inspection=AttributeInspectionState(
+            name="docs",
+            kind="dir",
+            path="/home/tadashi/develop/zivo/docs",
+        ),
+    )
+
+    next_state = _reduce_state(state, DismissAttributeDialog())
+
+    assert next_state.ui_mode == "BROWSING"
+    assert next_state.attribute_inspection is None
+
+def test_submit_command_palette_opens_current_directory_in_file_manager() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("manager"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.command_palette is None
+    assert result.state.next_request_id == 2
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=1,
+            request=ExternalLaunchRequest(
+                kind="open_file",
+                path="/home/tadashi/develop/zivo",
+            ),
+        ),
+    )
+
+def test_submit_command_palette_warns_when_query_has_no_match() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("zzz"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.notification == NotificationState(
+        level="warning",
+        message="No matching command",
+    )
+
+def test_submit_command_palette_toggles_hidden_files() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("hidden"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.ui_mode == "BROWSING"
+    assert next_state.command_palette is None
+    assert next_state.show_hidden is True
+    assert next_state.notification == NotificationState(
+        level="info",
+        message="Hidden files shown",
+    )
+
+def test_submit_command_palette_runs_open_terminal_flow() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("open terminal"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.command_palette is None
+    assert result.state.next_request_id == 2
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=1,
+            request=ExternalLaunchRequest(
+                kind="open_terminal",
+                path="/home/tadashi/develop/zivo",
+            ),
+        ),
+    )
+
+def test_submit_command_palette_begins_history_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("history search"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "history"
+
+def test_submit_command_palette_begins_bookmark_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("show bookmarks"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "bookmarks"
+
+def test_submit_command_palette_adds_current_directory_bookmark() -> None:
+    state = _reduce_state(
+        build_initial_app_state(config_path="/tmp/zivo/config.toml"),
+        BeginCommandPalette(),
+    )
+    state = _reduce_state(state, SetCommandPaletteQuery("bookmark this directory"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert result.effects == (
+        RunConfigSaveEffect(
+            request_id=1,
+            path="/tmp/zivo/config.toml",
+            config=AppConfig(
+                bookmarks=BookmarkConfig(paths=("/home/tadashi/develop/zivo",))
+            ),
+        ),
+    )
+
+def test_show_attributes_enters_detail_mode_for_single_target() -> None:
+    state = build_initial_app_state()
+
+    result = reduce_app_state(state, ShowAttributes())
+
+    assert result.state.ui_mode == "DETAIL"
+    assert result.state.attribute_inspection == AttributeInspectionState(
+        name="docs",
+        kind="dir",
+        path="/home/tadashi/develop/zivo/docs",
+        size_bytes=None,
+        modified_at=state.current_pane.entries[0].modified_at,
+        hidden=False,
+        permissions_mode=state.current_pane.entries[0].permissions_mode,
+    )
+
+def test_show_attributes_warns_without_single_target() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_pane=replace(
+            build_initial_app_state().current_pane,
+            selected_paths=frozenset(
+                {
+                    "/home/tadashi/develop/zivo/docs",
+                    "/home/tadashi/develop/zivo/src",
+                }
+            ),
+        ),
+    )
+
+    next_state = _reduce_state(state, ShowAttributes())
+
+    assert next_state.notification == NotificationState(
+        level="warning",
+        message="Show attributes requires a single target",
+    )
+
+def test_submit_command_palette_removes_current_directory_bookmark() -> None:
+    state = _reduce_state(
+        build_initial_app_state(
+            config_path="/tmp/zivo/config.toml",
+            config=AppConfig(
+                bookmarks=BookmarkConfig(paths=("/home/tadashi/develop/zivo", "/home/tadashi/src"))
+            ),
+        ),
+        BeginCommandPalette(),
+    )
+    state = _reduce_state(state, SetCommandPaletteQuery("remove bookmark"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert result.effects == (
+        RunConfigSaveEffect(
+            request_id=1,
+            path="/tmp/zivo/config.toml",
+            config=AppConfig(
+                bookmarks=BookmarkConfig(paths=("/home/tadashi/src",))
+            ),
+        ),
+    )
+
+def test_submit_command_palette_goes_back() -> None:
+    state = replace(
+        _reduce_state(build_initial_app_state(), BeginCommandPalette()),
+        history=HistoryState(
+            back=("/home/tadashi/downloads",),
+            forward=(),
+        ),
+    )
+    state = _reduce_state(state, SetCommandPaletteQuery("go back"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.state.command_palette is None
+    assert len(result.effects) == 1
+    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
+    assert result.effects[0].path == "/home/tadashi/downloads"
+
+def test_submit_command_palette_go_forward_is_unavailable_without_history() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("go forward"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.notification == NotificationState(
+        level="warning",
+        message="Go forward is not available yet",
+    )
+
+def test_submit_command_palette_reloads_directory() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("reload directory"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert len(result.effects) == 1
+    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
+
+def test_submit_command_palette_goes_to_home_directory() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("go to home directory"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.state.command_palette is None
+    assert len(result.effects) == 1
+    assert isinstance(result.effects[0], LoadBrowserSnapshotEffect)
+
+def test_submit_command_palette_toggles_split_terminal() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("split terminal"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.command_palette is None
+    assert result.state.split_terminal.visible is True
+    assert len(result.effects) == 1
+    assert isinstance(result.effects[0], StartSplitTerminalEffect)
+
+def test_submit_command_palette_begins_rename_with_single_target() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("rename"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "RENAME"
+    assert result.state.command_palette is None
+    assert result.state.pending_input is not None
+    assert result.state.pending_input.prompt == "Rename: "
+
+def test_submit_command_palette_deletes_targets() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("trash"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "CONFIRM"
+    assert result.state.command_palette is None
+    assert result.state.delete_confirmation is not None
+
+def test_submit_command_palette_uses_selected_paths_for_copy_path() -> None:
+    initial_state = build_initial_app_state()
+    state = replace(
+        initial_state,
+        current_pane=replace(
+            initial_state.current_pane,
+            selected_paths=frozenset(
+                {
+                    "/home/tadashi/develop/zivo/docs",
+                    "/home/tadashi/develop/zivo/src",
+                }
+            ),
+        ),
+    )
+    state = _reduce_state(state, BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("copy"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=1,
+            request=ExternalLaunchRequest(
+                kind="copy_paths",
+                paths=(
+                    "/home/tadashi/develop/zivo/docs",
+                    "/home/tadashi/develop/zivo/src",
+                ),
+            ),
+        ),
+    )
+
+def test_submit_command_palette_select_all_uses_visible_entries() -> None:
+    initial_state = build_initial_app_state()
+    state = replace(
+        initial_state,
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(
+                DirectoryEntryState(
+                    "/home/tadashi/develop/zivo/.env",
+                    ".env",
+                    "file",
+                    hidden=True,
+                ),
+                DirectoryEntryState("/home/tadashi/develop/zivo/docs", "docs", "dir"),
+                DirectoryEntryState("/home/tadashi/develop/zivo/src", "src", "dir"),
+            ),
+            cursor_path="/home/tadashi/develop/zivo/docs",
+        ),
+        filter=replace(initial_state.filter, query="s", active=True),
+    )
+    state = _reduce_state(state, BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("select all"))
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.current_pane.selected_paths == frozenset(
+        {
+            "/home/tadashi/develop/zivo/docs",
+            "/home/tadashi/develop/zivo/src",
+        }
+    )
+
+def test_cancel_command_palette_returns_to_browsing() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+
+    next_state = _reduce_state(state, CancelCommandPalette())
+
+    assert next_state.ui_mode == "BROWSING"
+    assert next_state.command_palette is None
+
+def test_begin_command_palette_clears_pending_key_sequence() -> None:
+    state = replace(
+        build_initial_app_state(),
+        pending_key_sequence=PendingKeySequenceState(
+            keys=("y",),
+            possible_next_keys=("y",),
+        ),
+    )
+
+    next_state = _reduce_state(state, BeginCommandPalette())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.pending_key_sequence is None
+

--- a/tests/test_state_reducer_palette_replace.py
+++ b/tests/test_state_reducer_palette_replace.py
@@ -1,0 +1,1220 @@
+from dataclasses import replace
+
+from tests.state_test_helpers import reduce_state
+from zivo.models import (
+    TextReplacePreviewEntry,
+    TextReplacePreviewResult,
+    TextReplaceRequest,
+    TextReplaceResult,
+)
+from zivo.state import (
+    BeginCommandPalette,
+    BeginFindAndReplace,
+    BeginGrepReplace,
+    BeginGrepReplaceSelected,
+    BeginTextReplace,
+    CancelCommandPalette,
+    CycleFindReplaceField,
+    CycleReplaceField,
+    DirectoryEntryState,
+    FileSearchCompleted,
+    FileSearchResultState,
+    GrepSearchCompleted,
+    GrepSearchResultState,
+    LoadBrowserSnapshotEffect,
+    MoveCommandPaletteCursor,
+    NotificationState,
+    PaneState,
+    ReplacePreviewResultState,
+    RunFileSearchEffect,
+    RunGrepSearchEffect,
+    RunTextReplaceApplyEffect,
+    RunTextReplacePreviewEffect,
+    SetCommandPaletteQuery,
+    SetFindReplaceField,
+    SetGrepReplaceField,
+    SetGrepReplaceSelectedField,
+    SetReplaceField,
+    SubmitCommandPalette,
+    TextReplaceApplied,
+    TextReplaceApplyFailed,
+    TextReplacePreviewCompleted,
+    TextReplacePreviewFailed,
+    build_initial_app_state,
+    reduce_app_state,
+)
+from zivo.state.reducer_common import browser_snapshot_invalidation_paths
+
+
+def _reduce_state(state, action):
+    return reduce_state(state, action)
+
+
+def _viewport_test_entries(
+    path: str,
+    count: int,
+    *,
+    hidden_indexes: frozenset[int] = frozenset(),
+) -> tuple[DirectoryEntryState, ...]:
+    return tuple(
+        DirectoryEntryState(
+            f"{path}/item_{index:02d}",
+            f"item_{index:02d}",
+            "file",
+            hidden=index in hidden_indexes,
+        )
+        for index in range(count)
+    )
+
+
+def test_begin_text_replace_enters_replace_mode() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
+    )
+
+    assert state.ui_mode == "PALETTE"
+    assert state.command_palette is not None
+    assert state.command_palette.source == "replace_text"
+    assert state.command_palette.replace_target_paths == (
+        "/home/tadashi/develop/zivo/README.md",
+    )
+
+def test_set_replace_field_starts_preview_effect() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
+    )
+
+    result = reduce_app_state(state, SetReplaceField(field="find", value="todo"))
+
+    assert result.state.command_palette is not None
+    assert result.state.pending_replace_preview_request_id == 1
+    assert result.effects == (
+        RunTextReplacePreviewEffect(
+            request_id=1,
+            request=TextReplaceRequest(
+                paths=("/home/tadashi/develop/zivo/README.md",),
+                find_text="todo",
+                replace_text="",
+            ),
+        ),
+    )
+
+def test_cycle_replace_field_switches_active_input() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
+    )
+
+    next_state = _reduce_state(state, CycleReplaceField(delta=1))
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.replace_active_field == "replace"
+
+def test_text_replace_preview_completed_updates_palette_results() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
+    )
+    state = replace(
+        state,
+        pending_replace_preview_request_id=4,
+        command_palette=replace(
+            state.command_palette,
+            replace_find_text="todo",
+        ),
+    )
+
+    next_state = _reduce_state(
+        state,
+        TextReplacePreviewCompleted(
+            request_id=4,
+            result=TextReplacePreviewResult(
+                request=TextReplaceRequest(
+                    paths=("/home/tadashi/develop/zivo/README.md",),
+                    find_text="todo",
+                    replace_text="done",
+                ),
+                changed_entries=(
+                    TextReplacePreviewEntry(
+                        path="/home/tadashi/develop/zivo/README.md",
+                        diff_text="--- before\n+++ after\n@@\n-todo item\n+done item\n",
+                        match_count=2,
+                        first_match_line_number=12,
+                        first_match_before="todo item",
+                        first_match_after="done item",
+                    ),
+                ),
+                total_match_count=2,
+                diff_text="--- before\n+++ after\n@@\n-todo item\n+done item\n",
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.replace_total_match_count == 2
+    assert next_state.command_palette.replace_preview_results[0].display_path == "README.md"
+    assert next_state.command_palette.replace_preview_results[0].diff_text == (
+        "--- before\n+++ after\n@@\n-todo item\n+done item\n"
+    )
+    assert next_state.child_pane.preview_title == "Replace Preview"
+    assert next_state.child_pane.preview_content == (
+        "--- before\n+++ after\n@@\n-todo item\n+done item\n"
+    )
+    assert next_state.child_pane.preview_path == "/home/tadashi/develop/zivo/README.md"
+    assert next_state.pending_replace_preview_request_id is None
+
+def test_move_palette_cursor_updates_replace_preview_diff() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(
+            target_paths=(
+                "/home/tadashi/develop/zivo/README.md",
+                "/home/tadashi/develop/zivo/docs/notes.md",
+            )
+        ),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            replace_preview_results=(
+                ReplacePreviewResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    diff_text="--- README\n+++ README\n@@\n-todo\n+done\n",
+                    match_count=1,
+                    first_match_line_number=1,
+                    first_match_before="todo",
+                    first_match_after="done",
+                ),
+                ReplacePreviewResultState(
+                    path="/home/tadashi/develop/zivo/docs/notes.md",
+                    display_path="docs/notes.md",
+                    diff_text="--- notes\n+++ notes\n@@\n-todo\n+done\n",
+                    match_count=1,
+                    first_match_line_number=2,
+                    first_match_before="todo",
+                    first_match_after="done",
+                ),
+            ),
+            replace_total_match_count=2,
+        ),
+        child_pane=PaneState(
+            directory_path=state.current_path,
+            entries=(),
+            mode="preview",
+            preview_path="/home/tadashi/develop/zivo/README.md",
+            preview_title="Replace Preview",
+            preview_content="--- README\n+++ README\n@@\n-todo\n+done\n",
+        ),
+    )
+
+    result = reduce_app_state(state, MoveCommandPaletteCursor(delta=1))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.cursor_index == 1
+    assert result.state.child_pane.preview_path == "/home/tadashi/develop/zivo/docs/notes.md"
+    assert result.state.child_pane.preview_content == (
+        "--- notes\n+++ notes\n@@\n-todo\n+done\n"
+    )
+
+def test_text_replace_preview_failed_sets_inline_error_for_invalid_regex() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
+    )
+    state = replace(state, pending_replace_preview_request_id=4)
+
+    next_state = _reduce_state(
+        state,
+        TextReplacePreviewFailed(
+            request_id=4,
+            message="missing )",
+            invalid_query=True,
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.replace_error_message == "missing )"
+    assert next_state.pending_replace_preview_request_id is None
+
+def test_submit_command_palette_applies_replace_when_preview_exists() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginTextReplace(target_paths=("/home/tadashi/develop/zivo/README.md",)),
+    )
+    state = replace(
+        state,
+        next_request_id=8,
+        command_palette=replace(
+            state.command_palette,
+            replace_find_text="todo",
+            replace_replacement_text="done",
+            replace_preview_results=(
+                ReplacePreviewResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    diff_text="--- before\n+++ after\n@@\n-todo item\n+done item\n",
+                    match_count=2,
+                    first_match_line_number=12,
+                    first_match_before="todo item",
+                    first_match_after="done item",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.pending_replace_apply_request_id == 8
+    assert result.state.ui_mode == "BROWSING"
+    assert result.effects == (
+        RunTextReplaceApplyEffect(
+            request_id=8,
+            request=TextReplaceRequest(
+                paths=("/home/tadashi/develop/zivo/README.md",),
+                find_text="todo",
+                replace_text="done",
+            ),
+        ),
+    )
+
+def test_text_replace_applied_refreshes_current_directory() -> None:
+    state = replace(
+        build_initial_app_state(),
+        pending_replace_apply_request_id=6,
+        current_path="/home/tadashi/develop/zivo",
+        current_pane=replace(
+            build_initial_app_state().current_pane,
+            cursor_path="/home/tadashi/develop/zivo/README.md",
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        TextReplaceApplied(
+            request_id=6,
+            result=TextReplaceResult(
+                request=TextReplaceRequest(
+                    paths=("/home/tadashi/develop/zivo/README.md",),
+                    find_text="todo",
+                    replace_text="done",
+                ),
+                changed_paths=("/home/tadashi/develop/zivo/README.md",),
+                total_match_count=3,
+                message="Replaced 3 match(es) in 1 file(s)",
+            ),
+        ),
+    )
+
+    assert result.state.post_reload_notification == NotificationState(
+        level="info",
+        message="Replaced 3 match(es) in 1 file(s)",
+    )
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path="/home/tadashi/develop/zivo",
+            cursor_path="/home/tadashi/develop/zivo/README.md",
+            blocking=True,
+            invalidate_paths=browser_snapshot_invalidation_paths(
+                "/home/tadashi/develop/zivo",
+                "/home/tadashi/develop/zivo/README.md",
+            ),
+        ),
+    )
+
+def test_text_replace_apply_failed_sets_error_notification() -> None:
+    state = replace(
+        build_initial_app_state(),
+        pending_replace_apply_request_id=3,
+    )
+
+    next_state = _reduce_state(
+        state,
+        TextReplaceApplyFailed(request_id=3, message="permission denied"),
+    )
+
+    assert next_state.pending_replace_apply_request_id is None
+    assert next_state.notification == NotificationState(
+        level="error",
+        message="permission denied",
+    )
+
+def test_run_replace_text_command_uses_cursor_file_when_nothing_is_selected() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = replace(
+        state,
+        command_palette=replace(state.command_palette, query="replace text"),
+        current_pane=replace(
+            state.current_pane,
+            selected_paths=frozenset(),
+            cursor_path="/home/tadashi/develop/zivo/README.md",
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "replace_text"
+    assert result.state.command_palette.replace_target_paths == (
+        "/home/tadashi/develop/zivo/README.md",
+    )
+
+def test_begin_find_and_replace_enters_rff_mode() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    assert state.ui_mode == "PALETTE"
+    assert state.command_palette is not None
+    assert state.command_palette.source == "replace_in_found_files"
+    assert state.command_palette.rff_active_field == "filename"
+
+def test_set_rff_filename_field_starts_file_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    result = reduce_app_state(state, SetFindReplaceField(field="filename", value="readme"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.rff_filename_query == "readme"
+    assert result.state.pending_file_search_request_id == 1
+    assert result.effects == (
+        RunFileSearchEffect(
+            request_id=1,
+            root_path="/home/tadashi/develop/zivo",
+            query="readme",
+            show_hidden=False,
+        ),
+    )
+
+def test_set_rff_filename_clear_triggers_no_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    result = reduce_app_state(
+        state,
+        SetFindReplaceField(field="filename", value=""),
+    )
+
+    assert result.state.command_palette is not None
+    assert result.state.pending_file_search_request_id is None
+    assert result.effects == ()
+
+def test_set_rff_find_field_with_file_results_starts_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            rff_filename_query="readme",
+            rff_file_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SetFindReplaceField(field="find", value="todo"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.rff_find_text == "todo"
+    assert result.state.pending_replace_preview_request_id == 1
+    assert result.effects == (
+        RunTextReplacePreviewEffect(
+            request_id=1,
+            request=TextReplaceRequest(
+                paths=("/home/tadashi/develop/zivo/README.md",),
+                find_text="todo",
+                replace_text="",
+            ),
+        ),
+    )
+
+def test_set_rff_find_field_without_file_results_no_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    result = reduce_app_state(state, SetFindReplaceField(field="find", value="todo"))
+
+    assert result.state.command_palette is not None
+    assert result.state.pending_replace_preview_request_id is None
+    assert result.effects == ()
+
+def test_cycle_find_replace_field_cycles_through_three_fields() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    assert state.command_palette is not None
+    assert state.command_palette.rff_active_field == "filename"
+
+    state = _reduce_state(state, CycleFindReplaceField(delta=1))
+    assert state.command_palette is not None
+    assert state.command_palette.rff_active_field == "find"
+
+    state = _reduce_state(state, CycleFindReplaceField(delta=1))
+    assert state.command_palette is not None
+    assert state.command_palette.rff_active_field == "replace"
+
+    state = _reduce_state(state, CycleFindReplaceField(delta=1))
+    assert state.command_palette is not None
+    assert state.command_palette.rff_active_field == "filename"
+
+def test_cycle_find_replace_field_reverse() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    state = _reduce_state(state, CycleFindReplaceField(delta=-1))
+    assert state.command_palette is not None
+    assert state.command_palette.rff_active_field == "replace"
+
+def test_rff_file_search_completed_stores_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+    state = replace(
+        state,
+        pending_file_search_request_id=3,
+        command_palette=replace(
+            state.command_palette,
+            rff_filename_query="readme",
+        ),
+    )
+
+    next_state = _reduce_state(
+        state,
+        FileSearchCompleted(
+            request_id=3,
+            query="readme",
+            results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.rff_file_results == (
+        FileSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+        ),
+    )
+    assert next_state.pending_file_search_request_id is None
+
+def test_rff_file_search_completed_auto_triggers_preview_when_find_text_present() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+    state = replace(
+        state,
+        pending_file_search_request_id=3,
+        command_palette=replace(
+            state.command_palette,
+            rff_filename_query="readme",
+            rff_find_text="todo",
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        FileSearchCompleted(
+            request_id=3,
+            query="readme",
+            results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    assert result.state.pending_replace_preview_request_id is not None
+    assert len(result.effects) == 1
+    assert isinstance(result.effects[0], RunTextReplacePreviewEffect)
+
+def test_rff_preview_completed_stores_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+    state = replace(
+        state,
+        pending_replace_preview_request_id=4,
+        command_palette=replace(
+            state.command_palette,
+            rff_find_text="todo",
+            rff_replacement_text="done",
+            rff_file_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    next_state = _reduce_state(
+        state,
+        TextReplacePreviewCompleted(
+            request_id=4,
+            result=TextReplacePreviewResult(
+                request=TextReplaceRequest(
+                    paths=("/home/tadashi/develop/zivo/README.md",),
+                    find_text="todo",
+                    replace_text="done",
+                ),
+                changed_entries=(
+                    TextReplacePreviewEntry(
+                        path="/home/tadashi/develop/zivo/README.md",
+                        diff_text="-todo\n+done",
+                        match_count=1,
+                        first_match_line_number=5,
+                        first_match_before="todo",
+                        first_match_after="done",
+                    ),
+                ),
+                total_match_count=1,
+                diff_text="-todo\n+done",
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.rff_total_match_count == 1
+    assert len(next_state.command_palette.rff_preview_results) == 1
+    assert next_state.command_palette.rff_preview_results[0].display_path == "README.md"
+    assert next_state.child_pane.preview_title == "Replace Preview"
+    assert next_state.pending_replace_preview_request_id is None
+
+def test_submit_rff_palette_warns_when_no_find_text() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.notification == NotificationState(
+        level="warning",
+        message="Find text is required",
+    )
+
+def test_submit_rff_palette_warns_when_no_preview_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            rff_find_text="todo",
+            rff_file_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.notification is not None
+    assert result.state.notification.level == "warning"
+
+def test_cancel_rff_returns_to_browsing() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFindAndReplace())
+    assert state.ui_mode == "PALETTE"
+
+    state = _reduce_state(state, CancelCommandPalette())
+    assert state.ui_mode == "BROWSING"
+    assert state.command_palette is None
+
+
+# ---------------------------------------------------------------------------
+# Grep replace (grf) tests
+# ---------------------------------------------------------------------------
+
+def test_begin_grep_replace_enters_grf_mode() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    assert state.ui_mode == "PALETTE"
+    assert state.command_palette is not None
+    assert state.command_palette.source == "replace_in_grep_files"
+    assert state.command_palette.grf_active_field == "keyword"
+
+def test_set_grf_keyword_field_starts_grep_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    result = reduce_app_state(state, SetGrepReplaceField(field="keyword", value="todo"))
+
+    assert result.state.pending_grep_search_request_id is not None
+    assert result.state.command_palette.grf_keyword == "todo"
+    effects = [e for e in result.effects if isinstance(e, RunGrepSearchEffect)]
+    assert len(effects) == 1
+    assert effects[0].query == "todo"
+
+def test_set_grf_keyword_clear_triggers_no_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = _reduce_state(state, SetGrepReplaceField(field="keyword", value="todo"))
+    result = reduce_app_state(state, SetGrepReplaceField(field="keyword", value=""))
+
+    assert result.state.pending_grep_search_request_id is None
+    assert result.state.command_palette.grf_grep_results == ()
+
+def test_set_grf_replace_field_with_grep_results_starts_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+    )
+    result = reduce_app_state(state, SetGrepReplaceField(field="replace", value="done"))
+
+    assert result.state.pending_replace_preview_request_id is not None
+    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
+    assert len(effects) == 1
+    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/README.md",)
+    assert effects[0].request.find_text == "todo"
+
+def test_set_grf_replace_field_without_grep_results_no_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    result = reduce_app_state(state, SetGrepReplaceField(field="replace", value="done"))
+
+    assert result.state.pending_replace_preview_request_id is None
+    assert result.state.command_palette.grf_preview_results == ()
+
+def test_grf_grep_search_completed_stores_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(state.command_palette, grf_keyword="todo"),
+        pending_grep_search_request_id=10,
+        next_request_id=11,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="todo item",
+        ),
+    )
+    result = reduce_app_state(
+        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
+    )
+
+    assert result.state.command_palette.grf_grep_results == results
+    assert result.state.pending_grep_search_request_id is None
+
+def test_grf_grep_search_completed_auto_triggers_preview_when_replace_text_present() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_replacement_text="done",
+        ),
+        pending_grep_search_request_id=10,
+        next_request_id=11,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="todo item",
+        ),
+    )
+    result = reduce_app_state(
+        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
+    )
+
+    assert result.state.command_palette.grf_grep_results == results
+    assert result.state.pending_replace_preview_request_id is not None
+    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
+    assert len(effects) == 1
+
+def test_grf_preview_completed_stores_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_replacement_text="done",
+            grf_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+        pending_replace_preview_request_id=10,
+        next_request_id=11,
+    )
+    preview_result = TextReplacePreviewResult(
+        request=TextReplaceRequest(
+            paths=("/home/tadashi/develop/zivo/README.md",),
+            find_text="todo",
+            replace_text="done",
+        ),
+        changed_entries=(
+            TextReplacePreviewEntry(
+                path="/home/tadashi/develop/zivo/README.md",
+                diff_text="- todo + done",
+                match_count=1,
+                first_match_line_number=1,
+                first_match_before="todo",
+                first_match_after="done",
+            ),
+        ),
+        total_match_count=1,
+        skipped_paths=(),
+    )
+    result = reduce_app_state(
+        state, TextReplacePreviewCompleted(request_id=10, result=preview_result)
+    )
+
+    assert len(result.state.command_palette.grf_preview_results) == 1
+    assert result.state.command_palette.grf_total_match_count == 1
+    assert result.state.pending_replace_preview_request_id is None
+
+def test_submit_grf_palette_warns_when_no_replace_text() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+    )
+    result = reduce_app_state(state, SubmitCommandPalette())
+    assert result.state.notification is not None
+    assert result.state.notification.level == "warning"
+
+def test_submit_grf_palette_warns_when_no_preview_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_replacement_text="done",
+            grf_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+    )
+    result = reduce_app_state(state, SubmitCommandPalette())
+    assert result.state.notification is not None
+    assert result.state.notification.level == "warning"
+
+def test_cancel_grf_returns_to_browsing() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    assert state.ui_mode == "PALETTE"
+
+    state = _reduce_state(state, CancelCommandPalette())
+    assert state.ui_mode == "BROWSING"
+    assert state.command_palette is None
+
+def test_submit_command_palette_begins_grep_replace() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery(query="replace text in grep"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "replace_in_grep_files"
+
+def test_grf_grep_search_completed_deduplicates_file_paths() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_replacement_text="done",
+        ),
+        pending_grep_search_request_id=10,
+        next_request_id=11,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="todo item 1",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=5,
+            line_text="todo item 2",
+        ),
+    )
+    result = reduce_app_state(
+        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
+    )
+
+    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
+    assert len(effects) == 1
+    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/README.md",)
+
+
+# ---------------------------------------------------------------------------
+# Grep replace selected (grs) tests
+# ---------------------------------------------------------------------------
+
+def test_begin_grep_replace_selected_enters_grs_mode() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(
+            target_paths=("/home/tadashi/develop/zivo/a.py", "/home/tadashi/develop/zivo/b.py")
+        ),
+    )
+    assert state.ui_mode == "PALETTE"
+    assert state.command_palette is not None
+    assert state.command_palette.source == "grep_replace_selected"
+    assert state.command_palette.grs_active_field == "keyword"
+    assert state.command_palette.grs_target_paths == (
+        "/home/tadashi/develop/zivo/a.py",
+        "/home/tadashi/develop/zivo/b.py",
+    )
+
+def test_set_grs_keyword_field_starts_grep_search() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    result = reduce_app_state(
+        state, SetGrepReplaceSelectedField(field="keyword", value="todo")
+    )
+
+    assert result.state.pending_grep_search_request_id is not None
+    assert result.state.command_palette.grs_keyword == "todo"
+    effects = [e for e in result.effects if isinstance(e, RunGrepSearchEffect)]
+    assert len(effects) == 1
+    assert effects[0].query == "todo"
+
+def test_set_grs_keyword_clear_triggers_no_search() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = _reduce_state(state, SetGrepReplaceSelectedField(field="keyword", value="todo"))
+    result = reduce_app_state(state, SetGrepReplaceSelectedField(field="keyword", value=""))
+
+    assert result.state.pending_grep_search_request_id is None
+    assert result.state.command_palette.grs_grep_results == ()
+
+def test_grs_grep_search_completed_filters_to_target_paths() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(
+            target_paths=("/home/tadashi/develop/zivo/a.py", "/home/tadashi/develop/zivo/c.py")
+        ),
+    )
+    state = replace(
+        state,
+        command_palette=replace(state.command_palette, grs_keyword="todo"),
+        pending_grep_search_request_id=10,
+        next_request_id=11,
+    )
+    all_results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/a.py",
+            display_path="a.py",
+            line_number=1,
+            line_text="todo in a",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/b.py",
+            display_path="b.py",
+            line_number=3,
+            line_text="todo in b",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/c.py",
+            display_path="c.py",
+            line_number=5,
+            line_text="todo in c",
+        ),
+    )
+    result = reduce_app_state(
+        state, GrepSearchCompleted(request_id=10, query="todo", results=all_results)
+    )
+
+    assert len(result.state.command_palette.grs_grep_results) == 2
+    assert result.state.command_palette.grs_grep_results[0].path == (
+        "/home/tadashi/develop/zivo/a.py"
+    )
+    assert result.state.command_palette.grs_grep_results[1].path == (
+        "/home/tadashi/develop/zivo/c.py"
+    )
+    assert result.state.pending_grep_search_request_id is None
+
+def test_grs_grep_search_completed_auto_triggers_preview_when_replace_text_present() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_keyword="todo",
+            grs_replacement_text="done",
+        ),
+        pending_grep_search_request_id=10,
+        next_request_id=11,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/a.py",
+            display_path="a.py",
+            line_number=1,
+            line_text="todo item",
+        ),
+    )
+    result = reduce_app_state(
+        state, GrepSearchCompleted(request_id=10, query="todo", results=results)
+    )
+
+    assert result.state.command_palette.grs_grep_results == results
+    assert result.state.pending_replace_preview_request_id is not None
+    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
+    assert len(effects) == 1
+    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/a.py",)
+
+def test_set_grs_replace_field_with_grep_results_starts_preview() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_keyword="todo",
+            grs_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/a.py",
+                    display_path="a.py",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+    )
+    result = reduce_app_state(
+        state, SetGrepReplaceSelectedField(field="replace", value="done")
+    )
+
+    assert result.state.pending_replace_preview_request_id is not None
+    effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
+    assert len(effects) == 1
+    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/a.py",)
+    assert effects[0].request.find_text == "todo"
+
+def test_set_grs_replace_field_without_grep_results_no_preview() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    result = reduce_app_state(
+        state, SetGrepReplaceSelectedField(field="replace", value="done")
+    )
+
+    assert result.state.pending_replace_preview_request_id is None
+    assert result.state.command_palette.grs_preview_results == ()
+
+def test_grs_preview_completed_stores_results() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_keyword="todo",
+            grs_replacement_text="done",
+            grs_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/a.py",
+                    display_path="a.py",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+        pending_replace_preview_request_id=10,
+        next_request_id=11,
+    )
+    preview_result = TextReplacePreviewResult(
+        request=TextReplaceRequest(
+            paths=("/home/tadashi/develop/zivo/a.py",),
+            find_text="todo",
+            replace_text="done",
+        ),
+        changed_entries=(
+            TextReplacePreviewEntry(
+                path="/home/tadashi/develop/zivo/a.py",
+                diff_text="- todo + done",
+                match_count=1,
+                first_match_line_number=1,
+                first_match_before="todo",
+                first_match_after="done",
+            ),
+        ),
+        total_match_count=1,
+        skipped_paths=(),
+    )
+    result = reduce_app_state(
+        state, TextReplacePreviewCompleted(request_id=10, result=preview_result)
+    )
+
+    assert len(result.state.command_palette.grs_preview_results) == 1
+    assert result.state.command_palette.grs_total_match_count == 1
+    assert result.state.pending_replace_preview_request_id is None
+
+def test_submit_grs_palette_applies_replacement() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_keyword="todo",
+            grs_replacement_text="done",
+            grs_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/a.py",
+                    display_path="a.py",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+            grs_preview_results=(
+                ReplacePreviewResultState(
+                    path="/home/tadashi/develop/zivo/a.py",
+                    display_path="a.py",
+                    diff_text="- todo + done",
+                    match_count=1,
+                    first_match_line_number=1,
+                    first_match_before="todo",
+                    first_match_after="done",
+                ),
+            ),
+            grs_total_match_count=1,
+        ),
+    )
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    effects = [e for e in result.effects if isinstance(e, RunTextReplaceApplyEffect)]
+    assert len(effects) == 1
+    assert effects[0].request.paths == ("/home/tadashi/develop/zivo/a.py",)
+    assert effects[0].request.find_text == "todo"
+    assert effects[0].request.replace_text == "done"
+    assert result.state.command_palette is None
+
+def test_submit_grs_palette_warns_when_no_keyword() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.notification is not None
+    assert result.state.notification.level == "warning"
+
+def test_submit_grs_palette_warns_when_no_preview_results() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grs_keyword="todo",
+            grs_replacement_text="done",
+            grs_grep_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/a.py",
+                    display_path="a.py",
+                    line_number=1,
+                    line_text="todo item",
+                ),
+            ),
+        ),
+    )
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.notification is not None
+    assert result.state.notification.level == "warning"
+
+def test_cancel_grs_returns_to_browsing() -> None:
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    assert state.ui_mode == "PALETTE"
+
+    state = _reduce_state(state, CancelCommandPalette())
+    assert state.ui_mode == "BROWSING"
+    assert state.command_palette is None
+
+def test_grs_grep_search_completed_filters_non_target_results() -> None:
+    """Verify that grep results not in target_paths are excluded."""
+    state = _reduce_state(
+        build_initial_app_state(),
+        BeginGrepReplaceSelected(target_paths=("/home/tadashi/develop/zivo/a.py",)),
+    )
+    state = replace(
+        state,
+        command_palette=replace(state.command_palette, grs_keyword="todo"),
+        pending_grep_search_request_id=10,
+        next_request_id=11,
+    )
+    all_results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/a.py",
+            display_path="a.py",
+            line_number=1,
+            line_text="todo in a",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/b.py",
+            display_path="b.py",
+            line_number=3,
+            line_text="todo in b",
+        ),
+    )
+    result = reduce_app_state(
+        state, GrepSearchCompleted(request_id=10, query="todo", results=all_results)
+    )
+
+    assert len(result.state.command_palette.grs_grep_results) == 1
+    assert result.state.command_palette.grs_grep_results[0].path == (
+        "/home/tadashi/develop/zivo/a.py"
+    )
+    # Preview is triggered even with empty replace text to show find matches
+    assert result.state.pending_replace_preview_request_id is not None
+

--- a/tests/test_state_reducer_palette_search.py
+++ b/tests/test_state_reducer_palette_search.py
@@ -1,0 +1,859 @@
+from dataclasses import replace
+
+from tests.state_test_helpers import reduce_state
+from zivo.models import (
+    ExternalLaunchRequest,
+)
+from zivo.state import (
+    BeginCommandPalette,
+    BeginFileSearch,
+    BeginGrepSearch,
+    CancelCommandPalette,
+    CommandPaletteState,
+    DirectoryEntryState,
+    FileSearchCompleted,
+    FileSearchFailed,
+    FileSearchResultState,
+    GrepSearchCompleted,
+    GrepSearchFailed,
+    GrepSearchResultState,
+    LoadBrowserSnapshotEffect,
+    LoadChildPaneSnapshotEffect,
+    NotificationState,
+    OpenFindResultInEditor,
+    OpenGrepResultInEditor,
+    PaneState,
+    RunDirectorySizeEffect,
+    RunExternalLaunchEffect,
+    RunFileSearchEffect,
+    RunGrepSearchEffect,
+    SetCommandPaletteQuery,
+    SetGrepSearchField,
+    SubmitCommandPalette,
+    build_initial_app_state,
+    reduce_app_state,
+)
+
+
+def _reduce_state(state, action):
+    return reduce_state(state, action)
+
+
+def _viewport_test_entries(
+    path: str,
+    count: int,
+    *,
+    hidden_indexes: frozenset[int] = frozenset(),
+) -> tuple[DirectoryEntryState, ...]:
+    return tuple(
+        DirectoryEntryState(
+            f"{path}/item_{index:02d}",
+            f"item_{index:02d}",
+            "file",
+            hidden=index in hidden_indexes,
+        )
+        for index in range(count)
+    )
+
+
+def test_open_find_result_in_editor_emits_external_launch_effect() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="readme",
+            file_search_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+            cursor_index=0,
+        ),
+    )
+
+    result = reduce_app_state(state, OpenFindResultInEditor())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.next_request_id == 2
+    assert result.state.command_palette == state.command_palette
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=1,
+            request=ExternalLaunchRequest(
+                kind="open_editor",
+                path="/home/tadashi/develop/zivo/README.md",
+                line_number=None,
+            ),
+        ),
+    )
+
+def test_open_grep_result_in_editor_keeps_palette_state() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="reduce_app_state",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/zivo/state/reducer.py",
+                    display_path="src/zivo/state/reducer.py",
+                    line_number=15,
+                    line_text=(
+                        "def reduce_app_state("
+                        "state: AppState, action: Action"
+                        ") -> ReduceResult:"
+                    ),
+                ),
+            ),
+            cursor_index=0,
+        ),
+    )
+
+    result = reduce_app_state(state, OpenGrepResultInEditor())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.next_request_id == 2
+    assert result.state.command_palette == state.command_palette
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=1,
+            request=ExternalLaunchRequest(
+                kind="open_editor",
+                path="/home/tadashi/develop/zivo/src/zivo/state/reducer.py",
+                line_number=15,
+            ),
+        ),
+    )
+
+def test_begin_file_search_enters_find_file_mode() -> None:
+    next_state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette == CommandPaletteState(source="file_search")
+
+def test_begin_grep_search_enters_grep_mode() -> None:
+    next_state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+
+    assert next_state.ui_mode == "PALETTE"
+    assert next_state.command_palette == CommandPaletteState(source="grep_search")
+
+def test_submit_command_palette_begins_file_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("find files"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "file_search"
+
+def test_submit_command_palette_begins_grep_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("grep search"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "grep_search"
+
+def test_set_command_palette_query_starts_file_search_effect() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+
+    result = reduce_app_state(state, SetCommandPaletteQuery("read"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "file_search"
+    assert result.state.command_palette.query == "read"
+    assert result.state.pending_file_search_request_id == 1
+    assert result.effects == (
+        RunFileSearchEffect(
+            request_id=1,
+            root_path="/home/tadashi/develop/zivo",
+            query="read",
+            show_hidden=False,
+        ),
+    )
+
+def test_set_command_palette_query_starts_grep_search_effect() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+
+    result = reduce_app_state(state, SetCommandPaletteQuery("todo"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.source == "grep_search"
+    assert result.state.command_palette.query == "todo"
+    assert result.state.pending_grep_search_request_id == 1
+    assert result.effects == (
+        RunGrepSearchEffect(
+            request_id=1,
+            root_path="/home/tadashi/develop/zivo",
+            query="todo",
+            show_hidden=False,
+            include_globs=(),
+            exclude_globs=(),
+        ),
+    )
+
+def test_set_grep_search_field_builds_include_and_exclude_globs() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
+
+    result = reduce_app_state(state, SetGrepSearchField(field="include", value="py, ts"))
+    result = reduce_app_state(result.state, SetGrepSearchField(field="exclude", value=".log"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_include_extensions == "py, ts"
+    assert result.state.command_palette.grep_search_exclude_extensions == ".log"
+    assert result.effects == (
+        RunGrepSearchEffect(
+            request_id=3,
+            root_path="/home/tadashi/develop/zivo",
+            query="todo",
+            show_hidden=False,
+            include_globs=("*.py", "*.ts"),
+            exclude_globs=("*.log",),
+        ),
+    )
+
+def test_set_grep_search_filename_filter_updates_palette_and_requests_search() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
+
+    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="readme"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_filename_filter == "readme"
+    assert result.effects == (
+        RunGrepSearchEffect(
+            request_id=2,
+            root_path="/home/tadashi/develop/zivo",
+            query="todo",
+            show_hidden=False,
+            include_globs=(),
+            exclude_globs=(),
+        ),
+    )
+
+def test_grep_search_completed_filters_results_by_filename() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="todo",
+            grep_search_filename_filter="readme",
+        ),
+        pending_grep_search_request_id=4,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="TODO",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/docs/guide.md",
+            display_path="docs/guide.md",
+            line_number=2,
+            line_text="TODO",
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        GrepSearchCompleted(request_id=4, query="todo", results=results),
+    )
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_results == (results[0],)
+    assert result.state.pending_grep_search_request_id is None
+
+def test_grep_search_completed_filters_results_by_filename_regex() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="todo",
+            grep_search_filename_filter="re:^docs/.+\\.md$",
+        ),
+        pending_grep_search_request_id=4,
+    )
+    results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+            line_number=1,
+            line_text="TODO",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/docs/guide.md",
+            display_path="docs/guide.md",
+            line_number=2,
+            line_text="TODO",
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        GrepSearchCompleted(request_id=4, query="todo", results=results),
+    )
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_results == (results[1],)
+
+def test_set_grep_search_field_rejects_conflicting_extensions() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
+    state = _reduce_state(state, SetGrepSearchField(field="include", value="py"))
+
+    result = reduce_app_state(state, SetGrepSearchField(field="exclude", value=".py"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_results == ()
+    assert (
+        result.state.command_palette.grep_search_error_message
+        == "Extensions cannot be included and excluded at the same time: py"
+    )
+    assert result.state.pending_grep_search_request_id is None
+    assert result.effects == ()
+
+def test_set_grep_search_field_rejects_invalid_extension_input() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
+
+    result = reduce_app_state(state, SetGrepSearchField(field="include", value="*.py"))
+
+    assert result.state.command_palette is not None
+    assert (
+        result.state.command_palette.grep_search_error_message
+        == "Invalid include extension: *.py"
+    )
+    assert result.effects == ()
+
+def test_set_grep_search_field_clears_results_when_keyword_becomes_empty() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="todo",
+            grep_search_keyword="todo",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                    line_number=1,
+                    line_text="TODO",
+                ),
+            ),
+        ),
+        pending_grep_search_request_id=4,
+        pending_child_pane_request_id=7,
+    )
+
+    result = reduce_app_state(state, SetGrepSearchField(field="keyword", value=""))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_results == ()
+    assert result.state.command_palette.grep_search_error_message is None
+    assert result.state.pending_grep_search_request_id is None
+    assert result.state.pending_child_pane_request_id is None
+    assert result.effects == ()
+
+def test_set_command_palette_query_reuses_completed_file_search_results_for_prefix_extension(
+) -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="read",
+            file_search_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/docs/readings.txt",
+                    display_path="docs/readings.txt",
+                ),
+            ),
+            file_search_cache_query="read",
+            file_search_cache_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/docs/readings.txt",
+                    display_path="docs/readings.txt",
+                ),
+            ),
+            file_search_cache_root_path="/home/tadashi/develop/zivo",
+            file_search_cache_show_hidden=False,
+        ),
+        pending_file_search_request_id=4,
+        next_request_id=5,
+    )
+
+    result = reduce_app_state(state, SetCommandPaletteQuery("readm"))
+
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=5,
+            current_path="/home/tadashi/develop/zivo",
+            cursor_path="/home/tadashi/develop/zivo/README.md",
+        ),
+    )
+    assert result.state.pending_file_search_request_id is None
+    assert result.state.pending_child_pane_request_id == 5
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.file_search_results == (
+        FileSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+        ),
+    )
+    assert result.state.next_request_id == 6
+
+def test_set_command_palette_query_runs_new_search_when_query_is_not_prefix_extension() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="read",
+            file_search_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+            file_search_cache_query="read",
+            file_search_cache_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+            file_search_cache_root_path="/home/tadashi/develop/zivo",
+            file_search_cache_show_hidden=False,
+        ),
+        next_request_id=4,
+    )
+
+    result = reduce_app_state(state, SetCommandPaletteQuery("rea"))
+
+    assert result.state.pending_file_search_request_id == 4
+    assert result.effects == (
+        RunFileSearchEffect(
+            request_id=4,
+            root_path="/home/tadashi/develop/zivo",
+            query="rea",
+            show_hidden=False,
+        ),
+    )
+
+def test_set_command_palette_query_runs_new_search_for_regex_queries() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="read",
+            file_search_cache_query="read",
+            file_search_cache_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+            file_search_cache_root_path="/home/tadashi/develop/zivo",
+            file_search_cache_show_hidden=False,
+        ),
+        next_request_id=4,
+    )
+
+    result = reduce_app_state(state, SetCommandPaletteQuery(r"re:^README\.md$"))
+
+    assert result.state.pending_file_search_request_id == 4
+    assert result.effects == (
+        RunFileSearchEffect(
+            request_id=4,
+            root_path="/home/tadashi/develop/zivo",
+            query=r"re:^README\.md$",
+            show_hidden=False,
+        ),
+    )
+
+def test_file_search_completed_updates_palette_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(state.command_palette, query="read"),
+        pending_file_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        FileSearchCompleted(
+            request_id=4,
+            query="read",
+            results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.file_search_results == (
+        FileSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+        ),
+    )
+    assert next_state.command_palette.file_search_cache_query == "read"
+    assert next_state.command_palette.file_search_cache_root_path == "/home/tadashi/develop/zivo"
+    assert next_state.command_palette.file_search_cache_show_hidden is False
+    assert next_state.pending_file_search_request_id is None
+
+def test_file_search_completed_does_not_cache_regex_queries() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(state.command_palette, query=r"re:^README\.md$"),
+        pending_file_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        FileSearchCompleted(
+            request_id=4,
+            query=r"re:^README\.md$",
+            results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.file_search_results == (
+        FileSearchResultState(
+            path="/home/tadashi/develop/zivo/README.md",
+            display_path="README.md",
+        ),
+    )
+    assert next_state.command_palette.file_search_cache_query == ""
+    assert next_state.command_palette.file_search_cache_results == ()
+
+def test_file_search_failed_sets_inline_error_for_invalid_regex() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="re:[",
+            file_search_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/README.md",
+                    display_path="README.md",
+                ),
+            ),
+        ),
+        pending_file_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        FileSearchFailed(
+            request_id=4,
+            query="re:[",
+            message="Invalid regex: unterminated character set",
+            invalid_query=True,
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.file_search_results == ()
+    assert (
+        next_state.command_palette.file_search_error_message
+        == "Invalid regex: unterminated character set"
+    )
+    assert next_state.notification is None
+    assert next_state.pending_file_search_request_id is None
+
+def test_submit_command_palette_uses_inline_error_message_when_present() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="re:[",
+            file_search_error_message="Invalid regex: unterminated character set",
+        ),
+    )
+
+    next_state = _reduce_state(state, SubmitCommandPalette())
+
+    assert next_state.notification == NotificationState(
+        level="warning",
+        message="Invalid regex: unterminated character set",
+    )
+
+def test_submit_command_palette_file_search_result_requests_snapshot() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="read",
+            file_search_results=(
+                FileSearchResultState(
+                    path="/home/tadashi/develop/zivo/docs/README.md",
+                    display_path="docs/README.md",
+                ),
+            ),
+            cursor_index=0,
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.state.command_palette is None
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path="/home/tadashi/develop/zivo/docs",
+            cursor_path="/home/tadashi/develop/zivo/docs/README.md",
+            blocking=True,
+        ),
+    )
+
+def test_grep_search_completed_updates_palette_results() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(state.command_palette, query="todo"),
+        pending_grep_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        GrepSearchCompleted(
+            request_id=4,
+            query="todo",
+            results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/zivo/app.py",
+                    display_path="src/zivo/app.py",
+                    line_number=42,
+                    line_text="TODO: update palette",
+                ),
+            ),
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.grep_search_results == (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/src/zivo/app.py",
+            display_path="src/zivo/app.py",
+            line_number=42,
+            line_text="TODO: update palette",
+        ),
+    )
+    assert next_state.pending_grep_search_request_id is None
+
+def test_grep_search_completed_requests_context_preview() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(state.command_palette, query="todo"),
+        pending_grep_search_request_id=4,
+    )
+    grep_result = GrepSearchResultState(
+        path="/home/tadashi/develop/zivo/src/zivo/app.py",
+        display_path="src/zivo/app.py",
+        line_number=42,
+        line_text="TODO: update palette",
+    )
+
+    result = reduce_app_state(
+        search_state,
+        GrepSearchCompleted(
+            request_id=4,
+            query="todo",
+            results=(grep_result,),
+        ),
+    )
+
+    assert result.state.pending_child_pane_request_id == 1
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=1,
+            current_path="/home/tadashi/develop/zivo",
+            cursor_path="/home/tadashi/develop/zivo/src/zivo/app.py",
+            grep_result=grep_result,
+            grep_context_lines=3,
+        ),
+    )
+
+def test_grep_search_completed_skips_context_preview_when_preview_disabled() -> None:
+    grep_result = GrepSearchResultState(
+        path="/home/tadashi/develop/zivo/src/zivo/app.py",
+        display_path="src/zivo/app.py",
+        line_number=42,
+        line_text="TODO: update palette",
+    )
+    search_state = replace(
+        _reduce_state(build_initial_app_state(), BeginGrepSearch()),
+        config=replace(
+            build_initial_app_state().config,
+            display=replace(build_initial_app_state().config.display, show_preview=False),
+        ),
+        command_palette=replace(
+            _reduce_state(build_initial_app_state(), BeginGrepSearch()).command_palette,
+            query="todo",
+        ),
+        pending_grep_search_request_id=4,
+    )
+
+    result = reduce_app_state(
+        search_state,
+        GrepSearchCompleted(
+            request_id=4,
+            query="todo",
+            results=(grep_result,),
+        ),
+    )
+
+    assert result.state.config.display.show_preview is False
+    assert result.state.pending_child_pane_request_id is None
+    assert result.effects == ()
+
+def test_grep_search_failed_sets_inline_error_for_invalid_regex() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    search_state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="re:[",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/zivo/app.py",
+                    display_path="src/zivo/app.py",
+                    line_number=42,
+                    line_text="TODO: update palette",
+                ),
+            ),
+        ),
+        pending_grep_search_request_id=4,
+    )
+
+    next_state = _reduce_state(
+        search_state,
+        GrepSearchFailed(
+            request_id=4,
+            query="re:[",
+            message="regex parse error",
+            invalid_query=True,
+        ),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.grep_search_results == ()
+    assert next_state.command_palette.grep_search_error_message == "regex parse error"
+    assert next_state.pending_grep_search_request_id is None
+
+def test_submit_command_palette_grep_result_requests_snapshot() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            query="todo",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/zivo/app.py",
+                    display_path="src/zivo/app.py",
+                    line_number=42,
+                    line_text="TODO: update palette",
+                ),
+            ),
+            cursor_index=0,
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "BUSY"
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path="/home/tadashi/develop/zivo/src/zivo",
+            cursor_path="/home/tadashi/develop/zivo/src/zivo/app.py",
+            blocking=True,
+        ),
+    )
+
+def test_cancel_grep_command_palette_restores_current_cursor_preview() -> None:
+    path = "/home/tadashi/develop/zivo/README.md"
+    grep_result = GrepSearchResultState(
+        path=path,
+        display_path="README.md",
+        line_number=3,
+        line_text="TODO: update docs",
+    )
+    state = replace(
+        _reduce_state(build_initial_app_state(), BeginGrepSearch()),
+        current_pane=replace(build_initial_app_state().current_pane, cursor_path=path),
+        command_palette=CommandPaletteState(
+            source="grep_search",
+            query="todo",
+            grep_search_results=(grep_result,),
+        ),
+        child_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(),
+            mode="preview",
+            preview_path=path,
+            preview_title="Preview: README.md:3",
+            preview_content="TODO: update docs\n",
+            preview_start_line=3,
+            preview_highlight_line=3,
+        ),
+    )
+
+    result = reduce_app_state(state, CancelCommandPalette())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.pending_child_pane_request_id == 1
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=1,
+            current_path="/home/tadashi/develop/zivo",
+            cursor_path=path,
+        ),
+        RunDirectorySizeEffect(
+            request_id=2,
+            paths=(
+                "/home/tadashi/develop/zivo/docs",
+                "/home/tadashi/develop/zivo/src",
+                "/home/tadashi/develop/zivo/tests",
+            ),
+        ),
+    )
+


### PR DESCRIPTION
## Summary
- split `src/zivo/state/reducer_palette.py` into shared, search, and replace workflow modules while keeping `handle_palette_action()` as the public entrypoint
- leave command-palette routing in the aggregate reducer and keep existing palette behavior/dispatch contracts intact
- move palette reducer tests out of `tests/test_state_reducer.py` into dedicated command/search/replace files

## Testing
- `uv run ruff check .`
- `uv run pytest tests/test_state_reducer.py tests/test_state_reducer_palette_commands.py tests/test_state_reducer_palette_search.py tests/test_state_reducer_palette_replace.py -q`
- `uv run pytest -q`  
  local macOS run fails in `tests/test_services_file_mutations.py` with `Operation not permitted: '/Users/tadashi/.Trash'` for three trash-related tests unrelated to this change

## Issue
- Closes #615
