### PR TITLE
Add Go to path support in Transfer mode (#669)

### DIFF
--- a/src/zivo/state/input_transfer.py
+++ b/src/zivo/state/input_transfer.py
@@ -4,6 +4,7 @@ from .actions import (
     ActivateNextTab,
     ActivatePreviousTab,
     BeginBookmarkSearch,
+    BeginGoToPath,
     BeginHistorySearch,
     ClearTransferSelection,
     EnterTransferDirectory,
@@ -28,6 +29,7 @@ from .selectors import compute_current_pane_visible_window
 
 TRANSFER_KEYMAP = {
     "2",
+    "G",
     "q",
     "[",
     "]",
@@ -137,6 +139,9 @@ def dispatch_transfer_input(
         return supported(UndoLastOperation())
     if key == "b":
         return supported(BeginBookmarkSearch())
+
+    if key == "G":
+        return supported(BeginGoToPath())
 
     if key == "H":
         return supported(BeginHistorySearch())

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -191,7 +191,11 @@ def _next_palette_query_state(state: AppState, query: str):
 def _handle_set_go_to_path_query(state: AppState, next_palette, query: str) -> ReduceResult:
     # Transferモード: アクティブペインのパスを基準に補完
     if state.layout_mode == "transfer":
-        active_pane = state.transfer_left if state.active_transfer_pane == "left" else state.transfer_right
+        active_pane = (
+            state.transfer_left
+            if state.active_transfer_pane == "left"
+            else state.transfer_right
+        )
         base_path = active_pane.current_path
     else:
         base_path = state.current_path
@@ -297,9 +301,15 @@ def _handle_submit_go_to_path_palette(state: AppState, reduce_state: ReducerFn) 
         ].path
     if state.layout_mode == "transfer":
         # Transferモード: アクティブペインのパスを基準に展開
-        active_pane = state.transfer_left if state.active_transfer_pane == "left" else state.transfer_right
+        active_pane = (
+            state.transfer_left
+            if state.active_transfer_pane == "left"
+            else state.transfer_right
+        )
         if expanded_path is None:
-            expanded_path = expand_and_validate_path(state.command_palette.query, active_pane.current_path)
+            expanded_path = expand_and_validate_path(
+                state.command_palette.query, active_pane.current_path
+            )
         if expanded_path is None:
             return notify(state, level="error", message="Path does not exist or is not a directory")
         next_state = restore_browsing_from_palette(state)

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -189,7 +189,13 @@ def _next_palette_query_state(state: AppState, query: str):
 
 
 def _handle_set_go_to_path_query(state: AppState, next_palette, query: str) -> ReduceResult:
-    matches = list_matching_directory_paths(query, state.current_path)
+    # Transferモード: アクティブペインのパスを基準に補完
+    if state.layout_mode == "transfer":
+        active_pane = state.transfer_left if state.active_transfer_pane == "left" else state.transfer_right
+        base_path = active_pane.current_path
+    else:
+        base_path = state.current_path
+    matches = list_matching_directory_paths(query, base_path)
     has_trailing_separator = query.endswith("/")
     return finalize(
         replace(
@@ -289,6 +295,21 @@ def _handle_submit_go_to_path_palette(state: AppState, reduce_state: ReducerFn) 
         expanded_path = items[
             normalize_command_palette_cursor(state, state.command_palette.cursor_index)
         ].path
+    if state.layout_mode == "transfer":
+        # Transferモード: アクティブペインのパスを基準に展開
+        active_pane = state.transfer_left if state.active_transfer_pane == "left" else state.transfer_right
+        if expanded_path is None:
+            expanded_path = expand_and_validate_path(state.command_palette.query, active_pane.current_path)
+        if expanded_path is None:
+            return notify(state, level="error", message="Path does not exist or is not a directory")
+        next_state = restore_browsing_from_palette(state)
+        return request_transfer_pane_snapshot(
+            next_state,
+            state.active_transfer_pane,
+            expanded_path,
+            invalidate_paths=(),
+        )
+    # メイン画面
     if expanded_path is None:
         expanded_path = expand_and_validate_path(state.command_palette.query, state.current_path)
     if expanded_path is None:

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -202,7 +202,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         return HelpBarState(
             (
                 "[ ] focus pane | Space select | y copy | m move",
-                "z undo | . hidden | b bookmarks | H history | q/2 close",
+                "z undo | . hidden | b bookmarks | H history | G go-to | q/2 close",
             )
         )
     if state.config.help_bar.browsing:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2654,7 +2654,7 @@ async def test_app_displays_transfer_help_bar() -> None:
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
         "[ ] focus pane | Space select | y copy | m move\n"
-        "z undo | . hidden | b bookmarks | H history | q/2 close"
+        "z undo | . hidden | b bookmarks | H history | G go-to | q/2 close"
     )
 
     async with app.run_test() as pilot:

--- a/tests/test_input_dispatch_transfer.py
+++ b/tests/test_input_dispatch_transfer.py
@@ -3,6 +3,7 @@ from zivo.state import NotificationState, build_initial_app_state, dispatch_key_
 from zivo.state.actions import (
     ActivateNextTab,
     ActivatePreviousTab,
+    BeginGoToPath,
     BeginHistorySearch,
     FocusTransferPane,
     SetNotification,
@@ -94,4 +95,12 @@ def test_transfer_mode_H_begins_history_search() -> None:
     assert dispatch_key_input(state, key="H") == (
         SetNotification(None),
         BeginHistorySearch(),
+    )
+
+def test_transfer_mode_G_begins_go_to_path() -> None:
+    state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+    assert dispatch_key_input(state, key="G") == (
+        SetNotification(None),
+        BeginGoToPath(),
     )


### PR DESCRIPTION
## Summary

Implement Go to path feature for Transfer mode (two-pane layout) to match main browsing functionality. Users can now press `G` in Transfer mode to jump to any directory path, just like in the main browsing mode.

## Changes

- **input_transfer.py**: Add `G` key binding in Transfer mode that triggers `BeginGoToPath` action
- **reducer_palette.py**: Update Go to path palette handlers to support Transfer mode by using active pane's current path instead of main browsing path
  - `_handle_submit_go_to_path_palette()`: Use active pane's path for expansion in Transfer mode
  - `_handle_set_go_to_path_query()`: Use active pane's path for path completion in Transfer mode
- **selectors_ui.py**: Update Transfer mode help bar to show `G go-to`
- **tests/test_input_dispatch_transfer.py**: Add test for `G` key dispatch in Transfer mode

## Test Results

- All 1109 tests passed
- New test `test_transfer_mode_G_begins_go_to_path` added and passing
- Updated `test_app_displays_transfer_help_bar` to reflect new help bar text

Resolves #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)