### PR TITLE
[#637] Unify selection target helpers

### DIFF
--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -6,7 +6,14 @@ from dataclasses import dataclass
 
 from zivo.archive_utils import is_supported_archive_path
 
-from .models import AppState, DirectoryEntryState
+from .models import AppState
+from .selectors import (
+    select_current_entry_for_path,
+    select_has_visible_current_entries,
+    select_single_target_entry,
+    select_target_file_paths,
+    select_target_paths,
+)
 
 
 @dataclass(frozen=True)
@@ -154,14 +161,14 @@ def normalize_command_palette_cursor(state: AppState, cursor_index: int) -> int:
 
 
 def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, ...]:
-    target_paths = _select_target_paths(state)
-    replace_target_paths = _replace_target_file_paths(state)
+    target_paths = select_target_paths(state)
+    replace_target_paths = select_target_file_paths(state)
     selected_files_grep_target_paths = _selected_files_grep_target_paths(state)
-    single_target_entry = _single_target_entry(state, target_paths)
+    single_target_entry = select_single_target_entry(state)
     has_target = bool(target_paths)
     has_single_target = single_target_entry is not None
     current_path_is_bookmarked = state.current_path in state.config.bookmarks.paths
-    has_visible_entries = _has_visible_current_entries(state)
+    has_visible_entries = select_has_visible_current_entries(state)
     tab_count = len(state.browser_tabs) or 1
 
     items = [
@@ -453,85 +460,22 @@ def _hidden_files_label(state: AppState) -> str:
     return "Hide hidden files" if state.show_hidden else "Show hidden files"
 
 
-def _select_target_paths(state: AppState) -> tuple[str, ...]:
-    selected_paths = tuple(
-        entry.path
-        for entry in _active_current_entries(state)
-        if entry.path in state.current_pane.selected_paths
-    )
-    if selected_paths:
-        return selected_paths
-
-    cursor_entry = _current_entry(state)
-    if cursor_entry is None:
-        return ()
-    return (cursor_entry.path,)
-
-
-def _single_target_entry(
-    state: AppState,
-    target_paths: tuple[str, ...],
-) -> DirectoryEntryState | None:
-    if len(target_paths) != 1:
-        return None
-    return _entry_for_path(state, target_paths[0])
-
-
-def _current_entry(state: AppState) -> DirectoryEntryState | None:
-    return _entry_for_path(state, state.current_pane.cursor_path)
-
-
-def _entry_for_path(state: AppState, path: str | None) -> DirectoryEntryState | None:
-    if path is None:
-        return None
-    for entry in _active_current_entries(state):
-        if entry.path == path:
-            return entry
-    return None
-
-
-def _active_current_entries(state: AppState) -> tuple[DirectoryEntryState, ...]:
-    return state.current_pane.entries
-
-
-def _has_visible_current_entries(state: AppState) -> bool:
-    query = state.filter.query.casefold()
-    filter_is_active = state.filter.active and bool(state.filter.query)
-    for entry in _active_current_entries(state):
-        if entry.hidden and not state.show_hidden:
-            continue
-        if filter_is_active and query not in entry.name.casefold():
-            continue
-        return True
-    return False
-
-
 def _replace_target_file_paths(state: AppState) -> tuple[str, ...]:
-    selected_paths = tuple(
-        entry.path
-        for entry in _active_current_entries(state)
-        if entry.path in state.current_pane.selected_paths and entry.kind == "file"
-    )
-    if state.current_pane.selected_paths:
-        return selected_paths
-
-    cursor_entry = _current_entry(state)
-    if cursor_entry is None or cursor_entry.kind != "file":
-        return ()
-    return (cursor_entry.path,)
+    return select_target_file_paths(state)
 
 
 def _selected_files_grep_target_paths(state: AppState) -> tuple[str, ...]:
     """Return target file paths for selected-files-grep."""
-    selected_paths = tuple(
-        entry.path
-        for entry in _active_current_entries(state)
-        if entry.path in state.current_pane.selected_paths and entry.kind == "file"
-    )
+    target_paths = select_target_paths(state)
     if state.current_pane.selected_paths:
-        return selected_paths
+        return tuple(
+            path
+            for path in target_paths
+            if (entry := select_current_entry_for_path(state, path)) is not None
+            and entry.kind == "file"
+        )
 
-    cursor_entry = _current_entry(state)
+    cursor_entry = select_current_entry_for_path(state, state.current_pane.cursor_path)
     if cursor_entry is None or cursor_entry.kind != "file":
         return ()
     return (cursor_entry.path,)

--- a/src/zivo/state/reducer_common.py
+++ b/src/zivo/state/reducer_common.py
@@ -48,7 +48,11 @@ from .models import (
     PaneState,
     SortState,
 )
-from .selectors import select_target_paths, select_visible_current_entry_states
+from .selectors import (
+    select_current_entry_for_path,
+    select_single_target_entry,
+    select_visible_current_entry_states,
+)
 
 ReducerFn = Callable[[AppState, Action], ReduceResult]
 
@@ -617,19 +621,11 @@ def current_entry_for_path(
     state: AppState,
     path: str | None,
 ) -> DirectoryEntryState | None:
-    if path is None:
-        return None
-    for entry in active_current_entries(state):
-        if entry.path == path:
-            return entry
-    return None
+    return select_current_entry_for_path(state, path)
 
 
 def single_target_entry(state: AppState) -> DirectoryEntryState | None:
-    target_paths = select_target_paths(state)
-    if len(target_paths) != 1:
-        return None
-    return current_entry_for_path(state, target_paths[0])
+    return select_single_target_entry(state)
 
 
 def single_target_path(state: AppState) -> str | None:

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from stat import S_IMODE, filemode
+from typing import TYPE_CHECKING
 
 from zivo.archive_utils import is_supported_archive_path
 from zivo.models import (
@@ -32,11 +33,6 @@ from zivo.models import (
 )
 from zivo.theme_support import preview_syntax_theme_for_app_theme
 
-from .command_palette import (
-    CommandPaletteItem,
-    get_command_palette_items,
-    normalize_command_palette_cursor,
-)
 from .models import (
     AppState,
     CommandPaletteState,
@@ -48,6 +44,21 @@ from .models import (
     SortState,
     select_browser_tabs,
 )
+
+if TYPE_CHECKING:
+    from .command_palette import CommandPaletteItem
+
+
+def get_command_palette_items(state: AppState) -> tuple["CommandPaletteItem", ...]:
+    from .command_palette import get_command_palette_items
+
+    return get_command_palette_items(state)
+
+
+def normalize_command_palette_cursor(state: AppState, cursor_index: int) -> int:
+    from .command_palette import normalize_command_palette_cursor
+
+    return normalize_command_palette_cursor(state, cursor_index)
 
 SIDE_PANE_SORT = SortState(field="name", descending=False, directories_first=True)
 COMMAND_PALETTE_VISIBLE_WINDOW = 8
@@ -1215,6 +1226,53 @@ def select_target_paths(state: AppState) -> tuple[str, ...]:
     return (current_pane.cursor_entry.path,)
 
 
+def select_current_entry_for_path(
+    state: AppState,
+    path: str | None,
+) -> DirectoryEntryState | None:
+    """Return the visible current-pane entry for the given path."""
+
+    if path is None:
+        return None
+    for entry in select_visible_current_entry_states(state):
+        if entry.path == path:
+            return entry
+    return None
+
+
+def select_single_target_entry(state: AppState) -> DirectoryEntryState | None:
+    """Return the visible entry when exactly one target is active."""
+
+    target_paths = select_target_paths(state)
+    if len(target_paths) != 1:
+        return None
+    return select_current_entry_for_path(state, target_paths[0])
+
+
+def select_target_file_paths(state: AppState) -> tuple[str, ...]:
+    """Return visible file targets, preserving selection-before-cursor behavior."""
+
+    visible_entries = select_visible_current_entry_states(state)
+    selected_files = tuple(
+        entry.path
+        for entry in visible_entries
+        if entry.path in state.current_pane.selected_paths and entry.kind == "file"
+    )
+    if state.current_pane.selected_paths:
+        return selected_files
+
+    cursor_entry = select_current_entry_for_path(state, state.current_pane.cursor_path)
+    if cursor_entry is None or cursor_entry.kind != "file":
+        return ()
+    return (cursor_entry.path,)
+
+
+def select_has_visible_current_entries(state: AppState) -> bool:
+    """Return whether the current pane has at least one visible entry."""
+
+    return bool(select_visible_current_entry_states(state))
+
+
 def select_visible_current_entry_states(state: AppState) -> tuple[DirectoryEntryState, ...]:
     """Return filtered and sorted raw current-pane entries."""
 
@@ -1793,10 +1851,10 @@ def _select_search_window(
 
 
 def _select_command_palette_window(
-    items: tuple[CommandPaletteItem, ...],
+    items: tuple["CommandPaletteItem", ...],
     cursor_index: int,
     visible_window: int = COMMAND_PALETTE_VISIBLE_WINDOW,
-) -> tuple[tuple[tuple[int, CommandPaletteItem], ...], str]:
+) -> tuple[tuple[tuple[int, "CommandPaletteItem"], ...], str]:
     total = len(items)
     if total <= visible_window:
         return tuple(enumerate(items)), "Command Palette"

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -34,6 +34,7 @@ from zivo.state import (
     SubmitCommandPalette,
     build_initial_app_state,
     reduce_app_state,
+    select_command_palette_state,
 )
 
 
@@ -608,6 +609,38 @@ def test_show_attributes_warns_without_single_target() -> None:
         message="Show attributes requires a single target",
     )
 
+
+def test_select_command_palette_disables_replace_text_for_hidden_selected_file() -> None:
+    hidden_path = "/home/tadashi/develop/zivo/.env"
+    visible_path = "/home/tadashi/develop/zivo/README.md"
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(
+                DirectoryEntryState(hidden_path, ".env", "file", hidden=True),
+                DirectoryEntryState(visible_path, "README.md", "file"),
+            ),
+            cursor_path=visible_path,
+            selected_paths=frozenset({hidden_path}),
+        ),
+    )
+
+    palette_state = select_command_palette_state(
+        replace(
+            _reduce_state(state, BeginCommandPalette()),
+            command_palette=replace(CommandPaletteState(), query="replace text"),
+        )
+    )
+
+    assert palette_state is not None
+    assert [item.label for item in palette_state.items] == [
+        "Replace text in selected files",
+        "Replace text in found files",
+        "Replace text in grep results",
+    ]
+    assert palette_state.items[0].enabled is False
+
 def test_submit_command_palette_removes_current_directory_bookmark() -> None:
     state = _reduce_state(
         build_initial_app_state(
@@ -803,4 +836,3 @@ def test_begin_command_palette_clears_pending_key_sequence() -> None:
 
     assert next_state.ui_mode == "PALETTE"
     assert next_state.pending_key_sequence is None
-

--- a/tests/test_state_selectors.py
+++ b/tests/test_state_selectors.py
@@ -743,6 +743,46 @@ def test_select_target_paths_returns_empty_tuple_for_empty_directory() -> None:
     assert select_target_paths(state) == ()
 
 
+def test_select_current_entry_for_path_returns_none_for_filtered_entry() -> None:
+    hidden_path = "/home/tadashi/develop/zivo/README.md"
+    visible_path = "/home/tadashi/develop/zivo/docs"
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(
+                DirectoryEntryState(hidden_path, "README.md", "file"),
+                DirectoryEntryState(visible_path, "docs", "dir"),
+            ),
+            cursor_path=visible_path,
+        ),
+        filter=replace(build_initial_app_state().filter, query="docs", active=True),
+    )
+
+    assert selectors_module.select_current_entry_for_path(state, hidden_path) is None
+    assert selectors_module.select_current_entry_for_path(state, visible_path) is not None
+
+
+def test_select_target_file_paths_ignores_hidden_selected_entries_when_hidden_files_are_off(
+) -> None:
+    hidden_path = "/home/tadashi/develop/zivo/.env"
+    visible_path = "/home/tadashi/develop/zivo/README.md"
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(
+                DirectoryEntryState(hidden_path, ".env", "file", hidden=True),
+                DirectoryEntryState(visible_path, "README.md", "file"),
+            ),
+            cursor_path=visible_path,
+            selected_paths=frozenset({hidden_path}),
+        ),
+    )
+
+    assert selectors_module.select_target_file_paths(state) == ()
+
+
 def test_select_current_entries_marks_selected_rows() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, ToggleSelection("/home/tadashi/develop/zivo/README.md"))


### PR DESCRIPTION
## Summary
- unify current-pane selection and visible-entry lookup through shared selectors
- remove duplicated selection helpers from command palette and align palette enablement with visible entries
- add regression tests for filtered/hidden selection behavior

## Testing
- `uv run pytest tests/test_state_selectors.py tests/test_state_reducer_palette_commands.py tests/test_input_dispatch.py`
- `uv run ruff check .`

Refs #637
