### PR TITLE
[#636] Split reducer common helpers

### DIFF
--- a/src/zivo/state/entry_state_helpers.py
+++ b/src/zivo/state/entry_state_helpers.py
@@ -1,0 +1,182 @@
+"""Shared helpers for visible entries and target resolution."""
+
+from dataclasses import replace
+from functools import lru_cache
+
+from .models import AppState, DirectoryEntryState, DirectorySizeCacheEntry, SortState
+
+
+def visible_current_entry_states(state: AppState) -> tuple[DirectoryEntryState, ...]:
+    """Return filtered and sorted raw current-pane entries."""
+
+    return select_visible_entry_states(
+        state.current_pane.entries,
+        state.directory_size_cache,
+        state.show_hidden,
+        state.filter.query,
+        state.filter.active,
+        state.sort,
+    )
+
+
+def target_paths(state: AppState) -> tuple[str, ...]:
+    """Return selected paths, or the cursor path when nothing is selected."""
+
+    visible_entries = visible_current_entry_states(state)
+    selected_paths = tuple(
+        entry.path
+        for entry in visible_entries
+        if entry.path in state.current_pane.selected_paths
+    )
+    if selected_paths:
+        return selected_paths
+
+    cursor_entry = current_entry_for_path(state, state.current_pane.cursor_path)
+    if cursor_entry is None:
+        return ()
+    return (cursor_entry.path,)
+
+
+def current_entry_for_path(
+    state: AppState,
+    path: str | None,
+) -> DirectoryEntryState | None:
+    """Return the visible current-pane entry for the given path."""
+
+    if path is None:
+        return None
+    for entry in visible_current_entry_states(state):
+        if entry.path == path:
+            return entry
+    return None
+
+
+def single_target_entry(state: AppState) -> DirectoryEntryState | None:
+    """Return the visible entry when exactly one target is active."""
+
+    active_target_paths = target_paths(state)
+    if len(active_target_paths) != 1:
+        return None
+    return current_entry_for_path(state, active_target_paths[0])
+
+
+@lru_cache(maxsize=256)
+def select_visible_entry_states(
+    entries: tuple[DirectoryEntryState, ...],
+    directory_size_cache: tuple[DirectorySizeCacheEntry, ...],
+    show_hidden: bool,
+    query: str,
+    active: bool,
+    sort: SortState,
+) -> tuple[DirectoryEntryState, ...]:
+    visible_entries = _filter_hidden_entries(entries, show_hidden)
+    visible_entries = _filter_entries(visible_entries, query, active)
+    if sort.field == "size":
+        visible_entries = _overlay_directory_sizes(visible_entries, directory_size_cache)
+    return _sort_entries(visible_entries, sort)
+
+
+@lru_cache(maxsize=256)
+def _filter_hidden_entries(
+    entries: tuple[DirectoryEntryState, ...],
+    show_hidden: bool,
+) -> tuple[DirectoryEntryState, ...]:
+    if show_hidden:
+        return entries
+    return tuple(entry for entry in entries if not entry.hidden)
+
+
+@lru_cache(maxsize=256)
+def _filter_entries(
+    entries: tuple[DirectoryEntryState, ...],
+    query: str,
+    active: bool,
+) -> tuple[DirectoryEntryState, ...]:
+    if not active or not query:
+        return entries
+
+    lowered_query = query.casefold()
+    return tuple(entry for entry in entries if lowered_query in entry.name.casefold())
+
+
+@lru_cache(maxsize=256)
+def _sort_entries(
+    entries: tuple[DirectoryEntryState, ...],
+    sort: SortState,
+) -> tuple[DirectoryEntryState, ...]:
+    if sort.field == "size":
+        return _sort_entries_by_size(entries, sort)
+
+    directories = [entry for entry in entries if entry.kind == "dir"]
+    files = [entry for entry in entries if entry.kind == "file"]
+
+    sorted_directories = sorted(directories, key=_sort_key(sort.field), reverse=sort.descending)
+    sorted_files = sorted(files, key=_sort_key(sort.field), reverse=sort.descending)
+
+    if sort.directories_first:
+        combined = [*sorted_directories, *sorted_files]
+    else:
+        combined = sorted(entries, key=_sort_key(sort.field), reverse=sort.descending)
+
+    return tuple(combined)
+
+
+def _sort_entries_by_size(
+    entries: tuple[DirectoryEntryState, ...],
+    sort: SortState,
+) -> tuple[DirectoryEntryState, ...]:
+    key = _sort_size_key(sort.descending)
+    directories = [entry for entry in entries if entry.kind == "dir"]
+    files = [entry for entry in entries if entry.kind == "file"]
+    if sort.directories_first:
+        combined = [*sorted(directories, key=key), *sorted(files, key=key)]
+    else:
+        combined = sorted(entries, key=key)
+    return tuple(combined)
+
+
+def _sort_key(field: str):
+    if field == "modified":
+        return lambda entry: (
+            entry.modified_at is None,
+            entry.modified_at or 0,
+            entry.name.casefold(),
+        )
+    if field == "size":
+        return lambda entry: (
+            entry.size_bytes is None,
+            entry.size_bytes or -1,
+            entry.name.casefold(),
+        )
+    return lambda entry: entry.name.casefold()
+
+
+def _sort_size_key(descending: bool):
+    def key(entry: DirectoryEntryState) -> tuple[int, int, str]:
+        if entry.size_bytes is None:
+            return (1, 0, entry.name.casefold())
+        value = -entry.size_bytes if descending else entry.size_bytes
+        return (0, value, entry.name.casefold())
+
+    return key
+
+
+def _overlay_directory_sizes(
+    entries: tuple[DirectoryEntryState, ...],
+    directory_size_cache: tuple[DirectorySizeCacheEntry, ...],
+) -> tuple[DirectoryEntryState, ...]:
+    cache_by_path = _directory_size_cache_by_path(directory_size_cache)
+    return tuple(
+        replace(entry, size_bytes=cache_by_path[entry.path].size_bytes)
+        if entry.kind == "dir"
+        and entry.path in cache_by_path
+        and cache_by_path[entry.path].status == "ready"
+        else entry
+        for entry in entries
+    )
+
+
+def _directory_size_cache_by_path(
+    entries: tuple[DirectorySizeCacheEntry, ...],
+) -> dict[str, DirectorySizeCacheEntry]:
+    return {entry.path: entry for entry in entries}

--- a/src/zivo/state/reducer_common.py
+++ b/src/zivo/state/reducer_common.py
@@ -1,1176 +1,165 @@
-"""Shared helpers for reducer action handlers."""
+"""Compatibility exports for shared reducer helpers."""
 
-import os
 import platform as _platform_module
-from collections.abc import Callable
-from dataclasses import replace
-from pathlib import Path
 
-from zivo.archive_utils import is_supported_archive_path, resolve_zip_destination_input
-from zivo.models import (
-    AppConfig,
-    CreatePathRequest,
-    CreateZipArchiveRequest,
-    DeleteRequest,
-    ExternalLaunchRequest,
-    ExtractArchiveRequest,
-    FileMutationResult,
-    PasteRequest,
-    PasteSummary,
-    RenameRequest,
-    UndoEntry,
+from .entry_state_helpers import current_entry_for_path, single_target_entry
+from .reducer_config import (
+    CONFIG_EDITOR_CATEGORIES,
+    CONFIG_EDITOR_COMMANDS,
+    CONFIG_LOG_LEVELS,
+    CONFIG_PASTE_ACTIONS,
+    CONFIG_PREVIEW_MAX_KIB,
+    CONFIG_PREVIEW_SYNTAX_THEMES,
+    CONFIG_SORT_FIELDS,
+    CONFIG_SPLIT_TERMINAL_POSITIONS,
+    CONFIG_THEMES,
+    apply_config_to_runtime_state,
+    config_editor_field_ids,
+    config_editor_labels,
+    config_editor_visual_order,
+    cycle_choice,
+    cycle_config_editor_value,
+    cycle_editor_command,
+    move_config_cursor_visual,
+    normalize_config_editor_cursor,
 )
-from zivo.theme_support import SUPPORTED_APP_THEMES, SUPPORTED_PREVIEW_SYNTAX_THEMES
-
-from .actions import Action, RequestDirectorySizes
-from .effects import (
-    Effect,
-    LoadBrowserSnapshotEffect,
-    LoadChildPaneSnapshotEffect,
-    ReduceResult,
-    RunArchiveExtractEffect,
-    RunArchivePreparationEffect,
-    RunClipboardPasteEffect,
-    RunExternalLaunchEffect,
-    RunFileMutationEffect,
-    RunUndoEffect,
-    RunZipCompressEffect,
-    RunZipCompressPreparationEffect,
+from .reducer_pane_sync import (
+    directory_size_cache_by_path,
+    directory_size_target_paths,
+    maybe_request_directory_sizes,
+    normalize_child_pane_for_display,
+    sync_child_pane,
+    upsert_directory_size_entries,
+    visible_directory_paths,
 )
-from .models import (
-    AppState,
-    DirectoryEntryState,
-    DirectorySizeCacheEntry,
-    FileSearchResultState,
-    HistoryState,
-    NameConflictKind,
-    NotificationState,
-    PaneState,
-    SortState,
+from .reducer_path_helpers import (
+    REGEX_FILE_SEARCH_PREFIX,
+    REGEX_GREP_SEARCH_PREFIX,
+    active_current_entries,
+    current_entry_paths,
+    expand_and_validate_path,
+    filter_file_search_results,
+    format_go_to_path_completion,
+    is_regex_file_search_query,
+    list_matching_directory_paths,
+    move_cursor,
+    normalize_cursor_path,
+    normalize_selected_paths,
+    normalize_selection_anchor_path,
+    select_range_paths,
 )
-from .selectors import (
-    select_current_entry_for_path,
-    select_single_target_entry,
-    select_visible_current_entry_states,
+from .reducer_pending_input import (
+    build_extract_archive_request,
+    build_file_mutation_request,
+    build_zip_compress_request,
+    is_name_conflict_validation_error,
+    name_conflict_kind,
+    pending_input_parent_and_target,
 )
-
-ReducerFn = Callable[[AppState, Action], ReduceResult]
-
-CONFIG_SORT_FIELDS = ("name", "modified", "size")
-CONFIG_THEMES = SUPPORTED_APP_THEMES
-CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
-CONFIG_PREVIEW_MAX_KIB = (64, 128, 256, 512, 1024)
-CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
-CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
-CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
-CONFIG_SPLIT_TERMINAL_POSITIONS = ("bottom", "right", "overlay")
-REGEX_FILE_SEARCH_PREFIX = "re:"
-REGEX_GREP_SEARCH_PREFIX = "re:"
-
-
-def finalize(next_state: AppState, *effects: Effect) -> ReduceResult:
-    """Wrap a state transition and optional side effects into a ReduceResult.
-
-    This is the standard way to return from reducer action handlers.
-    The result will be further processed by _finalize_reduce_result in
-    reducer.py (viewport adjustment, tab sync, transient delta clearing).
-    """
-    return ReduceResult(state=next_state, effects=effects)
-
+from .reducer_pending_input import (
+    validate_pending_input as _validate_pending_input,
+)
+from .reducer_requests import (
+    ReducerFn,
+    browser_snapshot_invalidation_paths,
+    build_history_after_snapshot_load,
+    cursor_path_after_file_mutation,
+    finalize,
+    format_clipboard_message,
+    notification_for_external_launch,
+    notification_for_paste_summary,
+    request_snapshot_refresh,
+    restore_ui_mode_after_pending_input,
+    run_archive_extract_request,
+    run_archive_prepare_request,
+    run_external_launch_request,
+    run_file_mutation_request,
+    run_paste_request,
+    run_undo_request,
+    run_zip_compress_prepare_request,
+    run_zip_compress_request,
+    split_terminal_exit_message,
+)
 
 _is_macos = _platform_module.system() == "Darwin"
 
-
-def current_entry_paths(state: AppState) -> set[str]:
-    return {entry.path for entry in active_current_entries(state)}
-
-
-def active_current_entries(state: AppState) -> tuple[DirectoryEntryState, ...]:
-    return state.current_pane.entries
-
-
-def _resolve_input_path(query: str, base_path: str) -> Path | None:
-    raw_query = query.strip()
-    if not raw_query:
-        return None
-
-    candidate = Path(os.path.expanduser(raw_query))
-    if not candidate.is_absolute():
-        candidate = Path(base_path) / candidate
-
-    try:
-        return candidate.resolve(strict=False)
-    except (OSError, ValueError, RuntimeError):
-        return None
-
-
-def list_matching_directory_paths(query: str, base_path: str) -> tuple[str, ...]:
-    """Return matching directory candidates for go-to-path completion."""
-
-    raw_query = query.strip()
-    if not raw_query:
-        return ()
-
-    resolved = _resolve_input_path(raw_query, base_path)
-    if resolved is None:
-        return ()
-
-    has_trailing_separator = raw_query.endswith(os.sep)
-    if os.altsep is not None and raw_query.endswith(os.altsep):
-        has_trailing_separator = True
-
-    parent = resolved if has_trailing_separator else resolved.parent
-    prefix = "" if has_trailing_separator else resolved.name.casefold()
-    if not parent.exists() or not parent.is_dir():
-        return ()
-
-    matches: list[str] = []
-    try:
-        for child in parent.iterdir():
-            try:
-                if not child.is_dir():
-                    continue
-            except OSError:
-                continue
-
-            if prefix and not child.name.casefold().startswith(prefix):
-                continue
-            matches.append(str(child.resolve()))
-    except (OSError, PermissionError):
-        return ()
-
-    matches.sort(key=lambda path: (Path(path).name.casefold(), path))
-    return tuple(matches)
-
-
-def format_go_to_path_completion(
-    path: str,
-    query: str,
-    base_path: str,
-    *,
-    append_separator: bool,
-) -> str:
-    """Render a selected go-to-path completion in the user's current path style."""
-
-    raw_query = query.strip()
-    normalized_path = str(Path(path).resolve())
-    if raw_query.startswith("~"):
-        home = os.path.expanduser("~")
-        if normalized_path.startswith(home + os.sep):
-            rendered = "~" + normalized_path[len(home) :]
-        elif normalized_path == home:
-            rendered = "~"
-        else:
-            rendered = normalized_path
-    elif raw_query.startswith(os.sep) or (
-        os.altsep is not None and raw_query.startswith(os.altsep)
-    ):
-        rendered = normalized_path
-    else:
-        rendered = os.path.relpath(normalized_path, str(Path(base_path).resolve()))
-
-    if append_separator and rendered != os.sep:
-        rendered = rendered.rstrip(os.sep)
-        if not rendered.endswith(os.sep):
-            rendered = f"{rendered}{os.sep}"
-    return rendered
-
-
-def expand_and_validate_path(query: str, base_path: str) -> str | None:
-    """Expand ~, ., .. and validate path exists and is a directory."""
-    expanded = _resolve_input_path(query, base_path)
-    if expanded is None:
-        return None
-    try:
-        if not expanded.exists() or not expanded.is_dir():
-            return None
-        return str(expanded)
-    except (OSError, ValueError, RuntimeError):
-        return None
-
-
-def normalize_selected_paths(
-    selected_paths: frozenset[str],
-    entries: tuple[DirectoryEntryState, ...],
-) -> frozenset[str]:
-    entry_paths = {entry.path for entry in entries}
-    return frozenset(path for path in selected_paths if path in entry_paths)
-
-
-def normalize_selection_anchor_path(
-    anchor_path: str | None,
-    visible_paths: tuple[str, ...],
-) -> str | None:
-    if anchor_path in visible_paths:
-        return anchor_path
-    return None
-
-
-def move_cursor(
-    current_path: str | None,
-    visible_paths: tuple[str, ...],
-    delta: int,
-) -> str | None:
-    if not visible_paths:
-        return None
-
-    if current_path in visible_paths:
-        current_index = visible_paths.index(current_path)
-    else:
-        current_index = 0
-
-    next_index = max(0, min(len(visible_paths) - 1, current_index + delta))
-    return visible_paths[next_index]
-
-
-def select_range_paths(
-    anchor_path: str,
-    cursor_path: str,
-    visible_paths: tuple[str, ...],
-) -> frozenset[str]:
-    anchor_index = visible_paths.index(anchor_path)
-    cursor_index = visible_paths.index(cursor_path)
-    start = min(anchor_index, cursor_index)
-    end = max(anchor_index, cursor_index)
-    return frozenset(visible_paths[start : end + 1])
-
-
-def run_paste_request(state: AppState, request: PasteRequest) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=None,
-        paste_conflict=None,
-        delete_confirmation=None,
-        pending_paste_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunClipboardPasteEffect(request_id=request_id, request=request),),
-    )
-
-
-def run_external_launch_request(
-    state: AppState,
-    request: ExternalLaunchRequest,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        next_request_id=request_id + 1,
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunExternalLaunchEffect(request_id=request_id, request=request),),
-    )
-
-
-def run_file_mutation_request(
-    state: AppState,
-    request: RenameRequest | CreatePathRequest | DeleteRequest,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=None,
-        delete_confirmation=None,
-        pending_file_mutation_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunFileMutationEffect(request_id=request_id, request=request),),
-    )
-
-
-def run_undo_request(state: AppState, entry: UndoEntry) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=None,
-        pending_undo_entry=entry,
-        pending_undo_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunUndoEffect(request_id=request_id, entry=entry),),
-    )
-
-
-def run_archive_prepare_request(
-    state: AppState,
-    request: ExtractArchiveRequest,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=NotificationState(level="info", message="Preparing archive extraction"),
-        delete_confirmation=None,
-        archive_extract_confirmation=None,
-        archive_extract_progress=None,
-        pending_archive_prepare_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunArchivePreparationEffect(request_id=request_id, request=request),),
-    )
-
-
-def run_archive_extract_request(
-    state: AppState,
-    request: ExtractArchiveRequest,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=NotificationState(level="info", message="Extracting archive..."),
-        archive_extract_confirmation=None,
-        archive_extract_progress=None,
-        pending_archive_extract_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunArchiveExtractEffect(request_id=request_id, request=request),),
-    )
-
-
-def run_zip_compress_prepare_request(
-    state: AppState,
-    request: CreateZipArchiveRequest,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=NotificationState(level="info", message="Preparing zip compression"),
-        delete_confirmation=None,
-        archive_extract_confirmation=None,
-        archive_extract_progress=None,
-        zip_compress_confirmation=None,
-        zip_compress_progress=None,
-        pending_zip_compress_prepare_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunZipCompressPreparationEffect(request_id=request_id, request=request),),
-    )
-
-
-def run_zip_compress_request(
-    state: AppState,
-    request: CreateZipArchiveRequest,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        notification=NotificationState(level="info", message="Compressing as zip..."),
-        zip_compress_confirmation=None,
-        zip_compress_progress=None,
-        pending_zip_compress_request_id=request_id,
-        next_request_id=request_id + 1,
-        ui_mode="BUSY",
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(RunZipCompressEffect(request_id=request_id, request=request),),
-    )
-
-
-def cursor_path_after_file_mutation(
-    state: AppState,
-    result: FileMutationResult,
-) -> str | None:
-    active_entries = active_current_entries(state)
-    if result.removed_paths:
-        remaining_paths = [
-            entry.path
-            for entry in active_entries
-            if entry.path not in result.removed_paths
-        ]
-        if not remaining_paths:
-            return None
-        current_cursor = state.current_pane.cursor_path
-        if current_cursor is not None and current_cursor not in result.removed_paths:
-            return current_cursor
-        original_paths = [entry.path for entry in active_entries]
-        if current_cursor in original_paths:
-            current_index = original_paths.index(current_cursor)
-            if current_index < len(remaining_paths):
-                return remaining_paths[current_index]
-        return remaining_paths[-1]
-    return result.path
-
-
-def restore_ui_mode_after_pending_input(state: AppState) -> str:
-    if state.pending_input is None:
-        return "BROWSING"
-    if state.pending_input.extract_source_path is not None:
-        return "EXTRACT"
-    if state.pending_input.zip_source_paths is not None:
-        return "ZIP"
-    if state.pending_input.create_kind is not None:
-        return "CREATE"
-    return "RENAME"
-
-
-def browser_snapshot_invalidation_paths(
-    path: str,
-    *extra_paths: str | None,
-) -> tuple[str, ...]:
-    resolved_path = str(Path(path).expanduser().resolve())
-    paths = [resolved_path, str(Path(resolved_path).parent)]
-    for extra_path in extra_paths:
-        if extra_path is not None:
-            paths.append(str(Path(extra_path).expanduser().resolve()))
-    return tuple(dict.fromkeys(paths))
-
-
-def request_snapshot_refresh(
-    state: AppState,
-    *,
-    cursor_path: str | None = None,
-    keep_current_cursor: bool = True,
-) -> ReduceResult:
-    request_id = state.next_request_id
-    resolved_cursor_path = (
-        state.current_pane.cursor_path
-        if keep_current_cursor and cursor_path is None
-        else cursor_path
-    )
-    next_state = replace(
-        state,
-        pending_browser_snapshot_request_id=request_id,
-        pending_child_pane_request_id=None,
-        next_request_id=request_id + 1,
-    )
-    return ReduceResult(
-        state=next_state,
-        effects=(
-            LoadBrowserSnapshotEffect(
-                request_id=request_id,
-                path=state.current_path,
-                cursor_path=resolved_cursor_path,
-                blocking=False,
-                invalidate_paths=browser_snapshot_invalidation_paths(
-                    state.current_path,
-                    resolved_cursor_path,
-                ),
-            ),
-        ),
-    )
-
-
-def maybe_request_directory_sizes(
-    state: AppState,
-    reduce_state: ReducerFn,
-    *effects: Effect,
-) -> ReduceResult:
-    target_paths = directory_size_target_paths(state)
-    if not target_paths:
-        return ReduceResult(state=state, effects=effects)
-
-    cache_by_path = directory_size_cache_by_path(state.directory_size_cache)
-    pending_paths = tuple(
-        path
-        for path in target_paths
-        if cache_by_path.get(path) is not None and cache_by_path[path].status == "pending"
-    )
-    missing_paths = tuple(path for path in target_paths if cache_by_path.get(path) is None)
-
-    if not missing_paths:
-        if pending_paths and state.pending_directory_size_request_id is None:
-            return reduce_state(state, RequestDirectorySizes(pending_paths))
-        return ReduceResult(state=state, effects=effects)
-
-    request_paths = tuple(dict.fromkeys((*pending_paths, *missing_paths)))
-    result = reduce_state(state, RequestDirectorySizes(request_paths))
-    return ReduceResult(state=result.state, effects=(*effects, *result.effects))
-
-
-def directory_size_target_paths(state: AppState) -> tuple[str, ...]:
-    if not state.config.display.show_directory_sizes and state.sort.field != "size":
-        return ()
-
-    return tuple(
-        dict.fromkeys(
-            visible_directory_paths(
-                select_visible_current_entry_states(state),
-                show_hidden=True,
-            )
-        )
-    )
-
-
-def visible_directory_paths(
-    entries: tuple[DirectoryEntryState, ...],
-    show_hidden: bool,
-) -> tuple[str, ...]:
-    return tuple(
-        entry.path
-        for entry in entries
-        if entry.kind == "dir" and (show_hidden or not entry.hidden)
-    )
-
-
-def directory_size_cache_by_path(
-    entries: tuple[DirectorySizeCacheEntry, ...],
-) -> dict[str, DirectorySizeCacheEntry]:
-    return {entry.path: entry for entry in entries}
-
-
-def upsert_directory_size_entries(
-    current_entries: tuple[DirectorySizeCacheEntry, ...],
-    new_entries: tuple[DirectorySizeCacheEntry, ...],
-) -> tuple[DirectorySizeCacheEntry, ...]:
-    cache_by_path = directory_size_cache_by_path(current_entries)
-    for entry in new_entries:
-        cache_by_path[entry.path] = entry
-    return tuple(sorted(cache_by_path.values(), key=lambda entry: entry.path))
-
-
-def sync_child_pane(
-    state: AppState,
-    cursor_path: str | None,
-    reduce_state: ReducerFn,
-) -> ReduceResult:
-    entry = current_entry_for_path(state, cursor_path)
-    if entry is None:
-        next_state = replace(
-            state,
-            child_pane=PaneState(directory_path=state.current_path, entries=()),
-            pending_child_pane_request_id=None,
-        )
-        return maybe_request_directory_sizes(next_state, reduce_state)
-
-    if entry.kind != "dir" and not is_supported_archive_path(entry.path):
-        if not state.config.display.show_preview:
-            next_child_pane = PaneState(directory_path=state.current_path, entries=())
-            if (
-                state.pending_child_pane_request_id is None
-                and state.child_pane == next_child_pane
-            ):
-                return maybe_request_directory_sizes(state, reduce_state)
-            next_state = replace(
-                state,
-                child_pane=next_child_pane,
-                pending_child_pane_request_id=None,
-            )
-            return maybe_request_directory_sizes(next_state, reduce_state)
-
-    if state.pending_child_pane_request_id is None and _child_pane_matches_entry(
-        state.child_pane,
-        entry,
-    ):
-        return maybe_request_directory_sizes(state, reduce_state)
-
-    request_id = state.next_request_id
-    next_state = replace(
-        state,
-        pending_child_pane_request_id=request_id,
-        next_request_id=request_id + 1,
-    )
-    return maybe_request_directory_sizes(
-        next_state,
-        reduce_state,
-        LoadChildPaneSnapshotEffect(
-            request_id=request_id,
-            current_path=state.current_path,
-            cursor_path=entry.path,
-            preview_max_bytes=state.config.display.preview_max_kib * 1024,
-        ),
-    )
-
-
-def _child_pane_matches_entry(
-    child_pane: PaneState,
-    entry: DirectoryEntryState,
-) -> bool:
-    if entry.kind == "dir" or is_supported_archive_path(entry.path):
-        return child_pane.mode == "entries" and child_pane.directory_path == entry.path
-    return (
-        child_pane.mode == "preview"
-        and child_pane.preview_path == entry.path
-        and child_pane.preview_title is None
-        and child_pane.preview_start_line is None
-        and child_pane.preview_highlight_line is None
-    )
-
-
-def normalize_child_pane_for_display(
-    current_path: str,
-    child_pane: PaneState,
-    *,
-    show_preview: bool,
-) -> PaneState:
-    if show_preview or child_pane.mode != "preview":
-        return child_pane
-    return PaneState(directory_path=current_path, entries=())
-
-
-def current_entry_for_path(
-    state: AppState,
-    path: str | None,
-) -> DirectoryEntryState | None:
-    return select_current_entry_for_path(state, path)
-
-
-def single_target_entry(state: AppState) -> DirectoryEntryState | None:
-    return select_single_target_entry(state)
-
-
-def single_target_path(state: AppState) -> str | None:
+__all__ = [
+    "CONFIG_EDITOR_CATEGORIES",
+    "CONFIG_EDITOR_COMMANDS",
+    "CONFIG_LOG_LEVELS",
+    "CONFIG_PASTE_ACTIONS",
+    "CONFIG_PREVIEW_MAX_KIB",
+    "CONFIG_PREVIEW_SYNTAX_THEMES",
+    "CONFIG_SORT_FIELDS",
+    "CONFIG_SPLIT_TERMINAL_POSITIONS",
+    "CONFIG_THEMES",
+    "REGEX_FILE_SEARCH_PREFIX",
+    "REGEX_GREP_SEARCH_PREFIX",
+    "ReducerFn",
+    "_is_macos",
+    "active_current_entries",
+    "apply_config_to_runtime_state",
+    "browser_snapshot_invalidation_paths",
+    "build_extract_archive_request",
+    "build_file_mutation_request",
+    "build_history_after_snapshot_load",
+    "build_zip_compress_request",
+    "config_editor_field_ids",
+    "config_editor_labels",
+    "config_editor_visual_order",
+    "current_entry_for_path",
+    "current_entry_paths",
+    "cursor_path_after_file_mutation",
+    "cycle_choice",
+    "cycle_config_editor_value",
+    "cycle_editor_command",
+    "directory_size_cache_by_path",
+    "directory_size_target_paths",
+    "expand_and_validate_path",
+    "filter_file_search_results",
+    "finalize",
+    "format_clipboard_message",
+    "format_go_to_path_completion",
+    "is_name_conflict_validation_error",
+    "is_regex_file_search_query",
+    "list_matching_directory_paths",
+    "maybe_request_directory_sizes",
+    "move_config_cursor_visual",
+    "move_cursor",
+    "name_conflict_kind",
+    "normalize_child_pane_for_display",
+    "normalize_config_editor_cursor",
+    "normalize_cursor_path",
+    "normalize_selected_paths",
+    "normalize_selection_anchor_path",
+    "notification_for_external_launch",
+    "notification_for_paste_summary",
+    "pending_input_parent_and_target",
+    "request_snapshot_refresh",
+    "restore_ui_mode_after_pending_input",
+    "run_archive_extract_request",
+    "run_archive_prepare_request",
+    "run_external_launch_request",
+    "run_file_mutation_request",
+    "run_paste_request",
+    "run_undo_request",
+    "run_zip_compress_prepare_request",
+    "run_zip_compress_request",
+    "select_range_paths",
+    "single_target_entry",
+    "single_target_path",
+    "split_terminal_exit_message",
+    "sync_child_pane",
+    "upsert_directory_size_entries",
+    "validate_pending_input",
+    "visible_directory_paths",
+]
+
+
+def validate_pending_input(state) -> str | None:
+    return _validate_pending_input(state, is_macos=_is_macos)
+
+
+def single_target_path(state) -> str | None:
     entry = single_target_entry(state)
     return entry.path if entry else None
-
-
-def normalize_cursor_path(
-    entries: tuple[DirectoryEntryState, ...],
-    current_cursor: str | None,
-) -> str | None:
-    entry_paths = {entry.path for entry in entries}
-    if current_cursor in entry_paths:
-        return current_cursor
-    if not entries:
-        return None
-    return entries[0].path
-
-
-def normalize_config_editor_cursor(cursor_index: int) -> int:
-    return max(0, min(len(config_editor_labels()) - 1, cursor_index))
-
-
-def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) -> AppConfig:
-    field_id = config_editor_field_ids()[normalize_config_editor_cursor(cursor_index)]
-    if field_id == "editor.command":
-        return replace(
-            config,
-            editor=replace(
-                config.editor,
-                command=cycle_editor_command(config.editor.command, delta),
-            ),
-        )
-    if field_id == "display.show_hidden_files":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                show_hidden_files=not config.display.show_hidden_files,
-            ),
-        )
-    if field_id == "display.show_directory_sizes":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                show_directory_sizes=not config.display.show_directory_sizes,
-            ),
-        )
-    if field_id == "display.show_preview":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                show_preview=not config.display.show_preview,
-            ),
-        )
-    if field_id == "display.show_help_bar":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                show_help_bar=not config.display.show_help_bar,
-            ),
-        )
-    if field_id == "display.theme":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                theme=cycle_choice(
-                    CONFIG_THEMES,
-                    config.display.theme,
-                    delta,
-                ),
-            ),
-        )
-    if field_id == "display.preview_syntax_theme":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                preview_syntax_theme=cycle_choice(
-                    CONFIG_PREVIEW_SYNTAX_THEMES,
-                    config.display.preview_syntax_theme,
-                    delta,
-                ),
-            ),
-        )
-    if field_id == "display.preview_max_kib":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                preview_max_kib=cycle_choice(
-                    CONFIG_PREVIEW_MAX_KIB,
-                    config.display.preview_max_kib,
-                    delta,
-                ),
-            ),
-        )
-    if field_id == "display.default_sort_field":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                default_sort_field=cycle_choice(
-                    CONFIG_SORT_FIELDS,
-                    config.display.default_sort_field,
-                    delta,
-                ),
-            ),
-        )
-    if field_id == "display.default_sort_descending":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                default_sort_descending=not config.display.default_sort_descending,
-            ),
-        )
-    if field_id == "display.directories_first":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                directories_first=not config.display.directories_first,
-            ),
-        )
-    if field_id == "display.grep_preview_context_lines":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                grep_preview_context_lines=max(
-                    0, config.display.grep_preview_context_lines + delta
-                ),
-            ),
-        )
-    if field_id == "display.split_terminal_position":
-        return replace(
-            config,
-            display=replace(
-                config.display,
-                split_terminal_position=cycle_choice(
-                    CONFIG_SPLIT_TERMINAL_POSITIONS,
-                    config.display.split_terminal_position,
-                    delta,
-                ),
-            ),
-        )
-    if field_id == "behavior.confirm_delete":
-        return replace(
-            config,
-            behavior=replace(
-                config.behavior,
-                confirm_delete=not config.behavior.confirm_delete,
-            ),
-        )
-    if field_id == "logging.level":
-        return replace(
-            config,
-            logging=replace(
-                config.logging,
-                level=cycle_choice(
-                    CONFIG_LOG_LEVELS,
-                    config.logging.level,
-                    delta,
-                ),
-            ),
-        )
-    return replace(
-        config,
-        behavior=replace(
-            config.behavior,
-            paste_conflict_action=cycle_choice(
-                CONFIG_PASTE_ACTIONS,
-                config.behavior.paste_conflict_action,
-                delta,
-            ),
-        ),
-    )
-
-
-def cycle_choice(options: tuple[str, ...], current: str, delta: int) -> str:
-    current_index = options.index(current) if current in options else 0
-    return options[(current_index + delta) % len(options)]
-
-
-def cycle_editor_command(current: str | None, delta: int) -> str | None:
-    if current in CONFIG_EDITOR_COMMANDS:
-        current_index = CONFIG_EDITOR_COMMANDS.index(current)
-    else:
-        current_index = len(CONFIG_EDITOR_COMMANDS)
-    return CONFIG_EDITOR_COMMANDS[(current_index + delta) % len(CONFIG_EDITOR_COMMANDS)]
-
-
-def config_editor_field_ids() -> tuple[str, ...]:
-    return (
-        "editor.command",
-        "display.show_hidden_files",
-        "display.theme",
-        "display.show_directory_sizes",
-        "display.show_preview",
-        "display.preview_syntax_theme",
-        "display.preview_max_kib",
-        "display.show_help_bar",
-        "display.default_sort_field",
-        "display.default_sort_descending",
-        "display.directories_first",
-        "display.grep_preview_context_lines",
-        "display.split_terminal_position",
-        "behavior.confirm_delete",
-        "behavior.paste_conflict_action",
-        "logging.level",
-    )
-
-
-def config_editor_labels() -> tuple[str, ...]:
-    return (
-        "Editor command",
-        "Show hidden files",
-        "Theme",
-        "Show directory sizes",
-        "Show preview",
-        "Preview syntax theme",
-        "Preview max KiB",
-        "Show help bar",
-        "Default sort field",
-        "Default sort descending",
-        "Directories first",
-        "Grep preview context lines",
-        "Split terminal position",
-        "Confirm delete",
-        "Paste conflict action",
-        "Log level",
-    )
-
-
-CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
-    ("External", (0,)),
-    ("Display", (2, 5, 1, 3, 4, 6, 7, 11, 12)),
-    ("Sorting", (8, 9, 10)),
-    ("Behavior", (13, 14)),
-    ("Logging", (15,)),
-)
-
-
-def config_editor_visual_order() -> tuple[int, ...]:
-    """Return field indices in visual display order."""
-    result: list[int] = []
-    for _header, field_indices in CONFIG_EDITOR_CATEGORIES:
-        result.extend(field_indices)
-    return tuple(result)
-
-
-def move_config_cursor_visual(cursor_index: int, delta: int) -> int:
-    """Move cursor by *delta* steps in visual order, returning the new field index."""
-    order = config_editor_visual_order()
-    try:
-        pos = order.index(cursor_index)
-    except ValueError:
-        pos = 0
-    new_pos = max(0, min(len(order) - 1, pos + delta))
-    return order[new_pos]
-
-
-def apply_config_to_runtime_state(state: AppState, config: AppConfig) -> AppState:
-    return replace(
-        state,
-        show_hidden=config.display.show_hidden_files,
-        show_help_bar=config.display.show_help_bar,
-        sort=SortState(
-            field=config.display.default_sort_field,
-            descending=config.display.default_sort_descending,
-            directories_first=config.display.directories_first,
-        ),
-        confirm_delete=config.behavior.confirm_delete,
-        paste_conflict_action=config.behavior.paste_conflict_action,
-    )
-
-
-def validate_pending_input(state: AppState) -> str | None:
-    if state.pending_input is None:
-        return "No input is active"
-
-    if state.pending_input.extract_source_path is not None:
-        destination = state.pending_input.value.strip()
-        if not destination:
-            return "Destination path cannot be empty"
-        source_path = Path(state.pending_input.extract_source_path)
-        resolved_destination = Path(destination).expanduser()
-        if not resolved_destination.is_absolute():
-            resolved_destination = source_path.parent / resolved_destination
-        resolved_destination = resolved_destination.resolve(strict=False)
-        if resolved_destination == source_path:
-            return "Destination path cannot be the archive file itself"
-        if resolved_destination.exists() and not resolved_destination.is_dir():
-            return "Destination path must be a directory"
-        return None
-
-    if state.pending_input.zip_source_paths is not None:
-        destination = state.pending_input.value.strip()
-        if not destination:
-            return "Destination path cannot be empty"
-        resolved_destination = Path(
-            resolve_zip_destination_input(state.current_pane.directory_path, destination)
-        )
-        if resolved_destination.suffix.casefold() != ".zip":
-            return "Destination path must end with .zip"
-        if resolved_destination.exists() and resolved_destination.is_dir():
-            return "Destination path already exists as a directory"
-
-        for source_path_str in state.pending_input.zip_source_paths:
-            source_path = Path(source_path_str).expanduser().resolve()
-            if resolved_destination == source_path:
-                return "Destination path cannot be one of the source paths"
-            if source_path.is_dir() and not source_path.is_symlink():
-                if resolved_destination.is_relative_to(source_path):
-                    return "Destination path cannot be inside a directory being compressed"
-        return None
-
-    name = state.pending_input.value
-    if not name:
-        return "Name cannot be empty"
-    if name in {".", ".."}:
-        return "'.' and '..' are not valid names"
-    if "/" in name or "\\" in name:
-        return "Names cannot include path separators"
-    if _is_macos and ":" in name:
-        return "Names cannot include colons"
-
-    parent_path, current_target_path = pending_input_parent_and_target(state)
-    if parent_path is None:
-        return "Unable to resolve target directory"
-
-    existing_paths = current_entry_paths(state)
-    if _is_macos:
-        name_cf = name.casefold()
-        for existing_path in existing_paths:
-            existing_name_cf = Path(existing_path).name.casefold()
-            if existing_name_cf == name_cf and existing_path != current_target_path:
-                return f"An entry named '{name}' already exists"
-    else:
-        candidate_path = str(Path(parent_path) / name)
-        if candidate_path in existing_paths and candidate_path != current_target_path:
-            return f"An entry named '{name}' already exists"
-    return None
-
-
-def is_name_conflict_validation_error(state: AppState, message: str) -> bool:
-    return state.pending_input is not None and message == (
-        f"An entry named '{state.pending_input.value}' already exists"
-    )
-
-
-def name_conflict_kind(state: AppState) -> NameConflictKind:
-    if state.pending_input is not None and state.pending_input.create_kind == "file":
-        return "create_file"
-    if state.pending_input is not None and state.pending_input.create_kind == "dir":
-        return "create_dir"
-    return "rename"
-
-
-def build_file_mutation_request(
-    state: AppState,
-) -> RenameRequest | CreatePathRequest | None:
-    if state.pending_input is None:
-        return None
-    if state.ui_mode == "RENAME" and state.pending_input.target_path is not None:
-        return RenameRequest(
-            source_path=state.pending_input.target_path,
-            new_name=state.pending_input.value,
-        )
-    if state.ui_mode == "CREATE" and state.pending_input.create_kind is not None:
-        return CreatePathRequest(
-            parent_dir=state.current_pane.directory_path,
-            name=state.pending_input.value,
-            kind=state.pending_input.create_kind,
-        )
-    return None
-
-
-def build_extract_archive_request(state: AppState) -> ExtractArchiveRequest | None:
-    if state.pending_input is None or state.pending_input.extract_source_path is None:
-        return None
-
-    destination = state.pending_input.value.strip()
-    if not destination:
-        return None
-
-    source_path = Path(state.pending_input.extract_source_path).expanduser().resolve()
-    resolved_destination = Path(destination).expanduser()
-    if not resolved_destination.is_absolute():
-        resolved_destination = source_path.parent / resolved_destination
-
-    return ExtractArchiveRequest(
-        source_path=str(source_path),
-        destination_path=str(resolved_destination.resolve(strict=False)),
-    )
-
-
-def build_zip_compress_request(state: AppState) -> CreateZipArchiveRequest | None:
-    if state.pending_input is None or state.pending_input.zip_source_paths is None:
-        return None
-
-    destination = state.pending_input.value.strip()
-    if not destination:
-        return None
-
-    return CreateZipArchiveRequest(
-        source_paths=state.pending_input.zip_source_paths,
-        destination_path=resolve_zip_destination_input(
-            state.current_pane.directory_path,
-            destination,
-        ),
-        root_dir=state.current_pane.directory_path,
-    )
-
-
-def pending_input_parent_and_target(state: AppState) -> tuple[str | None, str | None]:
-    if state.pending_input is None:
-        return (None, None)
-    if state.ui_mode == "RENAME" and state.pending_input.target_path is not None:
-        target_path = Path(state.pending_input.target_path)
-        return (str(target_path.parent), str(target_path))
-    if state.ui_mode == "CREATE":
-        return (state.current_pane.directory_path, None)
-    if state.ui_mode == "EXTRACT" and state.pending_input.extract_source_path is not None:
-        source_path = Path(state.pending_input.extract_source_path)
-        return (str(source_path.parent), None)
-    if state.ui_mode == "ZIP" and state.pending_input.zip_source_paths is not None:
-        return (state.current_pane.directory_path, None)
-    return (None, None)
-
-
-def filter_file_search_results(
-    results: tuple[FileSearchResultState, ...],
-    normalized_query: str,
-) -> tuple[FileSearchResultState, ...]:
-    return tuple(
-        result
-        for result in results
-        if normalized_query in Path(result.path).name.casefold()
-    )
-
-
-def is_regex_file_search_query(query: str) -> bool:
-    return query.strip().startswith(REGEX_FILE_SEARCH_PREFIX)
-
-
-def format_clipboard_message(prefix: str, paths: tuple[str, ...]) -> str:
-    noun = "item" if len(paths) == 1 else "items"
-    return f"{prefix} {len(paths)} {noun} to clipboard"
-
-
-def notification_for_external_launch(
-    request: ExternalLaunchRequest,
-) -> NotificationState | None:
-    if request.kind != "copy_paths":
-        return None
-    noun = "path" if len(request.paths) == 1 else "paths"
-    return NotificationState(
-        level="info",
-        message=f"Copied {len(request.paths)} {noun} to system clipboard",
-    )
-
-
-def split_terminal_exit_message(exit_code: int | None) -> str:
-    if exit_code is None:
-        return "Split terminal closed"
-    return f"Split terminal closed (exit {exit_code})"
-
-
-def notification_for_paste_summary(summary: PasteSummary) -> NotificationState:
-    verb = "Copied" if summary.mode == "copy" else "Moved"
-    if summary.failure_count and summary.success_count:
-        return NotificationState(
-            level="warning",
-            message=(
-                f"{verb} {summary.success_count}/{summary.total_count} items"
-                f" with {summary.failure_count} failure(s)"
-            ),
-        )
-    if summary.failure_count and not summary.success_count and not summary.skipped_count:
-        return NotificationState(
-            level="error",
-            message=f"Failed to {summary.mode} {summary.total_count} item(s)",
-        )
-    if summary.skipped_count and not summary.success_count and not summary.failure_count:
-        return NotificationState(
-            level="info",
-            message=f"Skipped {summary.skipped_count} conflicting item(s)",
-        )
-    message = f"{verb} {summary.success_count} item(s)"
-    if summary.skipped_count:
-        message += f", skipped {summary.skipped_count}"
-    if summary.overwrote_count:
-        message += ", undo unavailable for overwritten items"
-    return NotificationState(level="info", message=message)
-
-
-def build_history_after_snapshot_load(
-    state: AppState,
-    next_path: str,
-) -> HistoryState:
-    previous_path = state.current_path
-    new_history = state.history
-
-    if not state.history.back and not state.history.forward:
-        if next_path != previous_path:
-            new_history = HistoryState(
-                back=(previous_path,),
-                forward=(),
-                visited_all=(previous_path, next_path),
-            )
-        return new_history
-
-    if next_path != previous_path:
-        history = state.history
-        if history.forward and next_path == history.forward[0]:
-            new_history = HistoryState(
-                back=(*history.back, previous_path),
-                forward=history.forward[1:],
-                visited_all=history.visited_all,
-            )
-        elif history.back and next_path == history.back[-1]:
-            new_history = HistoryState(
-                back=history.back[:-1],
-                forward=(previous_path, *history.forward),
-                visited_all=history.visited_all,
-            )
-        else:
-            visited_all = history.visited_all
-            if not visited_all or visited_all[-1] != next_path:
-                visited_all = (*visited_all, next_path)
-            new_history = HistoryState(
-                back=(*history.back, previous_path),
-                forward=(),
-                visited_all=visited_all,
-            )
-    else:
-        new_history = HistoryState(
-            back=state.history.back,
-            forward=state.history.forward,
-            visited_all=state.history.visited_all,
-        )
-    return new_history

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -1,0 +1,331 @@
+"""Shared config editor definitions and helpers."""
+
+from dataclasses import replace
+
+from zivo.models import AppConfig
+from zivo.theme_support import SUPPORTED_APP_THEMES, SUPPORTED_PREVIEW_SYNTAX_THEMES
+
+from .models import SortState
+
+CONFIG_SORT_FIELDS = ("name", "modified", "size")
+CONFIG_THEMES = SUPPORTED_APP_THEMES
+CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
+CONFIG_PREVIEW_MAX_KIB = (64, 128, 256, 512, 1024)
+CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
+CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
+CONFIG_SPLIT_TERMINAL_POSITIONS = ("bottom", "right", "overlay")
+
+
+def normalize_config_editor_cursor(cursor_index: int) -> int:
+    return max(0, min(len(config_editor_labels()) - 1, cursor_index))
+
+
+def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) -> AppConfig:
+    field_id = config_editor_field_ids()[normalize_config_editor_cursor(cursor_index)]
+    if field_id == "editor.command":
+        return replace(
+            config,
+            editor=replace(
+                config.editor,
+                command=cycle_editor_command(config.editor.command, delta),
+            ),
+        )
+    if field_id == "display.show_hidden_files":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                show_hidden_files=not config.display.show_hidden_files,
+            ),
+        )
+    if field_id == "display.show_directory_sizes":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                show_directory_sizes=not config.display.show_directory_sizes,
+            ),
+        )
+    if field_id == "display.show_preview":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                show_preview=not config.display.show_preview,
+            ),
+        )
+    if field_id == "display.show_help_bar":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                show_help_bar=not config.display.show_help_bar,
+            ),
+        )
+    if field_id == "display.theme":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                theme=cycle_choice(
+                    CONFIG_THEMES,
+                    config.display.theme,
+                    delta,
+                ),
+            ),
+        )
+    if field_id == "display.preview_syntax_theme":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                preview_syntax_theme=cycle_choice(
+                    CONFIG_PREVIEW_SYNTAX_THEMES,
+                    config.display.preview_syntax_theme,
+                    delta,
+                ),
+            ),
+        )
+    if field_id == "display.preview_max_kib":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                preview_max_kib=cycle_choice(
+                    CONFIG_PREVIEW_MAX_KIB,
+                    config.display.preview_max_kib,
+                    delta,
+                ),
+            ),
+        )
+    if field_id == "display.default_sort_field":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                default_sort_field=cycle_choice(
+                    CONFIG_SORT_FIELDS,
+                    config.display.default_sort_field,
+                    delta,
+                ),
+            ),
+        )
+    if field_id == "display.default_sort_descending":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                default_sort_descending=not config.display.default_sort_descending,
+            ),
+        )
+    if field_id == "display.directories_first":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                directories_first=not config.display.directories_first,
+            ),
+        )
+    if field_id == "display.grep_preview_context_lines":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                grep_preview_context_lines=max(
+                    0, config.display.grep_preview_context_lines + delta
+                ),
+            ),
+        )
+    if field_id == "display.split_terminal_position":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                split_terminal_position=cycle_choice(
+                    CONFIG_SPLIT_TERMINAL_POSITIONS,
+                    config.display.split_terminal_position,
+                    delta,
+                ),
+            ),
+        )
+    if field_id == "behavior.confirm_delete":
+        return replace(
+            config,
+            behavior=replace(
+                config.behavior,
+                confirm_delete=not config.behavior.confirm_delete,
+            ),
+        )
+    if field_id == "logging.level":
+        return replace(
+            config,
+            logging=replace(
+                config.logging,
+                level=cycle_choice(
+                    CONFIG_LOG_LEVELS,
+                    config.logging.level,
+                    delta,
+                ),
+            ),
+        )
+    return replace(
+        config,
+        behavior=replace(
+            config.behavior,
+            paste_conflict_action=cycle_choice(
+                CONFIG_PASTE_ACTIONS,
+                config.behavior.paste_conflict_action,
+                delta,
+            ),
+        ),
+    )
+
+
+def cycle_choice(options: tuple[str, ...], current: str, delta: int) -> str:
+    current_index = options.index(current) if current in options else 0
+    return options[(current_index + delta) % len(options)]
+
+
+def cycle_editor_command(current: str | None, delta: int) -> str | None:
+    if current in CONFIG_EDITOR_COMMANDS:
+        current_index = CONFIG_EDITOR_COMMANDS.index(current)
+    else:
+        current_index = len(CONFIG_EDITOR_COMMANDS)
+    return CONFIG_EDITOR_COMMANDS[(current_index + delta) % len(CONFIG_EDITOR_COMMANDS)]
+
+
+def config_editor_field_ids() -> tuple[str, ...]:
+    return (
+        "editor.command",
+        "display.show_hidden_files",
+        "display.theme",
+        "display.show_directory_sizes",
+        "display.show_preview",
+        "display.preview_syntax_theme",
+        "display.preview_max_kib",
+        "display.show_help_bar",
+        "display.default_sort_field",
+        "display.default_sort_descending",
+        "display.directories_first",
+        "display.grep_preview_context_lines",
+        "display.split_terminal_position",
+        "behavior.confirm_delete",
+        "behavior.paste_conflict_action",
+        "logging.level",
+    )
+
+
+def config_editor_labels() -> tuple[str, ...]:
+    return (
+        "Editor command",
+        "Show hidden files",
+        "Theme",
+        "Show directory sizes",
+        "Show preview",
+        "Preview syntax theme",
+        "Preview max KiB",
+        "Show help bar",
+        "Default sort field",
+        "Default sort descending",
+        "Directories first",
+        "Grep preview context lines",
+        "Split terminal position",
+        "Confirm delete",
+        "Paste conflict action",
+        "Log level",
+    )
+
+
+CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
+    ("External", (0,)),
+    ("Display", (2, 5, 1, 3, 4, 6, 7, 11, 12)),
+    ("Sorting", (8, 9, 10)),
+    ("Behavior", (13, 14)),
+    ("Logging", (15,)),
+)
+
+
+def config_editor_visual_order() -> tuple[int, ...]:
+    """Return field indices in visual display order."""
+
+    result: list[int] = []
+    for _header, field_indices in CONFIG_EDITOR_CATEGORIES:
+        result.extend(field_indices)
+    return tuple(result)
+
+
+def move_config_cursor_visual(cursor_index: int, delta: int) -> int:
+    """Move cursor by *delta* steps in visual order, returning the new field index."""
+
+    order = config_editor_visual_order()
+    try:
+        pos = order.index(cursor_index)
+    except ValueError:
+        pos = 0
+    new_pos = max(0, min(len(order) - 1, pos + delta))
+    return order[new_pos]
+
+
+def apply_config_to_runtime_state(state, config: AppConfig):
+    return replace(
+        state,
+        show_hidden=config.display.show_hidden_files,
+        show_help_bar=config.display.show_help_bar,
+        sort=SortState(
+            field=config.display.default_sort_field,
+            descending=config.display.default_sort_descending,
+            directories_first=config.display.directories_first,
+        ),
+        confirm_delete=config.behavior.confirm_delete,
+        paste_conflict_action=config.behavior.paste_conflict_action,
+    )
+
+
+def format_config_field_value(field_index: int, config: AppConfig) -> str:
+    field_id = config_editor_field_ids()[field_index]
+    if field_id == "editor.command":
+        return _format_editor_command_value(config.editor.command)
+    if field_id == "display.show_hidden_files":
+        return _format_bool(config.display.show_hidden_files)
+    if field_id == "display.theme":
+        return config.display.theme
+    if field_id == "display.show_directory_sizes":
+        return _format_bool(config.display.show_directory_sizes)
+    if field_id == "display.show_preview":
+        return _format_bool(config.display.show_preview)
+    if field_id == "display.preview_syntax_theme":
+        return config.display.preview_syntax_theme
+    if field_id == "display.preview_max_kib":
+        return f"{config.display.preview_max_kib} KiB"
+    if field_id == "display.show_help_bar":
+        return _format_bool(config.display.show_help_bar)
+    if field_id == "display.default_sort_field":
+        return config.display.default_sort_field
+    if field_id == "display.default_sort_descending":
+        return _format_bool(config.display.default_sort_descending)
+    if field_id == "display.directories_first":
+        return _format_bool(config.display.directories_first)
+    if field_id == "display.grep_preview_context_lines":
+        return str(config.display.grep_preview_context_lines)
+    if field_id == "display.split_terminal_position":
+        return config.display.split_terminal_position
+    if field_id == "behavior.confirm_delete":
+        return _format_bool(config.behavior.confirm_delete)
+    if field_id == "behavior.paste_conflict_action":
+        return config.behavior.paste_conflict_action
+    if field_id == "logging.level":
+        return config.logging.level
+    return ""
+
+
+def _format_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _format_editor_command_value(command: str | None) -> str:
+    if command is None:
+        return "system default"
+    if command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw"}:
+        return command
+    return "custom (raw config only)"

--- a/src/zivo/state/reducer_pane_sync.py
+++ b/src/zivo/state/reducer_pane_sync.py
@@ -1,0 +1,158 @@
+"""Directory-size and child-pane synchronization helpers."""
+
+from dataclasses import replace
+
+from zivo.archive_utils import is_supported_archive_path
+
+from .actions import RequestDirectorySizes
+from .effects import Effect, LoadChildPaneSnapshotEffect, ReduceResult
+from .entry_state_helpers import current_entry_for_path, visible_current_entry_states
+from .models import DirectoryEntryState, DirectorySizeCacheEntry, PaneState
+from .reducer_requests import ReducerFn
+
+
+def maybe_request_directory_sizes(
+    state,
+    reduce_state: ReducerFn,
+    *effects: Effect,
+) -> ReduceResult:
+    active_target_paths = directory_size_target_paths(state)
+    if not active_target_paths:
+        return ReduceResult(state=state, effects=effects)
+
+    cache_by_path = directory_size_cache_by_path(state.directory_size_cache)
+    pending_paths = tuple(
+        path
+        for path in active_target_paths
+        if cache_by_path.get(path) is not None and cache_by_path[path].status == "pending"
+    )
+    missing_paths = tuple(path for path in active_target_paths if cache_by_path.get(path) is None)
+
+    if not missing_paths:
+        if pending_paths and state.pending_directory_size_request_id is None:
+            return reduce_state(state, RequestDirectorySizes(pending_paths))
+        return ReduceResult(state=state, effects=effects)
+
+    request_paths = tuple(dict.fromkeys((*pending_paths, *missing_paths)))
+    result = reduce_state(state, RequestDirectorySizes(request_paths))
+    return ReduceResult(state=result.state, effects=(*effects, *result.effects))
+
+
+def directory_size_target_paths(state) -> tuple[str, ...]:
+    if not state.config.display.show_directory_sizes and state.sort.field != "size":
+        return ()
+
+    return tuple(
+        dict.fromkeys(
+            visible_directory_paths(
+                visible_current_entry_states(state),
+                show_hidden=True,
+            )
+        )
+    )
+
+
+def visible_directory_paths(
+    entries: tuple[DirectoryEntryState, ...],
+    show_hidden: bool,
+) -> tuple[str, ...]:
+    return tuple(
+        entry.path
+        for entry in entries
+        if entry.kind == "dir" and (show_hidden or not entry.hidden)
+    )
+
+
+def directory_size_cache_by_path(
+    entries: tuple[DirectorySizeCacheEntry, ...],
+) -> dict[str, DirectorySizeCacheEntry]:
+    return {entry.path: entry for entry in entries}
+
+
+def upsert_directory_size_entries(
+    current_entries: tuple[DirectorySizeCacheEntry, ...],
+    new_entries: tuple[DirectorySizeCacheEntry, ...],
+) -> tuple[DirectorySizeCacheEntry, ...]:
+    cache_by_path = directory_size_cache_by_path(current_entries)
+    for entry in new_entries:
+        cache_by_path[entry.path] = entry
+    return tuple(sorted(cache_by_path.values(), key=lambda entry: entry.path))
+
+
+def sync_child_pane(
+    state,
+    cursor_path: str | None,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    entry = current_entry_for_path(state, cursor_path)
+    if entry is None:
+        next_state = replace(
+            state,
+            child_pane=PaneState(directory_path=state.current_path, entries=()),
+            pending_child_pane_request_id=None,
+        )
+        return maybe_request_directory_sizes(next_state, reduce_state)
+
+    if entry.kind != "dir" and not is_supported_archive_path(entry.path):
+        if not state.config.display.show_preview:
+            next_child_pane = PaneState(directory_path=state.current_path, entries=())
+            if (
+                state.pending_child_pane_request_id is None
+                and state.child_pane == next_child_pane
+            ):
+                return maybe_request_directory_sizes(state, reduce_state)
+            next_state = replace(
+                state,
+                child_pane=next_child_pane,
+                pending_child_pane_request_id=None,
+            )
+            return maybe_request_directory_sizes(next_state, reduce_state)
+
+    if state.pending_child_pane_request_id is None and _child_pane_matches_entry(
+        state.child_pane,
+        entry,
+    ):
+        return maybe_request_directory_sizes(state, reduce_state)
+
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        pending_child_pane_request_id=request_id,
+        next_request_id=request_id + 1,
+    )
+    return maybe_request_directory_sizes(
+        next_state,
+        reduce_state,
+        LoadChildPaneSnapshotEffect(
+            request_id=request_id,
+            current_path=state.current_path,
+            cursor_path=entry.path,
+            preview_max_bytes=state.config.display.preview_max_kib * 1024,
+        ),
+    )
+
+
+def normalize_child_pane_for_display(
+    current_path: str,
+    child_pane: PaneState,
+    *,
+    show_preview: bool,
+) -> PaneState:
+    if show_preview or child_pane.mode != "preview":
+        return child_pane
+    return PaneState(directory_path=current_path, entries=())
+
+
+def _child_pane_matches_entry(
+    child_pane: PaneState,
+    entry: DirectoryEntryState,
+) -> bool:
+    if entry.kind == "dir" or is_supported_archive_path(entry.path):
+        return child_pane.mode == "entries" and child_pane.directory_path == entry.path
+    return (
+        child_pane.mode == "preview"
+        and child_pane.preview_path == entry.path
+        and child_pane.preview_title is None
+        and child_pane.preview_start_line is None
+        and child_pane.preview_highlight_line is None
+    )

--- a/src/zivo/state/reducer_path_helpers.py
+++ b/src/zivo/state/reducer_path_helpers.py
@@ -1,0 +1,191 @@
+"""Path, selection, and lightweight search helpers for reducers."""
+
+import os
+from pathlib import Path
+
+from .models import DirectoryEntryState, FileSearchResultState
+
+REGEX_FILE_SEARCH_PREFIX = "re:"
+REGEX_GREP_SEARCH_PREFIX = "re:"
+
+
+def current_entry_paths(state) -> set[str]:
+    return {entry.path for entry in active_current_entries(state)}
+
+
+def active_current_entries(state) -> tuple[DirectoryEntryState, ...]:
+    return state.current_pane.entries
+
+
+def list_matching_directory_paths(query: str, base_path: str) -> tuple[str, ...]:
+    """Return matching directory candidates for go-to-path completion."""
+
+    raw_query = query.strip()
+    if not raw_query:
+        return ()
+
+    resolved = _resolve_input_path(raw_query, base_path)
+    if resolved is None:
+        return ()
+
+    has_trailing_separator = raw_query.endswith(os.sep)
+    if os.altsep is not None and raw_query.endswith(os.altsep):
+        has_trailing_separator = True
+
+    parent = resolved if has_trailing_separator else resolved.parent
+    prefix = "" if has_trailing_separator else resolved.name.casefold()
+    if not parent.exists() or not parent.is_dir():
+        return ()
+
+    matches: list[str] = []
+    try:
+        for child in parent.iterdir():
+            try:
+                if not child.is_dir():
+                    continue
+            except OSError:
+                continue
+
+            if prefix and not child.name.casefold().startswith(prefix):
+                continue
+            matches.append(str(child.resolve()))
+    except (OSError, PermissionError):
+        return ()
+
+    matches.sort(key=lambda path: (Path(path).name.casefold(), path))
+    return tuple(matches)
+
+
+def format_go_to_path_completion(
+    path: str,
+    query: str,
+    base_path: str,
+    *,
+    append_separator: bool,
+) -> str:
+    """Render a selected go-to-path completion in the user's current path style."""
+
+    raw_query = query.strip()
+    normalized_path = str(Path(path).resolve())
+    if raw_query.startswith("~"):
+        home = os.path.expanduser("~")
+        if normalized_path.startswith(home + os.sep):
+            rendered = "~" + normalized_path[len(home) :]
+        elif normalized_path == home:
+            rendered = "~"
+        else:
+            rendered = normalized_path
+    elif raw_query.startswith(os.sep) or (
+        os.altsep is not None and raw_query.startswith(os.altsep)
+    ):
+        rendered = normalized_path
+    else:
+        rendered = os.path.relpath(normalized_path, str(Path(base_path).resolve()))
+
+    if append_separator and rendered != os.sep:
+        rendered = rendered.rstrip(os.sep)
+        if not rendered.endswith(os.sep):
+            rendered = f"{rendered}{os.sep}"
+    return rendered
+
+
+def expand_and_validate_path(query: str, base_path: str) -> str | None:
+    """Expand ~, ., .. and validate path exists and is a directory."""
+
+    expanded = _resolve_input_path(query, base_path)
+    if expanded is None:
+        return None
+    try:
+        if not expanded.exists() or not expanded.is_dir():
+            return None
+        return str(expanded)
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+
+def normalize_selected_paths(
+    selected_paths: frozenset[str],
+    entries: tuple[DirectoryEntryState, ...],
+) -> frozenset[str]:
+    entry_paths = {entry.path for entry in entries}
+    return frozenset(path for path in selected_paths if path in entry_paths)
+
+
+def normalize_selection_anchor_path(
+    anchor_path: str | None,
+    visible_paths: tuple[str, ...],
+) -> str | None:
+    if anchor_path in visible_paths:
+        return anchor_path
+    return None
+
+
+def move_cursor(
+    current_path: str | None,
+    visible_paths: tuple[str, ...],
+    delta: int,
+) -> str | None:
+    if not visible_paths:
+        return None
+
+    if current_path in visible_paths:
+        current_index = visible_paths.index(current_path)
+    else:
+        current_index = 0
+
+    next_index = max(0, min(len(visible_paths) - 1, current_index + delta))
+    return visible_paths[next_index]
+
+
+def select_range_paths(
+    anchor_path: str,
+    cursor_path: str,
+    visible_paths: tuple[str, ...],
+) -> frozenset[str]:
+    anchor_index = visible_paths.index(anchor_path)
+    cursor_index = visible_paths.index(cursor_path)
+    start = min(anchor_index, cursor_index)
+    end = max(anchor_index, cursor_index)
+    return frozenset(visible_paths[start : end + 1])
+
+
+def normalize_cursor_path(
+    entries: tuple[DirectoryEntryState, ...],
+    current_cursor: str | None,
+) -> str | None:
+    entry_paths = {entry.path for entry in entries}
+    if current_cursor in entry_paths:
+        return current_cursor
+    if not entries:
+        return None
+    return entries[0].path
+
+
+def filter_file_search_results(
+    results: tuple[FileSearchResultState, ...],
+    normalized_query: str,
+) -> tuple[FileSearchResultState, ...]:
+    return tuple(
+        result
+        for result in results
+        if normalized_query in Path(result.path).name.casefold()
+    )
+
+
+def is_regex_file_search_query(query: str) -> bool:
+    return query.strip().startswith(REGEX_FILE_SEARCH_PREFIX)
+
+
+def _resolve_input_path(query: str, base_path: str) -> Path | None:
+    raw_query = query.strip()
+    if not raw_query:
+        return None
+
+    candidate = Path(os.path.expanduser(raw_query))
+    if not candidate.is_absolute():
+        candidate = Path(base_path) / candidate
+
+    try:
+        return candidate.resolve(strict=False)
+    except (OSError, ValueError, RuntimeError):
+        return None

--- a/src/zivo/state/reducer_pending_input.py
+++ b/src/zivo/state/reducer_pending_input.py
@@ -1,0 +1,167 @@
+"""Pending input validation and request builders."""
+
+from pathlib import Path
+
+from zivo.archive_utils import resolve_zip_destination_input
+from zivo.models import (
+    CreatePathRequest,
+    CreateZipArchiveRequest,
+    ExtractArchiveRequest,
+    RenameRequest,
+)
+
+from .reducer_path_helpers import current_entry_paths
+
+
+def validate_pending_input(state, *, is_macos: bool) -> str | None:
+    if state.pending_input is None:
+        return "No input is active"
+
+    if state.pending_input.extract_source_path is not None:
+        destination = state.pending_input.value.strip()
+        if not destination:
+            return "Destination path cannot be empty"
+        source_path = Path(state.pending_input.extract_source_path)
+        resolved_destination = Path(destination).expanduser()
+        if not resolved_destination.is_absolute():
+            resolved_destination = source_path.parent / resolved_destination
+        resolved_destination = resolved_destination.resolve(strict=False)
+        if resolved_destination == source_path:
+            return "Destination path cannot be the archive file itself"
+        if resolved_destination.exists() and not resolved_destination.is_dir():
+            return "Destination path must be a directory"
+        return None
+
+    if state.pending_input.zip_source_paths is not None:
+        destination = state.pending_input.value.strip()
+        if not destination:
+            return "Destination path cannot be empty"
+        resolved_destination = Path(
+            resolve_zip_destination_input(state.current_pane.directory_path, destination)
+        )
+        if resolved_destination.suffix.casefold() != ".zip":
+            return "Destination path must end with .zip"
+        if resolved_destination.exists() and resolved_destination.is_dir():
+            return "Destination path already exists as a directory"
+
+        for source_path_str in state.pending_input.zip_source_paths:
+            source_path = Path(source_path_str).expanduser().resolve()
+            if resolved_destination == source_path:
+                return "Destination path cannot be one of the source paths"
+            if source_path.is_dir() and not source_path.is_symlink():
+                if resolved_destination.is_relative_to(source_path):
+                    return "Destination path cannot be inside a directory being compressed"
+        return None
+
+    name = state.pending_input.value
+    if not name:
+        return "Name cannot be empty"
+    if name in {".", ".."}:
+        return "'.' and '..' are not valid names"
+    if "/" in name or "\\" in name:
+        return "Names cannot include path separators"
+    if is_macos and ":" in name:
+        return "Names cannot include colons"
+
+    parent_path, current_target_path = pending_input_parent_and_target(state)
+    if parent_path is None:
+        return "Unable to resolve target directory"
+
+    existing_paths = current_entry_paths(state)
+    if is_macos:
+        name_cf = name.casefold()
+        for existing_path in existing_paths:
+            existing_name_cf = Path(existing_path).name.casefold()
+            if existing_name_cf == name_cf and existing_path != current_target_path:
+                return f"An entry named '{name}' already exists"
+    else:
+        candidate_path = str(Path(parent_path) / name)
+        if candidate_path in existing_paths and candidate_path != current_target_path:
+            return f"An entry named '{name}' already exists"
+    return None
+
+
+def is_name_conflict_validation_error(state, message: str) -> bool:
+    return state.pending_input is not None and message == (
+        f"An entry named '{state.pending_input.value}' already exists"
+    )
+
+
+def name_conflict_kind(state):
+    if state.pending_input is not None and state.pending_input.create_kind == "file":
+        return "create_file"
+    if state.pending_input is not None and state.pending_input.create_kind == "dir":
+        return "create_dir"
+    return "rename"
+
+
+def build_file_mutation_request(
+    state,
+) -> RenameRequest | CreatePathRequest | None:
+    if state.pending_input is None:
+        return None
+    if state.ui_mode == "RENAME" and state.pending_input.target_path is not None:
+        return RenameRequest(
+            source_path=state.pending_input.target_path,
+            new_name=state.pending_input.value,
+        )
+    if state.ui_mode == "CREATE" and state.pending_input.create_kind is not None:
+        return CreatePathRequest(
+            parent_dir=state.current_pane.directory_path,
+            name=state.pending_input.value,
+            kind=state.pending_input.create_kind,
+        )
+    return None
+
+
+def build_extract_archive_request(state) -> ExtractArchiveRequest | None:
+    if state.pending_input is None or state.pending_input.extract_source_path is None:
+        return None
+
+    destination = state.pending_input.value.strip()
+    if not destination:
+        return None
+
+    source_path = Path(state.pending_input.extract_source_path).expanduser().resolve()
+    resolved_destination = Path(destination).expanduser()
+    if not resolved_destination.is_absolute():
+        resolved_destination = source_path.parent / resolved_destination
+
+    return ExtractArchiveRequest(
+        source_path=str(source_path),
+        destination_path=str(resolved_destination.resolve(strict=False)),
+    )
+
+
+def build_zip_compress_request(state) -> CreateZipArchiveRequest | None:
+    if state.pending_input is None or state.pending_input.zip_source_paths is None:
+        return None
+
+    destination = state.pending_input.value.strip()
+    if not destination:
+        return None
+
+    return CreateZipArchiveRequest(
+        source_paths=state.pending_input.zip_source_paths,
+        destination_path=resolve_zip_destination_input(
+            state.current_pane.directory_path,
+            destination,
+        ),
+        root_dir=state.current_pane.directory_path,
+    )
+
+
+def pending_input_parent_and_target(state) -> tuple[str | None, str | None]:
+    if state.pending_input is None:
+        return (None, None)
+    if state.ui_mode == "RENAME" and state.pending_input.target_path is not None:
+        target_path = Path(state.pending_input.target_path)
+        return (str(target_path.parent), str(target_path))
+    if state.ui_mode == "CREATE":
+        return (state.current_pane.directory_path, None)
+    if state.ui_mode == "EXTRACT" and state.pending_input.extract_source_path is not None:
+        source_path = Path(state.pending_input.extract_source_path)
+        return (str(source_path.parent), None)
+    if state.ui_mode == "ZIP" and state.pending_input.zip_source_paths is not None:
+        return (state.current_pane.directory_path, None)
+    return (None, None)

--- a/src/zivo/state/reducer_requests.py
+++ b/src/zivo/state/reducer_requests.py
@@ -1,0 +1,376 @@
+"""Reducer request builders and shared transition helpers."""
+
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+from zivo.models import (
+    CreatePathRequest,
+    CreateZipArchiveRequest,
+    DeleteRequest,
+    ExternalLaunchRequest,
+    ExtractArchiveRequest,
+    FileMutationResult,
+    PasteRequest,
+    PasteSummary,
+    RenameRequest,
+    UndoEntry,
+)
+
+from .actions import Action
+from .effects import (
+    Effect,
+    LoadBrowserSnapshotEffect,
+    ReduceResult,
+    RunArchiveExtractEffect,
+    RunArchivePreparationEffect,
+    RunClipboardPasteEffect,
+    RunExternalLaunchEffect,
+    RunFileMutationEffect,
+    RunUndoEffect,
+    RunZipCompressEffect,
+    RunZipCompressPreparationEffect,
+)
+from .models import HistoryState, NotificationState
+
+ReducerFn = Callable[[object, Action], ReduceResult]
+
+
+def finalize(next_state, *effects: Effect) -> ReduceResult:
+    """Wrap a state transition and optional side effects into a ReduceResult."""
+
+    return ReduceResult(state=next_state, effects=effects)
+
+
+def run_paste_request(state, request: PasteRequest) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=None,
+        paste_conflict=None,
+        delete_confirmation=None,
+        pending_paste_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunClipboardPasteEffect(request_id=request_id, request=request),),
+    )
+
+
+def run_external_launch_request(
+    state,
+    request: ExternalLaunchRequest,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        next_request_id=request_id + 1,
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunExternalLaunchEffect(request_id=request_id, request=request),),
+    )
+
+
+def run_file_mutation_request(
+    state,
+    request: RenameRequest | CreatePathRequest | DeleteRequest,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=None,
+        delete_confirmation=None,
+        pending_file_mutation_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunFileMutationEffect(request_id=request_id, request=request),),
+    )
+
+
+def run_undo_request(state, entry: UndoEntry) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=None,
+        pending_undo_entry=entry,
+        pending_undo_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunUndoEffect(request_id=request_id, entry=entry),),
+    )
+
+
+def run_archive_prepare_request(
+    state,
+    request: ExtractArchiveRequest,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=NotificationState(level="info", message="Preparing archive extraction"),
+        delete_confirmation=None,
+        archive_extract_confirmation=None,
+        archive_extract_progress=None,
+        pending_archive_prepare_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunArchivePreparationEffect(request_id=request_id, request=request),),
+    )
+
+
+def run_archive_extract_request(
+    state,
+    request: ExtractArchiveRequest,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=NotificationState(level="info", message="Extracting archive..."),
+        archive_extract_confirmation=None,
+        archive_extract_progress=None,
+        pending_archive_extract_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunArchiveExtractEffect(request_id=request_id, request=request),),
+    )
+
+
+def run_zip_compress_prepare_request(
+    state,
+    request: CreateZipArchiveRequest,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=NotificationState(level="info", message="Preparing zip compression"),
+        delete_confirmation=None,
+        archive_extract_confirmation=None,
+        archive_extract_progress=None,
+        zip_compress_confirmation=None,
+        zip_compress_progress=None,
+        pending_zip_compress_prepare_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunZipCompressPreparationEffect(request_id=request_id, request=request),),
+    )
+
+
+def run_zip_compress_request(
+    state,
+    request: CreateZipArchiveRequest,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        notification=NotificationState(level="info", message="Compressing as zip..."),
+        zip_compress_confirmation=None,
+        zip_compress_progress=None,
+        pending_zip_compress_request_id=request_id,
+        next_request_id=request_id + 1,
+        ui_mode="BUSY",
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(RunZipCompressEffect(request_id=request_id, request=request),),
+    )
+
+
+def cursor_path_after_file_mutation(
+    state,
+    result: FileMutationResult,
+) -> str | None:
+    active_entries = state.current_pane.entries
+    if result.removed_paths:
+        remaining_paths = [
+            entry.path
+            for entry in active_entries
+            if entry.path not in result.removed_paths
+        ]
+        if not remaining_paths:
+            return None
+        current_cursor = state.current_pane.cursor_path
+        if current_cursor is not None and current_cursor not in result.removed_paths:
+            return current_cursor
+        original_paths = [entry.path for entry in active_entries]
+        if current_cursor in original_paths:
+            current_index = original_paths.index(current_cursor)
+            if current_index < len(remaining_paths):
+                return remaining_paths[current_index]
+        return remaining_paths[-1]
+    return result.path
+
+
+def restore_ui_mode_after_pending_input(state) -> str:
+    if state.pending_input is None:
+        return "BROWSING"
+    if state.pending_input.extract_source_path is not None:
+        return "EXTRACT"
+    if state.pending_input.zip_source_paths is not None:
+        return "ZIP"
+    if state.pending_input.create_kind is not None:
+        return "CREATE"
+    return "RENAME"
+
+
+def browser_snapshot_invalidation_paths(
+    path: str,
+    *extra_paths: str | None,
+) -> tuple[str, ...]:
+    resolved_path = str(Path(path).expanduser().resolve())
+    paths = [resolved_path, str(Path(resolved_path).parent)]
+    for extra_path in extra_paths:
+        if extra_path is not None:
+            paths.append(str(Path(extra_path).expanduser().resolve()))
+    return tuple(dict.fromkeys(paths))
+
+
+def request_snapshot_refresh(
+    state,
+    *,
+    cursor_path: str | None = None,
+    keep_current_cursor: bool = True,
+) -> ReduceResult:
+    request_id = state.next_request_id
+    resolved_cursor_path = (
+        state.current_pane.cursor_path
+        if keep_current_cursor and cursor_path is None
+        else cursor_path
+    )
+    next_state = replace(
+        state,
+        pending_browser_snapshot_request_id=request_id,
+        pending_child_pane_request_id=None,
+        next_request_id=request_id + 1,
+    )
+    return ReduceResult(
+        state=next_state,
+        effects=(
+            LoadBrowserSnapshotEffect(
+                request_id=request_id,
+                path=state.current_path,
+                cursor_path=resolved_cursor_path,
+                blocking=False,
+                invalidate_paths=browser_snapshot_invalidation_paths(
+                    state.current_path,
+                    resolved_cursor_path,
+                ),
+            ),
+        ),
+    )
+
+
+def format_clipboard_message(prefix: str, paths: tuple[str, ...]) -> str:
+    noun = "item" if len(paths) == 1 else "items"
+    return f"{prefix} {len(paths)} {noun} to clipboard"
+
+
+def notification_for_external_launch(
+    request: ExternalLaunchRequest,
+) -> NotificationState | None:
+    if request.kind != "copy_paths":
+        return None
+    noun = "path" if len(request.paths) == 1 else "paths"
+    return NotificationState(
+        level="info",
+        message=f"Copied {len(request.paths)} {noun} to system clipboard",
+    )
+
+
+def split_terminal_exit_message(exit_code: int | None) -> str:
+    if exit_code is None:
+        return "Split terminal closed"
+    return f"Split terminal closed (exit {exit_code})"
+
+
+def notification_for_paste_summary(summary: PasteSummary) -> NotificationState:
+    verb = "Copied" if summary.mode == "copy" else "Moved"
+    if summary.failure_count and summary.success_count:
+        return NotificationState(
+            level="warning",
+            message=(
+                f"{verb} {summary.success_count}/{summary.total_count} items"
+                f" with {summary.failure_count} failure(s)"
+            ),
+        )
+    if summary.failure_count and not summary.success_count and not summary.skipped_count:
+        return NotificationState(
+            level="error",
+            message=f"Failed to {summary.mode} {summary.total_count} item(s)",
+        )
+    if summary.skipped_count and not summary.success_count and not summary.failure_count:
+        return NotificationState(
+            level="info",
+            message=f"Skipped {summary.skipped_count} conflicting item(s)",
+        )
+    message = f"{verb} {summary.success_count} item(s)"
+    if summary.skipped_count:
+        message += f", skipped {summary.skipped_count}"
+    if summary.overwrote_count:
+        message += ", undo unavailable for overwritten items"
+    return NotificationState(level="info", message=message)
+
+
+def build_history_after_snapshot_load(
+    state,
+    next_path: str,
+) -> HistoryState:
+    previous_path = state.current_path
+    new_history = state.history
+
+    if not state.history.back and not state.history.forward:
+        if next_path != previous_path:
+            new_history = HistoryState(
+                back=(previous_path,),
+                forward=(),
+                visited_all=(previous_path, next_path),
+            )
+        return new_history
+
+    if next_path != previous_path:
+        history = state.history
+        if history.forward and next_path == history.forward[0]:
+            new_history = HistoryState(
+                back=(*history.back, previous_path),
+                forward=history.forward[1:],
+                visited_all=history.visited_all,
+            )
+        elif history.back and next_path == history.back[-1]:
+            new_history = HistoryState(
+                back=history.back[:-1],
+                forward=(previous_path, *history.forward),
+                visited_all=history.visited_all,
+            )
+        else:
+            visited_all = history.visited_all
+            if not visited_all or visited_all[-1] != next_path:
+                visited_all = (*visited_all, next_path)
+            new_history = HistoryState(
+                back=(*history.back, previous_path),
+                forward=(),
+                visited_all=visited_all,
+            )
+    else:
+        new_history = HistoryState(
+            back=state.history.back,
+            forward=state.history.forward,
+            visited_all=state.history.visited_all,
+        )
+    return new_history

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -33,6 +33,18 @@ from zivo.models import (
 )
 from zivo.theme_support import preview_syntax_theme_for_app_theme
 
+from .entry_state_helpers import (
+    current_entry_for_path as shared_current_entry_for_path,
+)
+from .entry_state_helpers import (
+    single_target_entry as shared_single_target_entry,
+)
+from .entry_state_helpers import (
+    target_paths as shared_target_paths,
+)
+from .entry_state_helpers import (
+    visible_current_entry_states as shared_visible_current_entry_states,
+)
 from .models import (
     AppState,
     CommandPaletteState,
@@ -43,6 +55,11 @@ from .models import (
     ReplacePreviewResultState,
     SortState,
     select_browser_tabs,
+)
+from .reducer_config import (
+    CONFIG_EDITOR_CATEGORIES,
+    config_editor_labels,
+    format_config_field_value,
 )
 
 if TYPE_CHECKING:
@@ -1147,8 +1164,6 @@ def select_config_dialog_state(state: AppState) -> ConfigDialogState | None:
     if state.ui_mode != "CONFIG" or state.config_editor is None:
         return None
 
-    from .reducer_common import CONFIG_EDITOR_CATEGORIES, config_editor_labels
-
     config = state.config_editor.draft
     selected_index = state.config_editor.cursor_index
     labels = config_editor_labels()
@@ -1212,18 +1227,7 @@ def select_shell_command_dialog_state(state: AppState) -> ShellCommandDialogStat
 def select_target_paths(state: AppState) -> tuple[str, ...]:
     """Return selected paths, or the cursor path when nothing is selected."""
 
-    current_pane = _select_current_pane_projection(state)
-    selected_paths = tuple(
-        entry.path
-        for entry in current_pane.visible_entries
-        if entry.path in state.current_pane.selected_paths
-    )
-    if selected_paths:
-        return selected_paths
-
-    if current_pane.cursor_entry is None:
-        return ()
-    return (current_pane.cursor_entry.path,)
+    return shared_target_paths(state)
 
 
 def select_current_entry_for_path(
@@ -1232,21 +1236,13 @@ def select_current_entry_for_path(
 ) -> DirectoryEntryState | None:
     """Return the visible current-pane entry for the given path."""
 
-    if path is None:
-        return None
-    for entry in select_visible_current_entry_states(state):
-        if entry.path == path:
-            return entry
-    return None
+    return shared_current_entry_for_path(state, path)
 
 
 def select_single_target_entry(state: AppState) -> DirectoryEntryState | None:
     """Return the visible entry when exactly one target is active."""
 
-    target_paths = select_target_paths(state)
-    if len(target_paths) != 1:
-        return None
-    return select_current_entry_for_path(state, target_paths[0])
+    return shared_single_target_entry(state)
 
 
 def select_target_file_paths(state: AppState) -> tuple[str, ...]:
@@ -1276,14 +1272,7 @@ def select_has_visible_current_entries(state: AppState) -> bool:
 def select_visible_current_entry_states(state: AppState) -> tuple[DirectoryEntryState, ...]:
     """Return filtered and sorted raw current-pane entries."""
 
-    return _select_visible_current_entry_states(
-        state.current_pane.entries,
-        state.directory_size_cache,
-        state.show_hidden,
-        state.filter.query,
-        state.filter.active,
-        state.sort,
-    )
+    return shared_visible_current_entry_states(state)
 
 
 def _select_current_pane_projection(state: AppState) -> _CurrentPaneProjection:
@@ -1584,42 +1573,7 @@ def _format_bool(value: bool) -> str:
 
 
 def _config_field_value(field_index: int, config: "AppConfig") -> str:  # type: ignore[name-defined]  # noqa: F821
-    from .reducer_common import config_editor_field_ids
-
-    field_id = config_editor_field_ids()[field_index]
-    if field_id == "editor.command":
-        return _format_editor_command_value(config.editor.command)
-    if field_id == "display.show_hidden_files":
-        return _format_bool(config.display.show_hidden_files)
-    if field_id == "display.theme":
-        return config.display.theme
-    if field_id == "display.show_directory_sizes":
-        return _format_bool(config.display.show_directory_sizes)
-    if field_id == "display.show_preview":
-        return _format_bool(config.display.show_preview)
-    if field_id == "display.preview_syntax_theme":
-        return config.display.preview_syntax_theme
-    if field_id == "display.preview_max_kib":
-        return f"{config.display.preview_max_kib} KiB"
-    if field_id == "display.show_help_bar":
-        return _format_bool(config.display.show_help_bar)
-    if field_id == "display.default_sort_field":
-        return config.display.default_sort_field
-    if field_id == "display.default_sort_descending":
-        return _format_bool(config.display.default_sort_descending)
-    if field_id == "display.directories_first":
-        return _format_bool(config.display.directories_first)
-    if field_id == "display.grep_preview_context_lines":
-        return str(config.display.grep_preview_context_lines)
-    if field_id == "display.split_terminal_position":
-        return config.display.split_terminal_position
-    if field_id == "behavior.confirm_delete":
-        return _format_bool(config.behavior.confirm_delete)
-    if field_id == "behavior.paste_conflict_action":
-        return config.behavior.paste_conflict_action
-    if field_id == "logging.level":
-        return config.logging.level
-    return ""
+    return format_config_field_value(field_index, config)
 
 
 @lru_cache(maxsize=128)


### PR DESCRIPTION
## Summary
- split `src/zivo/state/reducer_common.py` into focused helper modules for entry visibility, config editor helpers, pending input validation, request builders, and pane synchronization
- keep `reducer_common.py` as a compatibility export layer while removing selector-specific reverse imports from config dialog rendering
- share visible-entry/target resolution logic between reducers and selectors to reduce coupling around current-pane visibility rules

## Testing
- `uv run ruff check src/zivo/state`
- `uv run pytest tests/test_state_reducer.py tests/test_state_reducer_mutations_*.py tests/test_state_reducer_palette_*.py tests/test_services_config.py tests/test_state_selectors.py -k "not test_sfg_open_grep_result_in_editor_with_empty_results"`

## Notes
- local worktree has pre-existing uncommitted test changes in `tests/test_state_reducer_palette_search.py` and `tests/test_ui_panes.py`; `uv run ruff check .` and the full targeted pytest invocation still reflect those unrelated edits
- Closes #636
