### PR TITLE
#723 Add minimum Windows startup support

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - develop
+      - feat/windows
   pull_request:
     branches:
       - main
       - develop
+      - feat/windows
 
 jobs:
   lint-and-test:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Overlay display:
 | Ubuntu | Supported | Primary verified environment at the moment. |
 | Ubuntu (WSL) | Supported | WSL running Ubuntu is part of the verified environments. |
 | macOS | Supported | Grant Full Disk Access to your terminal for trash operations. |
-| Windows | Not supported at this time | Native Windows runtime is not supported. |
+| Windows | Partial | Minimum startup and basic browsing are supported, but native Windows still lacks full feature parity. |
 
 ## Installation
 
@@ -152,7 +152,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-Windows is not supported at this time, so native Windows dependency guidance is out of scope.
+On native Windows, zivo currently focuses on minimum startup and basic browsing. POSIX-oriented features such as the embedded split terminal are still unavailable there, so native Windows dependency guidance remains intentionally limited.
 
 On macOS, grant **Full Disk Access** to your terminal application. Open **System Settings > Privacy & Security > Full Disk Access** and enable the terminal app you use to run zivo (for example Terminal.app, iTerm2, or Alacritty). Without this permission, operations that access `~/.Trash` or other protected directories will fail.
 
@@ -222,7 +222,7 @@ When a file is focused, press `e` to switch into a terminal editor in the curren
 | `.` | Toggle hidden files |
 | `s` | Cycle sort |
 | `R` | Reload directory |
-| `t` | Toggle split terminal |
+| `t` | Toggle split terminal (POSIX only) |
 | `T` | Open terminal at current directory |
 | `o` | Open new tab |
 | `w` | Close current tab |
@@ -364,7 +364,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Reload directory` | Always | Reloads the current directory. |
 | `Toggle transfer mode` / `Close transfer mode` | Always | Switches between the normal three-pane browser and the two-pane transfer layout. Also available with `q` / `2` while transfer mode is open, and `2` from normal mode. |
 | `Undo last file operation` | Undo history is not empty | Reverses the most recent undoable rename, paste, or trash operation. Also available with `z`. Trash restore is currently Linux-only. |
-| `Toggle split terminal` | Always | Opens or closes the embedded split terminal. |
+| `Toggle split terminal` | POSIX environments | Opens or closes the embedded split terminal. Not available on native Windows. |
 | `Select all` | Current directory has at least one visible entry | Selects every currently visible entry in the current directory, respecting hidden-file visibility and any active filter. |
 | `Replace text in selected files` | A file is focused or one or more files are selected in the current directory | Opens a two-field replacement palette for the selected files, or the focused file when nothing is explicitly selected. Matching files appear in the palette, `↑↓` and `Ctrl+n` / `Ctrl+p` move between them, and the right pane shows the selected file's diff before `Enter` applies the replacement. `Shift+↑` / `Shift+↓` scrolls the diff preview. |
 | `Replace text in found files` | Always | Opens a three-field replacement palette (filename, find, replace). Type a filename pattern to search for files, then type find/replace text to preview replacements. `Tab` / `Shift+Tab` cycle between fields. The right pane shows the diff preview, and `Enter` applies the replacement. |
@@ -394,7 +394,7 @@ If the file does not exist yet, zivo creates it automatically with default value
 
 - Linux: `${XDG_CONFIG_HOME:-~/.config}/zivo/config.toml`
 - macOS: `~/Library/Application Support/zivo/config.toml`
-- Windows config path is reserved for future compatibility, but native Windows runtime is still unsupported
+- Windows: `%APPDATA%\\zivo\\config.toml` (minimum startup support; some runtime features still unavailable)
 
 The supported settings are:
 
@@ -403,7 +403,7 @@ The supported settings are:
 | `terminal` | `launch_mode` | `window` / `foreground` | Chooses how `T` opens a terminal for zivo's current directory. `window` starts a separate terminal window. `foreground` suspends zivo, opens an interactive shell in the current terminal, and returns to zivo after `exit`. |
 | `terminal` | `linux` | Array of shell-style command templates | Optional terminal launch commands for Linux. Use `{path}` as the working-directory placeholder. Invalid or empty entries are ignored. |
 | `terminal` | `macos` | Array of shell-style command templates | Optional terminal launch commands for macOS, validated the same way as Linux entries. |
-| `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. The config key is accepted even though native Windows runtime is not currently supported. |
+| `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. Native Windows startup is supported at a minimum level, but full terminal integration is still incomplete. |
 | `editor` | `command` | Shell-style string, for example `nvim -u NONE` | Optional terminal editor command used by `e`. Do not include the file path; zivo appends it automatically. Unsupported GUI editors or invalid commands are ignored. |
 | `display` | `show_hidden_files` | `true` / `false` | Default hidden-file visibility when the app starts. |
 | `display` | `show_directory_sizes` | `true` / `false` | Shows recursive directory sizes in the current pane. Defaults to `true`. Large directories can be expensive to scan. zivo also calculates sizes automatically while the main pane is sorted by `size`. |
@@ -476,7 +476,7 @@ The accepted `display.preview_syntax_theme` values are `auto` plus the Pygments 
 
 - Refer to the "Supported OS" section above for current support status.
 - GUI integration such as default-app launch, file-manager launch, and external terminal launch is currently verified mainly on Ubuntu and Ubuntu running under WSL.
-- The embedded split terminal currently targets POSIX environments, especially Ubuntu/Linux and WSL.
+- The embedded split terminal currently targets POSIX environments, especially Ubuntu/Linux and WSL, and is not available on native Windows.
 - `config.toml` can override both the preferred terminal editor and external terminal launch commands before built-in fallbacks are used.
 - On WSL, `wslu` is recommended so `wslview` is available for the preferred bridge behavior.
 - On WSL, zivo prefers Windows-side bridges such as `wslview`, `explorer.exe`, and `clip.exe` when available, while keeping Linux-side fallbacks for WSLg and desktop Linux environments.

--- a/src/zivo/adapters/filesystem.py
+++ b/src/zivo/adapters/filesystem.py
@@ -1,8 +1,6 @@
 """Filesystem adapter for reading local directory entries."""
 
-import grp
 import os
-import pwd
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -191,6 +189,10 @@ class DirectorySizeCancelled(RuntimeError):
 @lru_cache(maxsize=256)
 def _resolve_user_name(uid: int) -> str | None:
     try:
+        import pwd
+    except ImportError:
+        return None
+    try:
         return pwd.getpwuid(uid).pw_name
     except (KeyError, OSError):
         return None
@@ -198,6 +200,10 @@ def _resolve_user_name(uid: int) -> str | None:
 
 @lru_cache(maxsize=256)
 def _resolve_group_name(gid: int) -> str | None:
+    try:
+        import grp
+    except ImportError:
+        return None
     try:
         return grp.getgrgid(gid).gr_name
     except (KeyError, OSError):

--- a/src/zivo/services/split_terminal.py
+++ b/src/zivo/services/split_terminal.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import os
-import pty
 import select
 import shlex
 import struct
 import subprocess
-import termios
 import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
@@ -58,6 +56,7 @@ class LiveSplitTerminalService:
     ) -> SplitTerminalSession:
         if os.name != "posix":
             raise OSError("Split terminal is currently supported only on POSIX platforms")
+        import pty
 
         resolved_cwd = str(Path(cwd).expanduser().resolve())
         if not Path(resolved_cwd).is_dir():
@@ -173,6 +172,8 @@ class _PtySplitTerminalSession:
     def resize(self, *, columns: int, rows: int) -> None:
         if self._closed.is_set():
             return
+        import termios
+
         winsize = struct.pack("HHHH", rows, columns, 0, 0)
         try:
             termios.tcsetwinsize(self.master_fd, (rows, columns))
@@ -246,4 +247,6 @@ def _default_shell_command() -> tuple[str, ...]:
         parsed = tuple(shlex.split(shell))
         if parsed:
             return (*parsed, "-i")
-    return ("/bin/bash", "-i")
+    if os.name == "posix":
+        return ("/bin/bash", "-i")
+    raise OSError("No supported interactive shell found for split terminal")

--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -278,7 +278,7 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
             id="toggle_split_terminal",
             label="Toggle split terminal",
             shortcut="t",
-            enabled=True,
+            enabled=_is_split_terminal_supported(),
         ),
         CommandPaletteItem(
             id="select_all",
@@ -673,3 +673,8 @@ def _transfer_single_target_entry(state: AppState):
 def _is_empty_trash_supported() -> bool:
     """Check if empty trash is supported on current platform."""
     return platform.system() in ("Linux", "Darwin")
+
+
+def _is_split_terminal_supported() -> bool:
+    """Check if the embedded split terminal is available on this platform."""
+    return os.name == "posix" and platform.system() != "Windows"

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -1,5 +1,6 @@
 """Status, palette, and dialog selectors."""
 
+import os
 from pathlib import Path
 
 from zivo.models import (
@@ -211,12 +212,17 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         )
     if state.config.help_bar.browsing:
         return HelpBarState(state.config.help_bar.browsing)
+    split_terminal_hint = " | t term" if os.name == "posix" else ""
+    browsing_shortcuts = (
+        "n new-file | N new-dir | H history | "
+        f"b bookmarks{split_terminal_hint} | : palette | q quit"
+    )
     return HelpBarState(
         (
             "enter open | e edit | i info | space select | c copy | x cut | v paste | "
             "d delete | r rename | z undo",
             "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
-            "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit",
+            browsing_shortcuts,
         )
     )
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import replace
 from stat import S_IFREG
 
@@ -128,8 +129,9 @@ def test_select_current_entries_hides_hidden_by_default() -> None:
 def test_build_placeholder_app_state_keeps_parent_pane_empty_at_root() -> None:
     state = build_placeholder_app_state("/")
 
-    assert state.current_path == "/"
-    assert state.parent_pane.directory_path == "/"
+    expected_root = "C:\\" if os.name == "nt" else "/"
+    assert state.current_path == expected_root
+    assert state.parent_pane.directory_path == expected_root
     assert state.parent_pane.entries == ()
     assert state.parent_pane.cursor_path is None
 
@@ -1267,18 +1269,23 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     state = build_initial_app_state()
 
     help_state = select_help_bar_state(state)
+    split_terminal_hint = " | t term" if os.name == "posix" else ""
 
     assert help_state.lines == (
         "enter open | e edit | i info | space select | c copy | x cut | v paste | "
         "d delete | r rename | z undo",
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
-        "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit",
+        (
+            "n new-file | N new-dir | H history | "
+            f"b bookmarks{split_terminal_hint} | : palette | q quit"
+        ),
     )
     assert help_state.text == (
         "enter open | e edit | i info | space select | c copy | x cut | v paste | "
         "d delete | r rename | z undo\n"
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
-        "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit"
+        "n new-file | N new-dir | H history | "
+        f"b bookmarks{split_terminal_hint} | : palette | q quit"
     )
 
 

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -1,5 +1,7 @@
-import grp
-import pwd
+import builtins
+import os
+
+import pytest
 
 from zivo.adapters import LocalFilesystemAdapter
 
@@ -36,7 +38,7 @@ def test_local_filesystem_adapter_lists_entries_with_lightweight_directory_metad
     assert hidden_entry.permissions_mode is not None
 
     assert readme_entry.kind == "file"
-    assert readme_entry.size_bytes == len("plain\n")
+    assert readme_entry.size_bytes == readme.stat().st_size
     assert readme_entry.permissions_mode is not None
 
 
@@ -48,14 +50,14 @@ def test_local_filesystem_adapter_list_directory_skips_owner_group_resolution(
     (tmp_path / "README.md").write_text("plain\n", encoding="utf-8")
     adapter = LocalFilesystemAdapter()
 
-    def _unexpected_user_lookup(_uid: int) -> None:
-        raise AssertionError("pwd.getpwuid should not be called while listing directories")
+    original_import = builtins.__import__
 
-    def _unexpected_group_lookup(_gid: int) -> None:
-        raise AssertionError("grp.getgrgid should not be called while listing directories")
+    def _unexpected_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"grp", "pwd"}:
+            raise AssertionError(f"{name} should not be imported while listing directories")
+        return original_import(name, globals, locals, fromlist, level)
 
-    monkeypatch.setattr(pwd, "getpwuid", _unexpected_user_lookup)
-    monkeypatch.setattr(grp, "getgrgid", _unexpected_group_lookup)
+    monkeypatch.setattr("builtins.__import__", _unexpected_import)
 
     entries = adapter.list_directory(str(tmp_path))
 
@@ -63,6 +65,8 @@ def test_local_filesystem_adapter_list_directory_skips_owner_group_resolution(
 
 
 def test_local_filesystem_adapter_inspect_entry_loads_detailed_metadata(tmp_path) -> None:
+    pwd = pytest.importorskip("pwd")
+    grp = pytest.importorskip("grp")
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
     adapter = LocalFilesystemAdapter()
@@ -72,7 +76,7 @@ def test_local_filesystem_adapter_inspect_entry_loads_detailed_metadata(tmp_path
     assert entry is not None
     stat_result = readme.stat()
     assert entry.kind == "file"
-    assert entry.size_bytes == len("plain\n")
+    assert entry.size_bytes == stat_result.st_size
     assert entry.permissions_mode == stat_result.st_mode
     assert entry.modified_at is not None
     assert entry.owner == pwd.getpwuid(stat_result.st_uid).pw_name
@@ -80,6 +84,31 @@ def test_local_filesystem_adapter_inspect_entry_loads_detailed_metadata(tmp_path
     assert entry.symlink is False
 
 
+def test_local_filesystem_adapter_inspect_entry_returns_none_owner_group_when_unavailable(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    adapter = LocalFilesystemAdapter()
+
+    original_import = builtins.__import__
+
+    def _import_with_missing_posix_modules(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"grp", "pwd"}:
+            raise ImportError(f"No module named {name}")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _import_with_missing_posix_modules)
+
+    entry = adapter.inspect_entry(str(readme))
+
+    assert entry is not None
+    assert entry.owner is None
+    assert entry.group is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_local_filesystem_adapter_inspect_entry_marks_symlink(tmp_path) -> None:
     target = tmp_path / "README.md"
     target.write_text("plain\n", encoding="utf-8")
@@ -94,6 +123,7 @@ def test_local_filesystem_adapter_inspect_entry_marks_symlink(tmp_path) -> None:
     assert entry.kind == "file"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_local_filesystem_adapter_includes_broken_symlink_entries(tmp_path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -108,6 +138,7 @@ def test_local_filesystem_adapter_includes_broken_symlink_entries(tmp_path) -> N
     assert entries[1].symlink is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_local_filesystem_adapter_treats_directory_symlink_as_dir(tmp_path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -139,6 +170,7 @@ def test_local_filesystem_adapter_calculates_recursive_directory_size(tmp_path) 
     assert size == len("guide") + len("deep-data")
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_local_filesystem_adapter_directory_size_ignores_symlinks(tmp_path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -154,6 +186,7 @@ def test_local_filesystem_adapter_directory_size_ignores_symlinks(tmp_path) -> N
     assert size == len("guide")
 
 
+@pytest.mark.skipif(os.name == "nt", reason="permission semantics differ on Windows")
 def test_local_filesystem_adapter_directory_size_skips_permission_denied_descendants(
     tmp_path,
 ) -> None:

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -1,4 +1,5 @@
 import builtins
+import importlib
 import os
 
 import pytest
@@ -88,18 +89,12 @@ def test_local_filesystem_adapter_inspect_entry_returns_none_owner_group_when_un
     tmp_path,
     monkeypatch,
 ) -> None:
+    filesystem_module = importlib.import_module("zivo.adapters.filesystem")
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
     adapter = LocalFilesystemAdapter()
-
-    original_import = builtins.__import__
-
-    def _import_with_missing_posix_modules(name, globals=None, locals=None, fromlist=(), level=0):
-        if name in {"grp", "pwd"}:
-            raise ImportError(f"No module named {name}")
-        return original_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr("builtins.__import__", _import_with_missing_posix_modules)
+    monkeypatch.setattr(filesystem_module, "_resolve_user_name", lambda _uid: None)
+    monkeypatch.setattr(filesystem_module, "_resolve_group_name", lambda _gid: None)
 
     entry = adapter.inspect_entry(str(readme))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import threading
 import time
 from contextlib import nullcontext
@@ -2612,11 +2613,13 @@ async def test_app_displays_browsing_help_bar() -> None:
         }
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
+    split_terminal_hint = " | t term" if os.name == "posix" else ""
     expected_help = (
         "enter open | e edit | i info | space select | c copy | x cut | v paste | "
         "d delete | r rename | z undo\n"
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
-        "n new-file | N new-dir | H history | b bookmarks | t term | : palette | q quit"
+        "n new-file | N new-dir | H history | "
+        f"b bookmarks{split_terminal_hint} | : palette | q quit"
     )
 
     async with app.run_test():

--- a/tests/test_services_split_terminal.py
+++ b/tests/test_services_split_terminal.py
@@ -6,6 +6,10 @@ import pytest
 from zivo.services import LiveSplitTerminalService
 
 
+@pytest.mark.skipif(
+    condition=__import__("os").name != "posix",
+    reason="split terminal PTY behavior is POSIX-only",
+)
 def test_live_split_terminal_service_starts_and_echoes_input(tmp_path) -> None:
     outputs: list[str] = []
     exit_codes: list[int | None] = []
@@ -30,6 +34,10 @@ def test_live_split_terminal_service_starts_and_echoes_input(tmp_path) -> None:
     assert exit_codes
 
 
+@pytest.mark.skipif(
+    condition=__import__("os").name != "posix",
+    reason="split terminal PTY behavior is POSIX-only",
+)
 def test_live_split_terminal_service_requires_directory(tmp_path) -> None:
     service = LiveSplitTerminalService(shell_command=("/bin/sh", "-c", "cat"))
     file_path = tmp_path / "README.md"

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import replace
 from pathlib import Path
 
@@ -130,7 +131,7 @@ def test_submit_command_palette_runs_create_symlink_flow() -> None:
     assert next_state.pending_input is not None
     assert next_state.pending_input.prompt == "Create link at: "
     assert next_state.pending_input.symlink_source_path == "/home/tadashi/develop/zivo/docs"
-    assert next_state.pending_input.value.endswith("/docs.link")
+    assert next_state.pending_input.value.endswith(("/docs.link", "\\docs.link"))
 
 def test_submit_command_palette_begins_extract_archive_flow() -> None:
     archive_path = "/home/tadashi/develop/zivo/archive.zip"
@@ -871,6 +872,17 @@ def test_submit_command_palette_toggles_split_terminal() -> None:
     state = _reduce_state(state, SetCommandPaletteQuery("split terminal"))
 
     result = reduce_app_state(state, SubmitCommandPalette())
+
+    if os.name != "posix":
+        assert result.state.ui_mode == "PALETTE"
+        assert result.state.command_palette is not None
+        assert result.state.split_terminal.visible is False
+        assert result.effects == ()
+        assert result.state.notification == NotificationState(
+            level="warning",
+            message="Toggle split terminal is not available yet",
+        )
+        return
 
     assert result.state.ui_mode == "BROWSING"
     assert result.state.command_palette is None


### PR DESCRIPTION
## Summary
- make filesystem metadata lookup import-safe on native Windows
- defer POSIX-only split-terminal imports and keep the feature unavailable on native Windows
- update tests and README for minimum Windows startup support

## Testing
- `uv run python -c "import zivo.app; print('ok')"`
- `uv run python -c "from zivo.app import create_app; create_app(); print('ok')"`
- `uv run zivo --help`
- `uv run ruff check .`
- `uv run pytest tests/test_adapters_filesystem.py tests/test_services_split_terminal.py tests/test_state_reducer_palette_commands.py tests/state_selectors_cases.py -q`

## Notes
- Local full `pytest` on native Windows still exposes broader path-normalization/UI behavior gaps outside this minimum-startup issue scope.
