### PR TITLE
Fix #652: Remove replaced text from replace preview file list display

### DIFF
--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -347,7 +347,7 @@ class ReplacePreviewResultState:
         return (
             f"{self.display_path} ({self.match_count}): "
             f"{self.first_match_line_number}: "
-            f"{self.first_match_before} -> {self.first_match_after}"
+            f"{self.first_match_before}"
         )
 
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1602,7 +1602,7 @@ def test_select_command_palette_state_for_text_replace_includes_input_fields() -
     assert [field.value for field in palette_state.input_fields] == ["todo", "done"]
     assert [field.active for field in palette_state.input_fields] == [False, True]
     assert [item.label for item in palette_state.items] == [
-        "README.md (2): 8: todo item -> done item"
+        "README.md (2): 8: todo item"
     ]
     assert palette_state.empty_message == "Preview shown in right pane. Press Enter to apply."
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3760,8 +3760,8 @@ async def test_app_command_palette_replace_text_previews_and_applies_selected_fi
         palette_state = select_command_palette_state(app.app_state)
         assert palette_state is not None
         assert [item.label for item in palette_state.items] == [
-            "README.md (2): 4: todo item -> done item",
-            "docs.md (1): 2: todo second -> done second",
+            "README.md (2): 4: todo item",
+            "docs.md (1): 2: todo second",
         ]
 
         child_pane = select_shell_data(app.app_state).child_pane


### PR DESCRIPTION
## Summary

- Remove replaced text from replace preview file list display
- The file list now only shows the matched line, not "before -> after"
- This reduces redundancy since the diff preview area already shows the changes

## Test plan

- [x] All existing tests pass
- [x] Lint checks pass
- [x] Manual testing: replace functionality shows only matched lines in file list

## Related issues

Fixes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)