### PR TITLE
#714 pandocのバージョンを明記

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -131,11 +131,13 @@ zivo 本体の起動は `uv` だけで行えますが、一部の機能は `PATH
 
 | 機能 | Ubuntu / Debian | Ubuntu (WSL) | macOS |
 | --- | --- | --- | --- |
-| ドキュメント preview (`docx` / `xlsx` / `pptx`) | `pandoc` | `pandoc` | `pandoc` |
+| ドキュメント preview (`docx` / `xlsx` / `pptx`) | `pandoc` 3.8.3+ | `pandoc` 3.8.3+ | `pandoc` 3.8.3+ |
 | PDF preview (`pdf`) | `poppler-utils` | `poppler-utils` | `poppler` |
 | grep 検索 (`g`) | `ripgrep` | `ripgrep` | `ripgrep` |
 | パスコピー (`C`) | X11: `xclip` / Wayland: `wl-clipboard` | 通常は不要 (`clip.exe`)、必要なら `xclip` / `wl-clipboard` | 不要 (`pbcopy` 組み込み) |
 | GUI 連携コマンド | 不要 | `wslu` 推奨 | 不要 |
+
+**注**: 一部のディストリビューションでは、パッケージマネージャー経由でpandoc 3.8.3以上が提供されない場合があります。インストールされたバージョンが3.8.3より古い場合は、公式pandocウェブサイトから最新版を手動でインストールしてください：https://pandoc.org/installing.html
 
 インストール例:
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ zivo itself can be installed and started with `uv`, but some features depend on 
 
 | Feature | Ubuntu / Debian | Ubuntu (WSL) | macOS |
 | --- | --- | --- | --- |
-| Document preview (`docx` / `xlsx` / `pptx`) | `pandoc` | `pandoc` | `pandoc` |
+| Document preview (`docx` / `xlsx` / `pptx`) | `pandoc` 3.8.3+ | `pandoc` 3.8.3+ | `pandoc` 3.8.3+ |
 | PDF preview (`pdf`) | `poppler-utils` | `poppler-utils` | `poppler` |
 | Grep search (`g`) | `ripgrep` | `ripgrep` | `ripgrep` |
 | Copy path (`C`) | X11: `xclip` / Wayland: `wl-clipboard` | Usually none (`clip.exe`), optional: `xclip` / `wl-clipboard` | None (`pbcopy` built in) |
 | GUI bridge commands | None | `wslu` recommended | None |
+
+**Note**: Some distributions may not provide pandoc 3.8.3+ through their package managers. If the installed version is older than 3.8.3, install the latest version manually from the official pandoc website: https://pandoc.org/installing.html
 
 Install example:
 


### PR DESCRIPTION
## 概要
xslsxとpptxファイルのプレビューに必要なpandocのバージョン（3.8.3以上）をREADMEに明記しました。また、パッケージマネージャーで最新版が入手できない場合の、公式サイトからの手動インストール方法を記載しました。

## 変更内容
- README.md と README.ja.md の Dependencies テーブルに、pandoc 3.8.3+ であることを明記
- Dependencies テーブルの直後に、パッケージマネージャーで最新版が入手できない場合の注記を追加

## テスト結果
- lint: ✓ 通過
- pytest: ✓ 1147 tests passed

## 関連Issue
Fixes #714