### PR TITLE
fix: prevent crash when typing backslash in grep filename filter (#659)

### DIFF
--- a/src/zivo/state/reducer_palette_replace.py
+++ b/src/zivo/state/reducer_palette_replace.py
@@ -45,6 +45,7 @@ from .reducer_palette_shared import (
     notify,
     replace_grf_field,
     replace_replace_field,
+    validate_filename_filter,
 )
 
 
@@ -358,6 +359,27 @@ def handle_set_grf_replace(state: AppState, value: str) -> ReduceResult:
 
 
 def handle_set_grf_filename(state: AppState, value: str) -> ReduceResult:
+    # Validate filename filter to prevent regex crashes
+    validation_error = validate_filename_filter(value)
+    if validation_error:
+        next_palette = replace(
+            state.command_palette,
+            grf_filename_filter=value,
+            grf_error_message=validation_error,
+            grf_status_message=None,
+            grf_preview_results=(),
+            grf_total_match_count=0,
+            cursor_index=0,
+        )
+        return sync_grep_replace_preview(
+            replace(
+                state,
+                command_palette=next_palette,
+                child_pane=PaneState(directory_path=state.current_path, entries=()),
+                pending_replace_preview_request_id=None,
+            )
+        )
+
     next_palette = replace(
         state.command_palette,
         grf_filename_filter=value,

--- a/src/zivo/state/reducer_palette_search.py
+++ b/src/zivo/state/reducer_palette_search.py
@@ -41,6 +41,7 @@ from .reducer_palette_shared import (
     notify,
     replace_grep_field,
     request_palette_snapshot,
+    validate_filename_filter,
 )
 
 
@@ -151,19 +152,35 @@ def handle_set_grep_search_field(
         )
 
     # If filename filter is changed and we have existing results, re-apply filtering
-    if field == "filename" and state.command_palette.grep_search_results:
-        return sync_grep_preview(
-            replace(
-                state,
-                command_palette=replace(
-                    next_palette,
-                    grep_search_results=filter_grep_results_by_filename(
-                        state.command_palette.grep_search_results,
-                        value,
+    if field == "filename":
+        # Validate filename filter to prevent regex crashes
+        validation_error = validate_filename_filter(value)
+        if validation_error:
+            return sync_grep_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        next_palette,
+                        grep_search_results=(),
+                        grep_search_error_message=validation_error,
                     ),
-                ),
+                    pending_grep_search_request_id=None,
+                    pending_child_pane_request_id=None,
+                )
             )
-        )
+        if state.command_palette.grep_search_results:
+            return sync_grep_preview(
+                replace(
+                    state,
+                    command_palette=replace(
+                        next_palette,
+                        grep_search_results=filter_grep_results_by_filename(
+                            state.command_palette.grep_search_results,
+                            value,
+                        ),
+                    ),
+                )
+            )
 
     try:
         include_globs, exclude_globs = validate_grep_search_filters(

--- a/src/zivo/state/reducer_palette_shared.py
+++ b/src/zivo/state/reducer_palette_shared.py
@@ -157,6 +157,21 @@ def normalize_grep_extension_filters(
     return tuple(normalized_globs)
 
 
+def validate_filename_filter(filename_query: str) -> str | None:
+    """ファイル名フィルタの正規表現をバリデーションし、エラーメッセージを返す
+
+    無効な正規表現の場合はエラーメッセージを返し、
+    有効な場合は None を返す。
+    """
+    if not is_regex_file_search_query(filename_query):
+        return None
+    try:
+        re.compile(filename_query[3:], re.IGNORECASE)
+        return None
+    except re.error as e:
+        return f"Invalid regex pattern: {e}"
+
+
 def filter_grep_results_by_filename(
     results: tuple[GrepSearchResultState, ...],
     filename_query: str,
@@ -164,8 +179,12 @@ def filter_grep_results_by_filename(
     if not filename_query.strip():
         return results
     if is_regex_file_search_query(filename_query):
-        pattern = re.compile(filename_query[3:], re.IGNORECASE)
-        return tuple(result for result in results if pattern.search(result.display_path))
+        try:
+            pattern = re.compile(filename_query[3:], re.IGNORECASE)
+            return tuple(result for result in results if pattern.search(result.display_path))
+        except re.error:
+            # バリデーション済みのため通常は到達しないが、安全性のため空を返す
+            return ()
     lowered = filename_query.casefold()
     return tuple(result for result in results if lowered in result.display_path.casefold())
 

--- a/tests/test_state_reducer_palette_replace.py
+++ b/tests/test_state_reducer_palette_replace.py
@@ -1231,3 +1231,77 @@ def test_grs_grep_search_completed_filters_non_target_results() -> None:
     )
     # Preview is triggered even with empty replace text to show find matches
     assert result.state.pending_replace_preview_request_id is not None
+
+
+def test_grf_filename_filter_with_invalid_regex_single_backslash() -> None:
+    """Test that single backslash in regex mode shows error and clears results."""
+    from dataclasses import replace
+
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    # First, set up grep results
+    all_results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/a.py",
+            display_path="a.py",
+            line_number=1,
+            line_text="todo in a",
+        ),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_grep_results=all_results,
+        ),
+    )
+
+    # Now test invalid filename filter
+    result = reduce_app_state(state, SetGrepReplaceField(field="filename", value="re:\\"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grf_filename_filter == "re:\\"
+    assert result.state.command_palette.grf_error_message is not None
+    assert "Invalid regex pattern" in result.state.command_palette.grf_error_message
+    assert result.state.command_palette.grf_preview_results == ()
+    assert result.state.command_palette.grf_total_match_count == 0
+
+
+def test_grf_filename_filter_with_valid_regex_backslash() -> None:
+    """Test that valid regex with backslash works correctly for grep replace."""
+    from dataclasses import replace
+
+    state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
+    # First, set up grep results
+    all_results = (
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/a.py",
+            display_path="a.py",
+            line_number=1,
+            line_text="todo in a",
+        ),
+        GrepSearchResultState(
+            path="/home/tadashi/develop/zivo/b.txt",
+            display_path="b.txt",
+            line_number=1,
+            line_text="todo in b",
+        ),
+    )
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grf_keyword="todo",
+            grf_replacement_text="done",
+            grf_grep_results=all_results,
+        ),
+    )
+
+    # Test valid filename filter
+    result = reduce_app_state(state, SetGrepReplaceField(field="filename", value="re:\\.py$"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grf_filename_filter == "re:\\.py$"
+    assert result.state.command_palette.grf_error_message is None
+    # Results should be filtered to .py files only
+    assert result.state.pending_replace_preview_request_id == 1

--- a/tests/test_state_reducer_palette_search.py
+++ b/tests/test_state_reducer_palette_search.py
@@ -1082,3 +1082,121 @@ def test_sfg_cycle_field_is_noop() -> None:
     assert result.state.command_palette is not None
     assert result.state.command_palette.sfg_active_field == "keyword"
     assert result.state == state  # No changes expected
+
+
+def test_grep_filename_filter_with_invalid_regex_single_backslash() -> None:
+    """Test that single backslash in regex mode shows error and clears results."""
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="test",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/test/file.py",
+                    display_path="file.py",
+                    line_number=1,
+                    line_text="test content",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="re:\\"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_filename_filter == "re:\\"
+    assert result.state.command_palette.grep_search_error_message is not None
+    assert "Invalid regex pattern" in result.state.command_palette.grep_search_error_message
+    assert result.state.command_palette.grep_search_results == ()
+
+
+def test_grep_filename_filter_with_invalid_regex_unclosed_char_class() -> None:
+    """Test that invalid regex (unclosed character class) shows error and clears results."""
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="test",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/test/file.py",
+                    display_path="file.py",
+                    line_number=1,
+                    line_text="test content",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="re:["))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_filename_filter == "re:["
+    assert result.state.command_palette.grep_search_error_message is not None
+    assert "Invalid regex pattern" in result.state.command_palette.grep_search_error_message
+    assert result.state.command_palette.grep_search_results == ()
+
+
+def test_grep_filename_filter_with_valid_regex_backslash() -> None:
+    """Test that valid regex with backslash works correctly."""
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="test",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/test/file.py",
+                    display_path="file.py",
+                    line_number=1,
+                    line_text="test content",
+                ),
+                GrepSearchResultState(
+                    path="/home/test/file.txt",
+                    display_path="file.txt",
+                    line_number=1,
+                    line_text="test content",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="re:\\.py$"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_filename_filter == "re:\\.py$"
+    assert result.state.command_palette.grep_search_error_message is None
+    assert len(result.state.command_palette.grep_search_results) == 1
+    assert result.state.command_palette.grep_search_results[0].display_path == "file.py"
+
+
+def test_grep_filename_filter_with_non_regex_backslash() -> None:
+    """Test that backslash in non-regex mode works correctly."""
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="test",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/test/file.py",
+                    display_path="file.py",
+                    line_number=1,
+                    line_text="test content",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, SetGrepSearchField(field="filename", value="\\"))
+
+    assert result.state.command_palette is not None
+    assert result.state.command_palette.grep_search_filename_filter == "\\"
+    assert result.state.command_palette.grep_search_error_message is None
+    # Non-regex mode should not crash, results may be empty or filtered
+    assert isinstance(result.state.command_palette.grep_search_results, tuple)


### PR DESCRIPTION
## Summary
Fixes #659 - grep検索のfilenameフィルタでバックスラッシュを入力するとクラッシュする問題を修正しました。

## Changes
- **`validate_filename_filter()`** 関数を追加して、正規表現のバリデーションを実装
- **`handle_set_grep_search_field()`** にfilenameフィルタのバリデーションを追加
- **`handle_set_grf_filename()`** にfilenameフィルタのバリデーションを追加（grep置換）
- **`filter_grep_results_by_filename()`** に防御的なtry-exceptを追加
- バックスラッシュ入力の包括的なテストを追加

## Test Plan
- ✅ 単一バックスラッシュ (`re:\`) → エラーメッセージ表示、結果クリア
- ✅ 無効な正規表現 (`re:[`) → エラーメッセージ表示、結果クリア
- ✅ 有効な正規表現 (`re:\.py$`) → 正常に動作
- ✅ 非正規表現モード (`\`) → 正常に動作
- ✅ grep置換のfilenameフィルタバリデーション
- ✅ 回帰テスト（92個のテストすべて成功）

## Behavior
- 無効な正規表現が入力された場合、インラインエラーメッセージを表示して結果をクリア
- 既存の有効な正規表現は変更なしに動作
- 既存の拡張子フィルタエラーと同じパターンに従う

🤖 Generated with [Claude Code](https://claude.com/claude-code)