### PR TITLE
Issue #687: Transferモード改善: パレットの表示位置改善

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -329,17 +329,48 @@ class zivoApp(App[None]):
         else:
             child_pane.display = False
 
+    def _get_target_overlay_pane(self) -> MainPane | None:
+        """
+        Get the target pane for overlay positioning based on current mode.
+
+        In transfer mode, overlays the opposite pane to keep the active pane visible.
+        In browser mode, overlays the current pane.
+
+        Returns:
+            MainPane instance if found, None otherwise
+        """
+        # Transfer mode with active left pane -> overlay on right pane
+        if (
+            self._app_state.layout_mode == "transfer"
+            and self._app_state.active_transfer_pane == "left"
+        ):
+            try:
+                return self.query_one("#transfer-right-pane", MainPane)
+            except NoMatches:
+                # Fallback to current pane if right pane doesn't exist
+                pass
+
+        # Default: current pane (browser mode or transfer mode with active right pane)
+        try:
+            return self.query_one("#current-pane", MainPane)
+        except NoMatches:
+            return None
+
     def _update_command_palette_geometry(self) -> None:
-        """Constrain the command palette overlay to the current pane."""
+        """Constrain the command palette overlay to the appropriate pane."""
 
         try:
             command_palette_layer = self.query_one("#command-palette-layer", Container)
-            current_pane = self.query_one("#current-pane", MainPane)
             browser_row = self.query_one("#browser-row")
         except NoMatches:
             return
 
-        pane_region = current_pane.region
+        # Determine target pane based on mode and active pane
+        target_pane = self._get_target_overlay_pane()
+        if target_pane is None:
+            return
+
+        pane_region = target_pane.region
         row_region = browser_row.region
         if pane_region.width <= 0 or pane_region.height <= 0:
             return
@@ -352,16 +383,20 @@ class zivoApp(App[None]):
         )
 
     def _update_config_dialog_geometry(self) -> None:
-        """Constrain the config dialog overlay to the current pane."""
+        """Constrain the config dialog overlay to the appropriate pane."""
 
         try:
             config_dialog_layer = self.query_one("#config-dialog-layer", Container)
-            current_pane = self.query_one("#current-pane", MainPane)
             browser_row = self.query_one("#browser-row")
         except NoMatches:
             return
 
-        pane_region = current_pane.region
+        # Determine target pane based on mode and active pane
+        target_pane = self._get_target_overlay_pane()
+        if target_pane is None:
+            return
+
+        pane_region = target_pane.region
         row_region = browser_row.region
         if pane_region.width <= 0 or pane_region.height <= 0:
             return
@@ -374,16 +409,20 @@ class zivoApp(App[None]):
         )
 
     def _update_input_dialog_geometry(self) -> None:
-        """Constrain the input dialog overlay to the current pane."""
+        """Constrain the input dialog overlay to the appropriate pane."""
 
         try:
             input_dialog_layer = self.query_one("#input-dialog-layer", Container)
-            current_pane = self.query_one("#current-pane", MainPane)
             browser_row = self.query_one("#browser-row")
         except NoMatches:
             return
 
-        pane_region = current_pane.region
+        # Determine target pane based on mode and active pane
+        target_pane = self._get_target_overlay_pane()
+        if target_pane is None:
+            return
+
+        pane_region = target_pane.region
         row_region = browser_row.region
         if pane_region.width <= 0 or pane_region.height <= 0:
             return


### PR DESCRIPTION
## Summary

- Transfer モード時のパレット表示位置を改善し、アクティブなペインの内容が見えるように変更
- コマンドパレット、設定ダイアログ、入力ダイアログがアクティブでないペインの領域にオーバーレイ表示されるように修正

## Changes

- **Left Directory がアクティブな場合**: Right Directory 表示領域にオーバーレイ
- **Right Directory がアクティブな場合**: Left Directory 表示領域にオーバーレイ
- **Browser モード**: 既存通り Current Directory にオーバーレイ（動作変更なし）

## Implementation Details

### 修正内容
- 新規ヘルパーメソッド `_get_target_overlay_pane()` を追加
- 3つの `_update_*_geometry` メソッドを修正：
  - `_update_command_palette_geometry`
  - `_update_config_dialog_geometry`
  - `_update_input_dialog_geometry`

### 修正ファイル
- `src/zivo/app.py` (48 行追加, 9 行削除)

## Test plan

### 手動テストシナリオ
1. **Browser モードでの動作確認**: `:` キーでコマンドパレットを開き、Current Directory にオーバーレイ表示されることを確認
2. **Transfer モード - Left Directory アクティブ**: `Ctrl+T` で Transfer モードに切り替え、Left Directory アクティブ状態で `:` キーを押し、パレットが Right Directory の領域に表示されることを確認
3. **Transfer モード - Right Directory アクティブ**: `[` キーで Right Directory をアクティブ化し、`:` キーでコマンドパレットを開き、パレットが Left Directory の領域に表示されることを確認
4. **設定ダイアログと入力ダイアログの確認**: 上記シナリオで設定ダイアログ（`,` キー）と入力ダイアログ（リネーム等）も同様に動作することを確認

### 自動テスト
- ✅ 全 1118 テスト成功
- ✅ Lint チェック成功

## Related Issue

Fixes #687

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)