### PR TITLE
[#674] Reorder transfer mode help bar shortcuts

### DIFF
--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -201,12 +201,9 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             return HelpBarState(state.config.help_bar.transfer)
         return HelpBarState(
             (
-                "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | "
-                "Space select | v paste",
-                (
-                    "c copy | x cut | d delete | r rename | z undo | . hidden | "
-                    "N new-dir | b bookmarks | H history | G go-to | : palette"
-                ),
+                "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close",
+                "Space select | c copy | x cut | v paste | d delete | r rename",
+                "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette",
             )
         )
     if state.config.help_bar.browsing:

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -201,11 +201,11 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             return HelpBarState(state.config.help_bar.transfer)
         return HelpBarState(
             (
-                "[ ] focus | Space select | c copy | x cut | v paste | y copy-to-pane | "
-                "m move-to-pane | d delete | r rename",
+                "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | "
+                "Space select | v paste",
                 (
-                    "z undo | . hidden | N new-dir | b bookmarks | "
-                    "H history | G go-to | : palette | q/2 close"
+                    "c copy | x cut | d delete | r rename | z undo | . hidden | "
+                    "N new-dir | b bookmarks | H history | G go-to | : palette"
                 ),
             )
         )

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1287,14 +1287,14 @@ def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> Non
     help_state = select_help_bar_state(state)
 
     assert help_state.lines == (
-        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | Space select | v paste",
-        "c copy | x cut | d delete | r rename | z undo | . hidden | N new-dir | "
-        "b bookmarks | H history | G go-to | : palette",
+        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close",
+        "Space select | c copy | x cut | v paste | d delete | r rename",
+        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette",
     )
     assert help_state.text == (
-        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | Space select | v paste\n"
-        "c copy | x cut | d delete | r rename | z undo | . hidden | N new-dir | "
-        "b bookmarks | H history | G go-to | : palette"
+        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close\n"
+        "Space select | c copy | x cut | v paste | d delete | r rename\n"
+        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette"
     )
 
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1281,6 +1281,23 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     )
 
 
+def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> None:
+    state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+    help_state = select_help_bar_state(state)
+
+    assert help_state.lines == (
+        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | Space select | v paste",
+        "c copy | x cut | d delete | r rename | z undo | . hidden | N new-dir | "
+        "b bookmarks | H history | G go-to | : palette",
+    )
+    assert help_state.text == (
+        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | Space select | v paste\n"
+        "c copy | x cut | d delete | r rename | z undo | . hidden | N new-dir | "
+        "b bookmarks | H history | G go-to | : palette"
+    )
+
+
 def test_select_help_bar_for_busy_mode() -> None:
     state = replace(build_initial_app_state(), ui_mode="BUSY")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2653,9 +2653,9 @@ async def test_app_displays_transfer_help_bar() -> None:
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
-        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | Space select | v paste\n"
-        "c copy | x cut | d delete | r rename | z undo | . hidden | N new-dir | b bookmarks | "
-        "H history | G go-to | : palette"
+        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close\n"
+        "Space select | c copy | x cut | v paste | d delete | r rename\n"
+        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette"
     )
 
     async with app.run_test() as pilot:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -676,6 +676,26 @@ async def _wait_for_request_count(service, expected_count: int, timeout: float =
         await asyncio.sleep(0.01)
 
 
+async def _wait_for_file_search_results(
+    app,
+    expected_paths: list[str],
+    timeout: float = 0.5,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        palette = app.app_state.command_palette
+        actual_paths = (
+            [result.display_path for result in palette.file_search_results]
+            if palette is not None
+            else None
+        )
+        if actual_paths == expected_paths:
+            return
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"file search results did not become {expected_paths!r}")
+        await asyncio.sleep(0.01)
+
+
 async def _wait_for_child_pane_request_count(
     loader,
     expected_count: int,
@@ -3255,6 +3275,7 @@ async def test_app_file_search_passes_regex_queries_through_to_service(tmp_path)
             "$",
         )
         await _wait_for_request_count(file_search_service, 1)
+        await _wait_for_file_search_results(app, ["README.md"])
 
         assert file_search_service.executed_requests == [(path, r"re:^README\.md$", False)]
         assert app.app_state.command_palette is not None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2653,9 +2653,9 @@ async def test_app_displays_transfer_help_bar() -> None:
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
-        "[ ] focus | Space select | c copy | x cut | v paste | y copy-to-pane | "
-        "m move-to-pane | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette | q/2 close"
+        "[ ] focus | y copy-to-pane | m move-to-pane | q/2 close | Space select | v paste\n"
+        "c copy | x cut | d delete | r rename | z undo | . hidden | N new-dir | b bookmarks | "
+        "H history | G go-to | : palette"
     )
 
     async with app.run_test() as pilot:

--- a/tests/test_state_selectors_ui.py
+++ b/tests/test_state_selectors_ui.py
@@ -33,6 +33,9 @@ test_select_conflict_dialog_state_formats_zip_confirmation = (
 test_select_help_bar_defaults_to_browsing_shortcuts = (
     cases.test_select_help_bar_defaults_to_browsing_shortcuts
 )
+test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions = (
+    cases.test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions
+)
 test_select_help_bar_for_attribute_dialog = (
     cases.test_select_help_bar_for_attribute_dialog
 )


### PR DESCRIPTION
## Summary
- reorder the default transfer mode help bar so transfer-specific primary actions appear first
- move secondary file operations and utility shortcuts onto the second line
- add a selector-level assertion for the new transfer help ordering and update the UI expectation

## Testing
- uv run ruff check src/zivo/state/selectors_ui.py tests/test_app.py tests/state_selectors_cases.py tests/test_state_selectors_ui.py
- uv run pytest

## Issue
- closes #674
