### PR TITLE
Issue #682: Transferモード改善 - Historyの挙動

### DIFF
--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -467,6 +467,7 @@ class TransferPaneState:
 
     pane: PaneState
     current_path: str
+    history: HistoryState = HistoryState()
     current_pane_window_start: int = 0
     current_pane_delta: CurrentPaneDeltaState = CurrentPaneDeltaState()
     pending_snapshot_request_id: int | None = None

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -140,7 +140,17 @@ from .selectors import select_target_paths, select_visible_current_entry_states
 
 
 def _handle_begin_history_search(state: AppState) -> ReduceResult:
-    history_items = tuple(dict.fromkeys(state.history.visited_all))
+    if state.layout_mode == "transfer":
+        transfer = (
+            state.transfer_left
+            if state.active_transfer_pane == "left"
+            else state.transfer_right
+        )
+        if transfer is None:
+            return finalize(state)
+        history_items = tuple(dict.fromkeys(transfer.history.visited_all))
+    else:
+        history_items = tuple(dict.fromkeys(state.history.visited_all))
     return finalize(enter_palette(state, source="history", history_results=history_items))
 
 

--- a/src/zivo/state/reducer_transfer.py
+++ b/src/zivo/state/reducer_transfer.py
@@ -30,7 +30,7 @@ from .effects import LoadTransferPaneEffect, ReduceResult
 from .entry_state_helpers import select_visible_entry_states
 from .models import AppState, NotificationState, PaneState, TransferPaneId, TransferPaneState
 from .reducer_common import finalize, move_cursor, run_paste_request, select_range_paths
-from .reducer_requests import browser_snapshot_invalidation_paths
+from .reducer_requests import browser_snapshot_invalidation_paths, build_history_after_snapshot_load
 
 ReducerFn = Callable[[object, Action], ReduceResult]
 
@@ -119,8 +119,12 @@ def _handle_toggle_transfer_mode(
                 notification=NotificationState(level="info", message="Transfer mode closed"),
             )
         )
-    left = TransferPaneState(pane=state.current_pane, current_path=state.current_path)
-    right = TransferPaneState(pane=state.current_pane, current_path=state.current_path)
+    left = TransferPaneState(
+        pane=state.current_pane, current_path=state.current_path, history=state.history
+    )
+    right = TransferPaneState(
+        pane=state.current_pane, current_path=state.current_path, history=state.history
+    )
     return finalize(
         replace(
             state,
@@ -451,11 +455,21 @@ def _handle_transfer_pane_snapshot_loaded(
     transfer = _transfer_pane(state, action.pane_id)
     if transfer is None or transfer.pending_snapshot_request_id != action.request_id:
         return finalize(state)
+
+    # 履歴を更新（build_history_after_snapshot_loadを再利用）
+    temp_state = replace(
+        state,
+        current_path=transfer.current_path,
+        history=transfer.history,
+    )
+    new_history = build_history_after_snapshot_load(temp_state, action.current_path)
+
     next_transfer = replace(
         transfer,
         pane=action.pane,
         current_path=action.current_path,
         current_pane_window_start=0,
+        history=new_history,
         pending_snapshot_request_id=None,
     )
     return finalize(


### PR DESCRIPTION
## Summary

Transferモードで左右のペインそれぞれのディレクトリ移動履歴を管理し、Transferモード起動前の履歴を継承できるようにしました。また、Hキーによる履歴ナビゲーションをTransferモードでも利用可能にしました。

## Changes

- **TransferPaneState** に `history` フィールドを追加
- Transferモード起動時に現在の履歴を左右のペインに継承
- Transferモード中のディレクトリ移動で履歴を更新
- Hキーによる履歴ナビゲーションをTransferモード対応

## Test Plan

- [x] 既存テスト（1118個）が全てパスすることを確認
- [ ] Transferモード起動前に履歴を作成し、起動後に履歴が継承されることを確認
- [ ] 左右のペインで独立した履歴が管理されることを確認
- [ ] Hキーで履歴ナビゲーションができることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)