### PR TITLE
#700 Add terminal launch mode option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -424,7 +424,7 @@ zivo は起動時にユーザー設定用の `config.toml` を読み込みます
 
 | セクション | キー | 値 | 説明 |
 | --- | --- | --- | --- |
-| `terminal` | `launch_mode` | `window` / `foreground` | `T` で zivo の current directory に対して外部ターミナルをどう開くかを選びます。`window` は別ウィンドウで起動し、`foreground` は zivo を一時停止して前面のターミナル終了後に戻ります。 |
+| `terminal` | `launch_mode` | `window` / `foreground` | `T` で zivo の current directory に対してターミナルをどう開くかを選びます。`window` は別ウィンドウで起動し、`foreground` は zivo を一時停止して現在の端末で対話シェルを開き、`exit` 後に zivo へ戻ります。 |
 | `terminal` | `linux` | shell 形式コマンド文字列の配列 | Linux 向けの任意ターミナル起動コマンドです。作業ディレクトリは `{path}` で埋め込みます。空文字や不正なエントリは無視されます。 |
 | `terminal` | `macos` | shell 形式コマンド文字列の配列 | macOS 向けの任意ターミナル起動コマンドです。検証ルールは Linux と同じです。 |
 | `terminal` | `windows` | shell 形式コマンド文字列の配列 | Windows / WSL ブリッジ向けの任意ターミナル起動コマンドです。Windows ネイティブ実行は未対応ですが設定キー自体は受け付けます。 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -404,11 +404,11 @@ Transferモードでは、アクティブな転送ペインで実行できるコ
 | `Move to trash` | 対象が 1 件以上あるとき | 選択中の項目、またはフォーカス項目をゴミ箱へ移動します（既定では確認あり、設定で変更可能）。 |
 | `Empty trash` | 常に表示（Linux/macOSのみ） | ゴミ箱内のすべての項目を完全に削除します。実行前に確認ダイアログを表示します。Windows では利用できません。 |
 | `Open in file manager` | 常に表示 | 現在ディレクトリを OS のファイルマネージャで開きます。`M` でも実行できます。 |
-| `Open terminal` | 常に表示 | `config.toml` の設定を優先しつつ、現在ディレクトリ起点で外部ターミナルを起動します。`T` でも実行できます。 |
+| `Open terminal` | 常に表示 | `config.toml` の設定を優先しつつ、zivo の current directory を起点に外部ターミナルを起動します。別ウィンドウ起動と前面起動を設定で切り替えられます。`T` でも実行できます。 |
 | `Run shell command` | 常に表示 | 1 行シェルコマンド入力ダイアログを開き、現在ディレクトリでバックグラウンド実行します。完了後は先頭の出力行、または失敗要約を status bar に表示します。`!` でも実行できます。 |
 | `Bookmark this directory` / `Remove bookmark` | 常に表示 | 現在ディレクトリを `[bookmarks].paths` に追加または削除します。ラベルは現在状態を反映し、`B` でも切り替えられます。 |
 | `Show hidden files` / `Hide hidden files` | 常に表示 | ブラウザ 3 ペインの隠しファイル表示を切り替えます。ラベルは現在状態を反映し、`.` でも切り替えられます。 |
-| `Edit config` | 常に表示 | 起動時設定を編集するオーバーレイを開きます。優先ターミナルエディタ、隠しファイル表示、ディレクトリサイズ表示、テキスト preview 表示、テーマ、ソート、貼り付け競合時の既定動作、削除確認の有無などを編集できます。テーマ変更はその場で即時プレビューされます。`↑` / `↓` または `Ctrl+n` / `Ctrl+p` で項目移動し、`←` / `→` / `Enter` で値変更、`s` で `config.toml` 保存、`e` で生の設定ファイルをターミナルエディタで開けます。 |
+| `Edit config` | 常に表示 | 起動時設定を編集するオーバーレイを開きます。優先ターミナルエディタ、外部ターミナル起動モード、隠しファイル表示、ディレクトリサイズ表示、テキスト preview 表示、テーマ、ソート、貼り付け競合時の既定動作、削除確認の有無などを編集できます。テーマ変更はその場で即時プレビューされます。`↑` / `↓` または `Ctrl+n` / `Ctrl+p` で項目移動し、`←` / `→` / `Enter` で値変更、`s` で `config.toml` 保存、`e` で生の設定ファイルをターミナルエディタで開けます。 |
 | `Create file` | 常に表示 | 現在ディレクトリで新規ファイル作成の入力を開始します。 |
 | `Create directory` | 常に表示 | 現在ディレクトリで新規ディレクトリ作成の入力を開始します。 |
 
@@ -424,6 +424,7 @@ zivo は起動時にユーザー設定用の `config.toml` を読み込みます
 
 | セクション | キー | 値 | 説明 |
 | --- | --- | --- | --- |
+| `terminal` | `launch_mode` | `window` / `foreground` | `T` で zivo の current directory に対して外部ターミナルをどう開くかを選びます。`window` は別ウィンドウで起動し、`foreground` は zivo を一時停止して前面のターミナル終了後に戻ります。 |
 | `terminal` | `linux` | shell 形式コマンド文字列の配列 | Linux 向けの任意ターミナル起動コマンドです。作業ディレクトリは `{path}` で埋め込みます。空文字や不正なエントリは無視されます。 |
 | `terminal` | `macos` | shell 形式コマンド文字列の配列 | macOS 向けの任意ターミナル起動コマンドです。検証ルールは Linux と同じです。 |
 | `terminal` | `windows` | shell 形式コマンド文字列の配列 | Windows / WSL ブリッジ向けの任意ターミナル起動コマンドです。Windows ネイティブ実行は未対応ですが設定キー自体は受け付けます。 |
@@ -449,6 +450,7 @@ zivo は起動時にユーザー設定用の `config.toml` を読み込みます
 
 ```toml
 [terminal]
+launch_mode = "window"
 linux = ["konsole --working-directory {path}", "gnome-terminal --working-directory={path}"]
 macos = ["open -a Terminal {path}"]
 windows = ["wt -d {path}"]

--- a/README.md
+++ b/README.md
@@ -399,11 +399,11 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Move to trash` | At least one target is selected or focused | Moves the selected items, or the focused item, to trash (confirmation is enabled by default and can be configured). |
 | `Empty trash` | Always (Linux/macOS only) | Permanently deletes all items from the trash. Shows a confirmation dialog before emptying. Not available on Windows. |
 | `Open in file manager` | Always | Opens the current directory in the OS file manager. Also available with `M`. |
-| `Open terminal` | Always | Launches an external terminal rooted at the current directory, using `config.toml` templates before built-in fallbacks. Also available with `T`. |
+| `Open terminal` | Always | Launches an external terminal rooted at zivo's current directory, using `config.toml` templates before built-in fallbacks. The launch mode can be switched between a separate window and foreground terminal handoff. Also available with `T`. |
 | `Run shell command` | Always | Opens a one-line shell command dialog, runs the command in the current directory in the background, and returns the first output line or failure summary in the status bar. Also available with `!`. |
 | `Bookmark this directory` / `Remove bookmark` | Always | Saves or removes the current directory in `[bookmarks].paths`. The label reflects whether the current directory is already bookmarked. Also available with `B`. |
 | `Show hidden files` / `Hide hidden files` | Always | Toggles hidden-file visibility for the browser panes. The label reflects the current visibility state. Also available with `.`. |
-| `Edit config` | Always | Opens the settings overlay for startup defaults. You can edit the preferred terminal editor, hidden-file visibility, directory-size visibility, text preview visibility, preview size limit, theme, sorting, default paste-conflict behavior, and delete confirmation. Theme changes are previewed immediately. Use `↑` / `↓` or `Ctrl+n` / `Ctrl+p` to move, `←` / `→` / `Enter` to change values, `s` to save `config.toml`, and `e` to open the raw config file in a terminal editor. |
+| `Edit config` | Always | Opens the settings overlay for startup defaults. You can edit the preferred terminal editor, external terminal launch mode, hidden-file visibility, directory-size visibility, text preview visibility, preview size limit, theme, sorting, default paste-conflict behavior, and delete confirmation. Theme changes are previewed immediately. Use `↑` / `↓` or `Ctrl+n` / `Ctrl+p` to move, `←` / `→` / `Enter` to change values, `s` to save `config.toml`, and `e` to open the raw config file in a terminal editor. |
 | `Create file` | Always | Starts the inline create-file flow in the current directory. |
 | `Create directory` | Always | Starts the inline create-directory flow in the current directory. |
 
@@ -420,6 +420,7 @@ The supported settings are:
 
 | Section | Key | Values | Description |
 | --- | --- | --- | --- |
+| `terminal` | `launch_mode` | `window` / `foreground` | Chooses how `T` opens the external terminal for zivo's current directory. `window` starts a separate terminal window. `foreground` suspends zivo, runs the terminal in the foreground, and returns to zivo after the terminal exits. |
 | `terminal` | `linux` | Array of shell-style command templates | Optional terminal launch commands for Linux. Use `{path}` as the working-directory placeholder. Invalid or empty entries are ignored. |
 | `terminal` | `macos` | Array of shell-style command templates | Optional terminal launch commands for macOS, validated the same way as Linux entries. |
 | `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. The config key is accepted even though native Windows runtime is not currently supported. |
@@ -447,6 +448,7 @@ Example:
 
 ```toml
 [terminal]
+launch_mode = "window"
 linux = ["konsole --working-directory {path}", "gnome-terminal --working-directory={path}"]
 macos = ["open -a Terminal {path}"]
 windows = ["wt -d {path}"]

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ The supported settings are:
 
 | Section | Key | Values | Description |
 | --- | --- | --- | --- |
-| `terminal` | `launch_mode` | `window` / `foreground` | Chooses how `T` opens the external terminal for zivo's current directory. `window` starts a separate terminal window. `foreground` suspends zivo, runs the terminal in the foreground, and returns to zivo after the terminal exits. |
+| `terminal` | `launch_mode` | `window` / `foreground` | Chooses how `T` opens a terminal for zivo's current directory. `window` starts a separate terminal window. `foreground` suspends zivo, opens an interactive shell in the current terminal, and returns to zivo after `exit`. |
 | `terminal` | `linux` | Array of shell-style command templates | Optional terminal launch commands for Linux. Use `{path}` as the working-directory placeholder. Invalid or empty entries are ignored. |
 | `terminal` | `macos` | Array of shell-style command templates | Optional terminal launch commands for macOS, validated the same way as Linux entries. |
 | `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. The config key is accepted even though native Windows runtime is not currently supported. |

--- a/src/zivo/adapters/external_launcher.py
+++ b/src/zivo/adapters/external_launcher.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol
 
-from zivo.models import EditorConfig, TerminalConfig
+from zivo.models import EditorConfig, TerminalConfig, TerminalLaunchMode
 
 CommandRunner = Callable[[Sequence[str], str | None, str | None], None]
 ForegroundCommandRunner = Callable[[Sequence[str], str | None], None]
@@ -40,7 +40,7 @@ class ExternalLaunchAdapter(Protocol):
 
     def open_in_editor(self, path: str) -> None: ...
 
-    def open_terminal(self, path: str) -> None: ...
+    def open_terminal(self, path: str, launch_mode: TerminalLaunchMode = "window") -> None: ...
 
     def copy_to_clipboard(self, text: str) -> None: ...
 
@@ -90,9 +90,16 @@ class LocalExternalLaunchAdapter:
 
         raise OSError(errors[-1] if errors else f"Failed to open {resolved_path} in editor")
 
-    def open_terminal(self, path: str) -> None:
+    def open_terminal(self, path: str, launch_mode: TerminalLaunchMode = "window") -> None:
         resolved_path = _resolve_directory_path(path)
         candidates = self._terminal_candidates(self._platform_kind(), str(resolved_path))
+        if launch_mode == "foreground":
+            self._run_first_available_foreground(
+                candidates,
+                context=f"open terminal in {resolved_path}",
+                cwd=str(resolved_path),
+            )
+            return
         self._run_first_available(
             candidates,
             context=f"open terminal in {resolved_path}",
@@ -181,6 +188,29 @@ class LocalExternalLaunchAdapter:
         for command in available_candidates:
             try:
                 self.command_runner(command, cwd, input_text)
+                return
+            except OSError as error:
+                errors.append(str(error) or f"{command[0]} failed")
+
+        raise OSError(errors[-1] if errors else f"Failed to {context}")
+
+    def _run_first_available_foreground(
+        self,
+        candidates: tuple[tuple[str, ...], ...],
+        *,
+        context: str,
+        cwd: str | None = None,
+    ) -> None:
+        available_candidates = [
+            command for command in candidates if self._command_exists(command[0])
+        ]
+        if not available_candidates:
+            raise OSError(f"No supported command found to {context}")
+
+        errors: list[str] = []
+        for command in available_candidates:
+            try:
+                self.foreground_command_runner(command, cwd)
                 return
             except OSError as error:
                 errors.append(str(error) or f"{command[0]} failed")

--- a/src/zivo/adapters/external_launcher.py
+++ b/src/zivo/adapters/external_launcher.py
@@ -92,14 +92,11 @@ class LocalExternalLaunchAdapter:
 
     def open_terminal(self, path: str, launch_mode: TerminalLaunchMode = "window") -> None:
         resolved_path = _resolve_directory_path(path)
-        candidates = self._terminal_candidates(self._platform_kind(), str(resolved_path))
         if launch_mode == "foreground":
-            self._run_first_available_foreground(
-                candidates,
-                context=f"open terminal in {resolved_path}",
-                cwd=str(resolved_path),
-            )
+            command = self._foreground_terminal_command()
+            self.foreground_command_runner(command, str(resolved_path))
             return
+        candidates = self._terminal_candidates(self._platform_kind(), str(resolved_path))
         self._run_first_available(
             candidates,
             context=f"open terminal in {resolved_path}",
@@ -188,29 +185,6 @@ class LocalExternalLaunchAdapter:
         for command in available_candidates:
             try:
                 self.command_runner(command, cwd, input_text)
-                return
-            except OSError as error:
-                errors.append(str(error) or f"{command[0]} failed")
-
-        raise OSError(errors[-1] if errors else f"Failed to {context}")
-
-    def _run_first_available_foreground(
-        self,
-        candidates: tuple[tuple[str, ...], ...],
-        *,
-        context: str,
-        cwd: str | None = None,
-    ) -> None:
-        available_candidates = [
-            command for command in candidates if self._command_exists(command[0])
-        ]
-        if not available_candidates:
-            raise OSError(f"No supported command found to {context}")
-
-        errors: list[str] = []
-        for command in available_candidates:
-            try:
-                self.foreground_command_runner(command, cwd)
                 return
             except OSError as error:
                 errors.append(str(error) or f"{command[0]} failed")
@@ -333,6 +307,19 @@ class LocalExternalLaunchAdapter:
         if command_path.is_absolute():
             return command_path.exists()
         return self.command_available(command) is not None
+
+    def _foreground_terminal_command(self) -> tuple[str, ...]:
+        shell = self.environment_variable("SHELL")
+        if shell:
+            try:
+                parsed = tuple(shlex.split(shell))
+            except ValueError as error:
+                raise OSError(f"Invalid SHELL value: {error}") from error
+            if parsed and self._command_exists(parsed[0]):
+                return (*parsed, "-i")
+        if self._command_exists("/bin/bash"):
+            return ("/bin/bash", "-i")
+        raise OSError("No supported interactive shell found for foreground terminal mode")
 
     def _terminal_candidates(
         self,

--- a/src/zivo/app_runtime_execution.py
+++ b/src/zivo/app_runtime_execution.py
@@ -410,6 +410,12 @@ def schedule_external_launch_effect(app: Any, effect: RunExternalLaunchEffect) -
     if effect.request.kind == "open_editor":
         app.call_next(run_foreground_external_launch, app, effect)
         return
+    if (
+        effect.request.kind == "open_terminal"
+        and effect.request.terminal_launch_mode == "foreground"
+    ):
+        app.call_next(run_foreground_external_launch, app, effect)
+        return
     schedule_external_launch(app, effect)
 
 

--- a/src/zivo/models/__init__.py
+++ b/src/zivo/models/__init__.py
@@ -17,6 +17,7 @@ from .config import (
     PreviewMaxKiB,
     PreviewSyntaxTheme,
     TerminalConfig,
+    TerminalLaunchMode,
 )
 from .external_launch import ExternalLaunchKind, ExternalLaunchRequest
 from .file_operations import (
@@ -162,6 +163,7 @@ __all__ = [
     "TabBarState",
     "TabItemState",
     "TerminalConfig",
+    "TerminalLaunchMode",
     "ThreePaneShellData",
     "TransferPaneViewState",
     "build_dummy_shell_data",

--- a/src/zivo/models/config.py
+++ b/src/zivo/models/config.py
@@ -7,6 +7,7 @@ from zivo.theme_support import AUTO_PREVIEW_SYNTAX_THEME, DEFAULT_APP_THEME
 
 ConfigSortField = Literal["name", "modified", "size"]
 SplitTerminalPosition = Literal["bottom", "right", "overlay"]
+TerminalLaunchMode = Literal["window", "foreground"]
 ConfigTheme = str
 PreviewSyntaxTheme = str
 PreviewMaxKiB = Literal[64, 128, 256, 512, 1024]
@@ -18,6 +19,7 @@ PasteConflictAction = Literal["overwrite", "skip", "rename", "prompt"]
 class TerminalConfig:
     """Terminal launch command templates keyed by target platform."""
 
+    launch_mode: TerminalLaunchMode = "window"
     linux: tuple[str, ...] = ()
     macos: tuple[str, ...] = ()
     windows: tuple[str, ...] = ()

--- a/src/zivo/models/external_launch.py
+++ b/src/zivo/models/external_launch.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from .config import TerminalLaunchMode
+
 ExternalLaunchKind = Literal["open_file", "open_editor", "open_terminal", "copy_paths"]
 
 
@@ -14,3 +16,4 @@ class ExternalLaunchRequest:
     path: str | None = None
     paths: tuple[str, ...] = ()
     line_number: int | None = None
+    terminal_launch_mode: TerminalLaunchMode | None = None

--- a/src/zivo/services/config/loader.py
+++ b/src/zivo/services/config/loader.py
@@ -36,6 +36,7 @@ from .shared import (
     VALID_SORT_FIELDS,
     VALID_SPLIT_TERMINAL_POSITIONS,
     VALID_TERMINAL_EDITOR_NAMES,
+    VALID_TERMINAL_LAUNCH_MODES,
     VALID_THEMES,
     VALIDATION_PATH,
 )
@@ -110,6 +111,15 @@ def load_terminal_config(section: object, warnings: list[str]) -> TerminalConfig
     if validated is None:
         return TerminalConfig()
     return TerminalConfig(
+        launch_mode=read_enum(
+            validated,
+            key="launch_mode",
+            default="window",
+            valid_values=VALID_TERMINAL_LAUNCH_MODES,
+            valid_display="window, foreground",
+            section_name="terminal",
+            warnings=warnings,
+        ),
         linux=load_command_templates(validated, "linux", warnings),
         macos=load_command_templates(validated, "macos", warnings),
         windows=load_command_templates(validated, "windows", warnings),

--- a/src/zivo/services/config/render.py
+++ b/src/zivo/services/config/render.py
@@ -35,6 +35,9 @@ def render_terminal_section(config: AppConfig) -> str:
     windows = render_command_array(config.terminal.windows)
     return (
         "[terminal]\n"
+        '# launch_mode = "window"\n'
+        "# window: launch a separate terminal window.\n"
+        "# foreground: suspend zivo and use the terminal in the foreground until exit.\n"
         "# Optional OS-specific terminal launch templates.\n"
         "# Use {path} for the working directory.\n"
         "# Examples:\n"
@@ -44,6 +47,7 @@ def render_terminal_section(config: AppConfig) -> str:
         '# ]\n'
         '# macos = ["open -a Terminal {path}"]\n'
         '# windows = ["wt -d {path}"]\n'
+        f'launch_mode = "{config.terminal.launch_mode}"\n'
         f"linux = [{linux}]\n"
         f"macos = [{macos}]\n"
         f"windows = [{windows}]"

--- a/src/zivo/services/config/shared.py
+++ b/src/zivo/services/config/shared.py
@@ -10,6 +10,7 @@ VALID_PREVIEW_SYNTAX_THEMES = frozenset(SUPPORTED_PREVIEW_SYNTAX_THEMES)
 VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
 VALID_SPLIT_TERMINAL_POSITIONS = frozenset({"bottom", "right", "overlay"})
+VALID_TERMINAL_LAUNCH_MODES = frozenset({"window", "foreground"})
 VALID_PREVIEW_MAX_KIB = frozenset({64, 128, 256, 512, 1024})
 VALID_TERMINAL_EDITOR_NAMES = frozenset(
     {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}

--- a/src/zivo/services/external_launcher.py
+++ b/src/zivo/services/external_launcher.py
@@ -48,7 +48,7 @@ class LiveExternalLaunchService:
 
         path = _require_path(request)
         try:
-            self.adapter.open_terminal(path)
+            self.adapter.open_terminal(path, request.terminal_launch_mode or "window")
         except OSError as error:
             raise OSError(_format_terminal_error(path, str(error))) from error
 

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -62,6 +62,7 @@ LayoutMode = Literal["browser", "transfer"]
 TransferPaneId = Literal["left", "right"]
 ConfigFieldId = Literal[
     "editor.command",
+    "terminal.launch_mode",
     "display.show_hidden_files",
     "display.show_directory_sizes",
     "display.show_preview",

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -13,6 +13,7 @@ CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
 CONFIG_PREVIEW_MAX_KIB = (64, 128, 256, 512, 1024)
 CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
+CONFIG_TERMINAL_LAUNCH_MODES = ("window", "foreground")
 CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
 CONFIG_SPLIT_TERMINAL_POSITIONS = ("bottom", "right", "overlay")
 CONFIG_FILE_SEARCH_MAX_RESULTS = (None, 100, 500, 1000, 5000, 10000)
@@ -30,6 +31,18 @@ def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) 
             editor=replace(
                 config.editor,
                 command=cycle_editor_command(config.editor.command, delta),
+            ),
+        )
+    if field_id == "terminal.launch_mode":
+        return replace(
+            config,
+            terminal=replace(
+                config.terminal,
+                launch_mode=cycle_choice(
+                    CONFIG_TERMINAL_LAUNCH_MODES,
+                    config.terminal.launch_mode,
+                    delta,
+                ),
             ),
         )
     if field_id == "display.show_hidden_files":
@@ -214,6 +227,7 @@ def cycle_editor_command(current: str | None, delta: int) -> str | None:
 def config_editor_field_ids() -> tuple[str, ...]:
     return (
         "editor.command",
+        "terminal.launch_mode",
         "display.show_hidden_files",
         "display.theme",
         "display.show_directory_sizes",
@@ -236,6 +250,7 @@ def config_editor_field_ids() -> tuple[str, ...]:
 def config_editor_labels() -> tuple[str, ...]:
     return (
         "Editor command",
+        "Terminal launch mode",
         "Show hidden files",
         "Theme",
         "Show directory sizes",
@@ -256,12 +271,12 @@ def config_editor_labels() -> tuple[str, ...]:
 
 
 CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
-    ("External", (0,)),
-    ("Display", (2, 5, 1, 3, 4, 6, 7, 11, 12)),
-    ("Sorting", (8, 9, 10)),
-    ("Behavior", (13, 14)),
-    ("Logging", (15,)),
-    ("File Search", (16,)),
+    ("External", (0, 1)),
+    ("Display", (3, 6, 2, 4, 5, 7, 8, 12, 13)),
+    ("Sorting", (9, 10, 11)),
+    ("Behavior", (14, 15)),
+    ("Logging", (16,)),
+    ("File Search", (17,)),
 )
 
 
@@ -305,6 +320,8 @@ def format_config_field_value(field_index: int, config: AppConfig) -> str:
     field_id = config_editor_field_ids()[field_index]
     if field_id == "editor.command":
         return _format_editor_command_value(config.editor.command)
+    if field_id == "terminal.launch_mode":
+        return config.terminal.launch_mode
     if field_id == "display.show_hidden_files":
         return _format_bool(config.display.show_hidden_files)
     if field_id == "display.theme":

--- a/src/zivo/state/reducer_terminal_config.py
+++ b/src/zivo/state/reducer_terminal_config.py
@@ -408,7 +408,11 @@ def _handle_open_terminal_at_path(
 ) -> ReduceResult:
     return run_external_launch_request(
         replace(state, notification=None),
-        ExternalLaunchRequest(kind="open_terminal", path=action.path),
+        ExternalLaunchRequest(
+            kind="open_terminal",
+            path=action.path,
+            terminal_launch_mode=state.config.terminal.launch_mode,
+        ),
     )
 
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1973,7 +1973,7 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=2,
+            cursor_index=3,
             dirty=True,
         ),
     )
@@ -1985,6 +1985,7 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     assert "Path: /tmp/zivo/config.toml" in dialog.lines
     assert "  ── External ──" in dialog.lines
     assert "  Editor command: system default" in dialog.lines
+    assert "  Terminal launch mode: window" in dialog.lines
     assert "  ── Display ──" in dialog.lines
     assert "> Theme: textual-dark" in dialog.lines
     assert "  Preview syntax theme: auto" in dialog.lines

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4056,7 +4056,7 @@ async def test_app_command_palette_opens_config_dialog_and_saves_changes() -> No
         assert "Path: /tmp/zivo/config.toml" in str(lines.renderable)
         assert "> Editor command: system default" in str(lines.renderable)
 
-        for _ in range(3):
+        for _ in range(4):
             await pilot.press("down")
         await pilot.press("enter")
         await pilot.press("s")
@@ -4127,7 +4127,8 @@ async def test_app_config_dialog_save_updates_theme(monkeypatch) -> None:
 
         assert app.theme == "textual-dark"
 
-        await pilot.press("down")
+        for _ in range(2):
+            await pilot.press("down")
         await pilot.press("enter")
         await _wait_for_app_theme(app, "textual-light")
         await _wait_for_predicate(
@@ -4189,7 +4190,8 @@ async def test_app_config_dialog_dismiss_restores_theme_preview() -> None:
         await pilot.press("enter")
         await _wait_for_config_dialog(app)
 
-        await pilot.press("down")
+        for _ in range(2):
+            await pilot.press("down")
         await pilot.press("enter")
         await _wait_for_app_theme(app, "textual-light")
 
@@ -4252,7 +4254,8 @@ async def test_app_config_dialog_theme_preview_updates_auto_syntax_theme() -> No
         await pilot.press("c", "o", "n", "f", "i", "g")
         await pilot.press("enter")
         await _wait_for_config_dialog(app)
-        await pilot.press("down")
+        for _ in range(2):
+            await pilot.press("down")
         await pilot.press("enter")
         await _wait_for_app_theme(app, "textual-light")
 
@@ -4319,7 +4322,7 @@ async def test_app_config_dialog_save_updates_preview_syntax_theme() -> None:
         await pilot.press("enter")
         await _wait_for_config_dialog(app)
 
-        for _ in range(2):
+        for _ in range(3):
             await pilot.press("down")
         await pilot.press("enter")
 
@@ -4418,9 +4421,17 @@ async def test_app_config_save_refreshes_live_external_launch_service() -> None:
 
         assert isinstance(app._external_launch_service, LiveExternalLaunchService)
         assert app._external_launch_service.adapter.editor_command_template.command is None
+        assert (
+            app._external_launch_service.adapter.terminal_command_templates.launch_mode
+            == "window"
+        )
 
         app._app_state = replace(app.app_state, pending_config_save_request_id=7)
-        saved_config = replace(app.app_state.config, editor=EditorConfig(command="nvim -u NONE"))
+        saved_config = replace(
+            app.app_state.config,
+            editor=EditorConfig(command="nvim -u NONE"),
+            terminal=replace(app.app_state.config.terminal, launch_mode="foreground"),
+        )
         await app.dispatch_actions(
             (
                 ConfigSaveCompleted(
@@ -4434,6 +4445,10 @@ async def test_app_config_save_refreshes_live_external_launch_service() -> None:
         assert isinstance(app._external_launch_service, LiveExternalLaunchService)
         assert (
             app._external_launch_service.adapter.editor_command_template.command == "nvim -u NONE"
+        )
+        assert (
+            app._external_launch_service.adapter.terminal_command_templates.launch_mode
+            == "foreground"
         )
 
 
@@ -4611,7 +4626,11 @@ async def test_app_command_palette_open_terminal_launches_current_directory() ->
         await _wait_for_external_launch_count(app, 1)
 
         assert launch_service.executed_requests == [
-            ExternalLaunchRequest(kind="open_terminal", path=path)
+            ExternalLaunchRequest(
+                kind="open_terminal",
+                path=path,
+                terminal_launch_mode="window",
+            )
         ]
         assert app.app_state.ui_mode == "BROWSING"
 

--- a/tests/test_services_config.py
+++ b/tests/test_services_config.py
@@ -39,6 +39,7 @@ def test_loader_creates_default_config_when_missing(tmp_path) -> None:
     assert result.config.display.show_hidden_files is False
     assert config_path.exists()
     written = config_path.read_text(encoding="utf-8")
+    assert '# launch_mode = "window"' in written
     assert '# linux = [' in written
     assert '#   "konsole --working-directory {path}",' in written
     assert '#   "gnome-terminal --working-directory={path}",' in written
@@ -61,6 +62,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
     config_path.write_text(
         """
         [terminal]
+        launch_mode = "foreground"
         linux = ["konsole --working-directory {path}"]
 
         [editor]
@@ -96,6 +98,7 @@ def test_loader_reads_valid_config_values(tmp_path) -> None:
 
     assert result.created is False
     assert result.warnings == ()
+    assert result.config.terminal.launch_mode == "foreground"
     assert result.config.terminal.linux == ("konsole --working-directory {path}",)
     assert result.config.editor.command == "nvim -u NONE"
     assert result.config.display.show_hidden_files is True
@@ -124,6 +127,7 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
     config_path.write_text(
         """
         [terminal]
+        launch_mode = "popup"
         linux = ["konsole --working-directory {path}", "{broken"]
 
         [editor]
@@ -155,6 +159,7 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
 
     result = AppConfigLoader(config_path_resolver=lambda: config_path).load()
 
+    assert result.config.terminal.launch_mode == "window"
     assert result.config.terminal.linux == ("konsole --working-directory {path}",)
     assert result.config.editor.command is None
     assert result.config.display.show_hidden_files is True
@@ -169,7 +174,7 @@ def test_loader_keeps_valid_values_and_warns_for_invalid_entries(tmp_path) -> No
     assert result.config.logging.enabled is True
     assert result.config.logging.path is None
     assert result.config.bookmarks.paths == ()
-    assert len(result.warnings) == 15
+    assert len(result.warnings) == 16
 
 
 def test_loader_warns_for_invalid_editor_command_syntax(tmp_path) -> None:
@@ -197,7 +202,10 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
     saved_path = service.save(
         path=str(config_path),
         config=AppConfig(
-            terminal=TerminalConfig(linux=("konsole --working-directory {path}",)),
+            terminal=TerminalConfig(
+                launch_mode="foreground",
+                linux=("konsole --working-directory {path}",),
+            ),
             editor=EditorConfig(command="nvim -u NONE"),
             display=DisplayConfig(
                 show_hidden_files=True,
@@ -225,6 +233,7 @@ def test_config_save_service_writes_normalized_config_file(tmp_path) -> None:
 
     assert saved_path == str(config_path)
     written = config_path.read_text(encoding="utf-8")
+    assert 'launch_mode = "foreground"' in written
     assert '# macos = ["open -a Terminal {path}"]' in written
     assert '# windows = ["wt -d {path}"]' in written
     assert 'linux = ["konsole --working-directory {path}"]' in written

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -46,7 +46,7 @@ class StubExternalLaunchAdapter:
     def open_in_editor(self, path: str) -> None:
         self.edited_paths.append(path)
 
-    def open_terminal(self, path: str) -> None:
+    def open_terminal(self, path: str, launch_mode: str = "window") -> None:
         self.terminal_paths.append(path)
 
     def copy_to_clipboard(self, text: str) -> None:
@@ -285,6 +285,19 @@ def test_local_external_launch_adapter_uses_windows_templates_first_on_wsl(tmp_p
     ]
 
 
+def test_local_external_launch_adapter_runs_terminal_in_foreground_mode(tmp_path) -> None:
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "kgx" else None,
+        foreground_command_runner=runner,
+    )
+
+    adapter.open_terminal(str(tmp_path), launch_mode="foreground")
+
+    assert runner.executed == [(("kgx",), str(tmp_path))]
+
+
 def test_local_external_launch_adapter_copies_to_clipboard_on_linux() -> None:
     runner = StubCommandRunner()
     adapter = LocalExternalLaunchAdapter(
@@ -431,6 +444,27 @@ def test_live_external_launch_service_opens_terminal_with_adapter() -> None:
     service.execute(ExternalLaunchRequest(kind="open_terminal", path="/tmp/zivo"))
 
     assert adapter.terminal_paths == ["/tmp/zivo"]
+
+
+def test_live_external_launch_service_opens_terminal_in_foreground_mode(tmp_path) -> None:
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "kgx" else None,
+        foreground_command_runner=runner,
+    )
+    service = LiveExternalLaunchService(adapter=adapter)
+    path = str(tmp_path.resolve())
+
+    service.execute(
+        ExternalLaunchRequest(
+            kind="open_terminal",
+            path=path,
+            terminal_launch_mode="foreground",
+        )
+    )
+
+    assert runner.executed == [(("kgx",), path)]
 
 
 def test_live_external_launch_service_copies_paths_with_expected_payload() -> None:

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -289,13 +289,13 @@ def test_local_external_launch_adapter_runs_terminal_in_foreground_mode(tmp_path
     runner = StubForegroundRunner()
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Linux",
-        command_available=lambda command: command if command == "kgx" else None,
         foreground_command_runner=runner,
+        environment_variable=lambda name: "/bin/sh" if name == "SHELL" else None,
     )
 
     adapter.open_terminal(str(tmp_path), launch_mode="foreground")
 
-    assert runner.executed == [(("kgx",), str(tmp_path))]
+    assert runner.executed == [(("/bin/sh", "-i"), str(tmp_path))]
 
 
 def test_local_external_launch_adapter_copies_to_clipboard_on_linux() -> None:
@@ -450,8 +450,8 @@ def test_live_external_launch_service_opens_terminal_in_foreground_mode(tmp_path
     runner = StubForegroundRunner()
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Linux",
-        command_available=lambda command: command if command == "kgx" else None,
         foreground_command_runner=runner,
+        environment_variable=lambda name: "/bin/sh" if name == "SHELL" else None,
     )
     service = LiveExternalLaunchService(adapter=adapter)
     path = str(tmp_path.resolve())
@@ -464,7 +464,7 @@ def test_live_external_launch_service_opens_terminal_in_foreground_mode(tmp_path
         )
     )
 
-    assert runner.executed == [(("kgx",), path)]
+    assert runner.executed == [(("/bin/sh", "-i"), path)]
 
 
 def test_live_external_launch_service_copies_paths_with_expected_payload() -> None:

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -729,6 +729,7 @@ def test_open_terminal_at_path_emits_external_launch_effect() -> None:
             request=ExternalLaunchRequest(
                 kind="open_terminal",
                 path="/home/tadashi/develop/zivo",
+                terminal_launch_mode="window",
             ),
         ),
     )
@@ -754,7 +755,24 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     next_state = _reduce_state(state, MoveConfigEditorCursor(delta=99))
 
     assert next_state.config_editor is not None
-    assert next_state.config_editor.cursor_index == 16
+    assert next_state.config_editor.cursor_index == 17
+
+def test_cycle_config_editor_terminal_launch_mode_updates_draft() -> None:
+    state = replace(
+        build_initial_app_state(config_path="/tmp/zivo/config.toml"),
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/zivo/config.toml",
+            draft=build_initial_app_state().config,
+            cursor_index=1,
+        ),
+    )
+
+    next_state = _reduce_state(state, CycleConfigEditorValue(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.draft.terminal.launch_mode == "foreground"
+    assert next_state.config_editor.dirty is True
 
 def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:
     state = replace(
@@ -780,7 +798,7 @@ def test_cycle_config_editor_value_updates_draft_and_dirty_state() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=1,
+            cursor_index=2,
         ),
     )
 
@@ -798,7 +816,7 @@ def test_cycle_config_editor_split_terminal_position_updates_draft() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=original_state.config,
-            cursor_index=12,
+            cursor_index=13,
         ),
     )
 
@@ -822,7 +840,7 @@ def test_cycle_config_editor_split_terminal_position_reaches_overlay() -> None:
                     split_terminal_position="right",
                 ),
             ),
-            cursor_index=12,
+            cursor_index=13,
         ),
     )
 
@@ -840,7 +858,7 @@ def test_cycle_config_editor_theme_updates_draft_and_dirty_state() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=original_state.config,
-            cursor_index=2,
+            cursor_index=3,
         ),
     )
 
@@ -863,7 +881,7 @@ def test_cycle_config_editor_theme_supports_all_builtin_themes() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=themed_config,
-            cursor_index=2,
+            cursor_index=3,
         ),
     )
 
@@ -880,7 +898,7 @@ def test_cycle_config_editor_directory_size_visibility_updates_draft_and_dirty_s
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=3,
+            cursor_index=4,
         ),
     )
 
@@ -897,7 +915,7 @@ def test_cycle_config_editor_preview_visibility_updates_draft_and_dirty_state() 
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=4,
+            cursor_index=5,
         ),
     )
 
@@ -914,7 +932,7 @@ def test_cycle_config_editor_preview_syntax_theme_updates_draft_and_dirty_state(
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=5,
+            cursor_index=6,
         ),
     )
 
@@ -931,7 +949,7 @@ def test_cycle_config_editor_preview_max_kib_updates_draft_and_dirty_state() -> 
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=build_initial_app_state().config,
-            cursor_index=6,
+            cursor_index=7,
         ),
     )
 
@@ -1154,7 +1172,7 @@ def test_cycle_config_editor_file_search_max_results_updates_draft() -> None:
         config_editor=ConfigEditorState(
             path="/tmp/zivo/config.toml",
             draft=original_state.config,
-            cursor_index=16,  # file_search.max_results
+            cursor_index=17,  # file_search.max_results
         ),
     )
 

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -623,6 +623,7 @@ def test_submit_command_palette_runs_open_terminal_flow() -> None:
             request=ExternalLaunchRequest(
                 kind="open_terminal",
                 path="/home/tadashi/develop/zivo",
+                terminal_launch_mode="window",
             ),
         ),
     )


### PR DESCRIPTION
## Summary
- add a configurable external terminal launch mode for `T`
- keep external terminal launches rooted at zivo's current directory in both window and foreground modes
- update config docs and tests for the new option

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Related
- Closes #700
