### PR TITLE
#717 Implement Windows external launcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Move to trash` | At least one target is selected or focused | Moves the selected items, or the focused item, to trash (confirmation is enabled by default and can be configured). |
 | `Empty trash` | Always (Linux/macOS only) | Permanently deletes all items from the trash. Shows a confirmation dialog before emptying. Not available on Windows. |
 | `Open in file manager` | Always | Opens the current directory in the OS file manager. Also available with `M`. |
-| `Open terminal` | Always | Launches an external terminal rooted at zivo's current directory, using `config.toml` templates before built-in fallbacks. The launch mode can be switched between a separate window and foreground terminal handoff. Also available with `T`. |
+| `Open terminal` | Always | Launches an external terminal rooted at zivo's current directory, using `config.toml` templates before built-in fallbacks. The launch mode can be switched between a separate window and foreground terminal handoff. On Windows, `window` mode is supported and `foreground` remains unavailable for now. Also available with `T`. |
 | `Run shell command` | Always | Opens a one-line shell command dialog, runs the command in the current directory in the background, and returns the first output line or failure summary in the status bar. Also available with `!`. |
 | `Bookmark this directory` / `Remove bookmark` | Always | Saves or removes the current directory in `[bookmarks].paths`. The label reflects whether the current directory is already bookmarked. Also available with `B`. |
 | `Show hidden files` / `Hide hidden files` | Always | Toggles hidden-file visibility for the browser panes. The label reflects the current visibility state. Also available with `.`. |
@@ -394,16 +394,16 @@ If the file does not exist yet, zivo creates it automatically with default value
 
 - Linux: `${XDG_CONFIG_HOME:-~/.config}/zivo/config.toml`
 - macOS: `~/Library/Application Support/zivo/config.toml`
-- Windows: `%APPDATA%\\zivo\\config.toml` (minimum startup support; some runtime features still unavailable)
+- Windows: `%APPDATA%\\zivo\\config.toml`
 
 The supported settings are:
 
 | Section | Key | Values | Description |
 | --- | --- | --- | --- |
-| `terminal` | `launch_mode` | `window` / `foreground` | Chooses how `T` opens a terminal for zivo's current directory. `window` starts a separate terminal window. `foreground` suspends zivo, opens an interactive shell in the current terminal, and returns to zivo after `exit`. |
+| `terminal` | `launch_mode` | `window` / `foreground` | Chooses how `T` opens a terminal for zivo's current directory. `window` starts a separate terminal window. `foreground` suspends zivo, opens an interactive shell in the current terminal, and returns to zivo after `exit`. Windows currently supports `window` only. |
 | `terminal` | `linux` | Array of shell-style command templates | Optional terminal launch commands for Linux. Use `{path}` as the working-directory placeholder. Invalid or empty entries are ignored. |
 | `terminal` | `macos` | Array of shell-style command templates | Optional terminal launch commands for macOS, validated the same way as Linux entries. |
-| `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. Native Windows startup is supported at a minimum level, but full terminal integration is still incomplete. |
+| `terminal` | `windows` | Array of shell-style command templates | Optional terminal launch commands for Windows and WSL bridge workflows. Windows native `window` launch is supported; `foreground` is tracked separately and not yet implemented. |
 | `editor` | `command` | Shell-style string, for example `nvim -u NONE` | Optional terminal editor command used by `e`. Do not include the file path; zivo appends it automatically. Unsupported GUI editors or invalid commands are ignored. |
 | `display` | `show_hidden_files` | `true` / `false` | Default hidden-file visibility when the app starts. |
 | `display` | `show_directory_sizes` | `true` / `false` | Shows recursive directory sizes in the current pane. Defaults to `true`. Large directories can be expensive to scan. zivo also calculates sizes automatically while the main pane is sorted by `size`. |

--- a/src/zivo/adapters/external_launcher.py
+++ b/src/zivo/adapters/external_launcher.py
@@ -21,7 +21,7 @@ ClipboardFallback = Callable[[str], None]
 ClipboardReader = Callable[[], str]
 EnvironmentVariableReader = Callable[[str], str | None]
 TextFileReader = Callable[[str], str]
-PlatformKind = Literal["linux", "wsl", "darwin"]
+PlatformKind = Literal["linux", "wsl", "darwin", "windows"]
 TERMINAL_EDITOR_NAMES = frozenset(
     {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
 )
@@ -30,6 +30,7 @@ _PLATFORM_TEMPLATE_KEYS: dict[PlatformKind, tuple[str, ...]] = {
     "linux": ("linux",),
     "darwin": ("macos",),
     "wsl": ("windows", "linux"),
+    "windows": ("windows",),
 }
 
 
@@ -92,11 +93,12 @@ class LocalExternalLaunchAdapter:
 
     def open_terminal(self, path: str, launch_mode: TerminalLaunchMode = "window") -> None:
         resolved_path = _resolve_directory_path(path)
+        platform_kind = self._platform_kind()
         if launch_mode == "foreground":
-            command = self._foreground_terminal_command()
+            command = self._foreground_terminal_command(platform_kind)
             self.foreground_command_runner(command, str(resolved_path))
             return
-        candidates = self._terminal_candidates(self._platform_kind(), str(resolved_path))
+        candidates = self._terminal_candidates(platform_kind, str(resolved_path))
         self._run_first_available(
             candidates,
             context=f"open terminal in {resolved_path}",
@@ -200,7 +202,7 @@ class LocalExternalLaunchAdapter:
                 return "wsl"
             return "linux"
         if system_name == "Windows":
-            raise OSError("Windows native is unsupported; run zivo from WSL")
+            return "windows"
         raise OSError(f"Unsupported operating system: {system_name}")
 
     def _platform_candidates(
@@ -210,6 +212,7 @@ class LocalExternalLaunchAdapter:
         linux: tuple[tuple[str, ...], ...] = (),
         wsl: tuple[tuple[str, ...], ...] = (),
         darwin: tuple[tuple[str, ...], ...] = (),
+        windows: tuple[tuple[str, ...], ...] = (),
     ) -> tuple[tuple[str, ...], ...]:
         if platform_kind == "linux":
             return linux
@@ -217,6 +220,8 @@ class LocalExternalLaunchAdapter:
             return wsl + linux
         if platform_kind == "darwin":
             return darwin
+        if platform_kind == "windows":
+            return windows
         raise OSError(f"Unsupported platform kind: {platform_kind}")
 
     def _default_app_candidates(
@@ -235,6 +240,10 @@ class LocalExternalLaunchAdapter:
                 ("explorer.exe", path),
             ),
             darwin=(("open", path),),
+            windows=(
+                ("cmd.exe", "/c", "start", "", path),
+                ("powershell.exe", "-NoProfile", "-Command", "Start-Process", path),
+            ),
         )
 
     def _editor_candidates(
@@ -308,7 +317,9 @@ class LocalExternalLaunchAdapter:
             return command_path.exists()
         return self.command_available(command) is not None
 
-    def _foreground_terminal_command(self) -> tuple[str, ...]:
+    def _foreground_terminal_command(self, platform_kind: PlatformKind) -> tuple[str, ...]:
+        if platform_kind == "windows":
+            raise OSError("Foreground terminal launch is not yet supported on Windows")
         shell = self.environment_variable("SHELL")
         if shell:
             try:
@@ -346,6 +357,28 @@ class LocalExternalLaunchAdapter:
                 ("cmd.exe", "/c", "start", "", "wsl.exe", "--cd", path),
             ),
             darwin=(("open", "-a", "Terminal", path),),
+            windows=(
+                ("wt.exe", "-d", path),
+                (
+                    "cmd.exe",
+                    "/c",
+                    "start",
+                    "",
+                    "powershell.exe",
+                    "-NoExit",
+                    "-Command",
+                    _windows_set_location_command(path),
+                ),
+                (
+                    "cmd.exe",
+                    "/c",
+                    "start",
+                    "",
+                    "cmd.exe",
+                    "/k",
+                    _windows_cd_command(path),
+                ),
+            ),
         )
 
     def _configured_terminal_commands(
@@ -362,15 +395,15 @@ class LocalExternalLaunchAdapter:
             "macos": self.terminal_command_templates.macos,
             "windows": self.terminal_command_templates.windows,
         }
-        templates: list[str] = []
+        template_specs: list[tuple[str, str]] = []
         for key in template_keys:
-            templates.extend(template_map[key])
+            template_specs.extend((template, key) for template in template_map[key])
 
         commands: list[tuple[str, ...]] = []
-        for template in templates:
+        for template, template_key in template_specs:
             try:
-                rendered = template.format(path=path)
-                parsed_command = tuple(shlex.split(rendered))
+                rendered = template.format(path=_render_template_path(path, template_key))
+                parsed_command = tuple(shlex.split(rendered, posix=template_key != "windows"))
             except (IndexError, KeyError, ValueError):
                 continue
             if parsed_command:
@@ -387,6 +420,10 @@ class LocalExternalLaunchAdapter:
             ),
             wsl=(("clip.exe",),),
             darwin=(("pbcopy",),),
+            windows=(
+                ("clip.exe",),
+                ("powershell.exe", "-NoProfile", "-Command", "Set-Clipboard"),
+            ),
         )
 
     def _clipboard_read_candidates(
@@ -402,6 +439,7 @@ class LocalExternalLaunchAdapter:
             ),
             wsl=(("powershell.exe", "-noprofile", "-command", "Get-Clipboard"),),
             darwin=(("pbpaste",),),
+            windows=(("powershell.exe", "-NoProfile", "-Command", "Get-Clipboard"),),
         )
 
 
@@ -486,6 +524,22 @@ def _read_from_clipboard_with_tkinter() -> str:
 
 def _read_text_file(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
+
+
+def _render_template_path(path: str, template_key: str) -> str:
+    if template_key == "windows":
+        return subprocess.list2cmdline([path])
+    return shlex.quote(path)
+
+
+def _windows_set_location_command(path: str) -> str:
+    escaped_path = path.replace("'", "''")
+    return f"Set-Location -LiteralPath '{escaped_path}'"
+
+
+def _windows_cd_command(path: str) -> str:
+    escaped_path = path.replace('"', '""')
+    return f'cd /d "{escaped_path}"'
 
 
 def _resolve_existing_path(path: str) -> Path:

--- a/src/zivo/services/config/render.py
+++ b/src/zivo/services/config/render.py
@@ -38,6 +38,7 @@ def render_terminal_section(config: AppConfig) -> str:
         '# launch_mode = "window"\n'
         "# window: launch a separate terminal window.\n"
         "# foreground: suspend zivo and use the terminal in the foreground until exit.\n"
+        "# Windows currently supports window mode only.\n"
         "# Optional OS-specific terminal launch templates.\n"
         "# Use {path} for the working directory.\n"
         "# Examples:\n"

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -323,6 +323,7 @@ def config_editor_field_description(field_index: int, config: AppConfig) -> tupl
         return (
             "Controls how the external terminal command is launched.",
             "window opens a separate terminal app; foreground hands the current terminal over.",
+            "Windows currently supports window mode only.",
             f"Current behavior: `{config.terminal.launch_mode}`.",
         )
     if field_id == "display.show_hidden_files":

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -1,4 +1,5 @@
 import io
+import re
 import sys
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -125,6 +126,23 @@ def test_local_external_launch_adapter_falls_back_to_explorer_on_wsl(tmp_path) -
     ]
 
 
+def test_local_external_launch_adapter_uses_cmd_start_on_windows(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command if command == "cmd.exe" else None,
+        command_runner=runner,
+    )
+
+    adapter.open_with_default_app(str(readme))
+
+    assert runner.executed == [
+        (("cmd.exe", "/c", "start", "", str(readme.resolve())), str(tmp_path.resolve()), None)
+    ]
+
+
 def test_local_external_launch_adapter_runs_terminal_editor_in_current_terminal(tmp_path) -> None:
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
@@ -243,6 +261,21 @@ def test_local_external_launch_adapter_uses_open_on_macos(tmp_path) -> None:
     ]
 
 
+def test_local_external_launch_adapter_uses_wt_on_windows_for_terminal(tmp_path) -> None:
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command if command == "wt.exe" else None,
+        command_runner=runner,
+    )
+
+    adapter.open_terminal(str(tmp_path))
+
+    assert runner.executed == [
+        (("wt.exe", "-d", str(tmp_path.resolve())), str(tmp_path), None)
+    ]
+
+
 def test_local_external_launch_adapter_prefers_configured_terminal_commands(tmp_path) -> None:
     runner = StubCommandRunner()
     adapter = LocalExternalLaunchAdapter(
@@ -289,13 +322,25 @@ def test_local_external_launch_adapter_runs_terminal_in_foreground_mode(tmp_path
     runner = StubForegroundRunner()
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "bash" else None,
         foreground_command_runner=runner,
-        environment_variable=lambda name: "/bin/sh" if name == "SHELL" else None,
+        environment_variable=lambda name: "bash" if name == "SHELL" else None,
     )
 
     adapter.open_terminal(str(tmp_path), launch_mode="foreground")
 
-    assert runner.executed == [(("/bin/sh", "-i"), str(tmp_path))]
+    assert runner.executed == [(("bash", "-i"), str(tmp_path))]
+
+
+def test_local_external_launch_adapter_rejects_windows_foreground_terminal_mode(tmp_path) -> None:
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command,
+        foreground_command_runner=StubForegroundRunner(),
+    )
+
+    with pytest.raises(OSError, match="not yet supported on Windows"):
+        adapter.open_terminal(str(tmp_path), launch_mode="foreground")
 
 
 def test_local_external_launch_adapter_copies_to_clipboard_on_linux() -> None:
@@ -320,6 +365,21 @@ def test_local_external_launch_adapter_uses_clip_exe_on_wsl() -> None:
         command_available=lambda command: command if command == "clip.exe" else None,
         command_runner=runner,
         environment_variable=lambda name: "Ubuntu" if name == "WSL_DISTRO_NAME" else None,
+    )
+
+    adapter.copy_to_clipboard("/tmp/zivo/docs\n/tmp/zivo/README.md")
+
+    assert runner.executed == [
+        (("clip.exe",), None, "/tmp/zivo/docs\n/tmp/zivo/README.md")
+    ]
+
+
+def test_local_external_launch_adapter_uses_clip_exe_on_windows() -> None:
+    runner = StubCommandRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command if command == "clip.exe" else None,
+        command_runner=runner,
     )
 
     adapter.copy_to_clipboard("/tmp/zivo/docs\n/tmp/zivo/README.md")
@@ -387,17 +447,19 @@ def test_local_external_launch_adapter_reports_invalid_editor_value(tmp_path) ->
         adapter.open_in_editor(str(readme))
 
 
-def test_local_external_launch_adapter_rejects_windows_native_support(tmp_path) -> None:
-    readme = tmp_path / "README.md"
-    readme.write_text("plain\n", encoding="utf-8")
+def test_local_external_launch_adapter_reads_from_windows_clipboard(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        assert args == (["powershell.exe", "-NoProfile", "-Command", "Get-Clipboard"],)
+        assert kwargs == {"capture_output": True, "text": True, "check": True}
+        return SimpleNamespace(stdout="clipboard text", returncode=0)
+
+    monkeypatch.setattr("zivo.adapters.external_launcher.subprocess.run", fake_run)
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Windows",
-        command_available=lambda command: command,
-        command_runner=StubCommandRunner(),
+        command_available=lambda command: command if command == "powershell.exe" else None,
     )
 
-    with pytest.raises(OSError, match="Windows native is unsupported"):
-        adapter.open_with_default_app(str(readme))
+    assert adapter.get_from_clipboard() == "clipboard text"
 
 
 def test_local_external_launch_adapter_uses_clipboard_fallback_when_commands_missing() -> None:
@@ -424,7 +486,10 @@ def test_live_external_launch_service_formats_open_error(tmp_path) -> None:
     )
     service = LiveExternalLaunchService(adapter=adapter)
 
-    with pytest.raises(OSError, match=f"Failed to open {missing.resolve()}: Not found: "):
+    with pytest.raises(
+        OSError,
+        match=re.escape(f"Failed to open {missing.resolve()}: Not found: "),
+    ):
         service.execute(ExternalLaunchRequest(kind="open_file", path=str(missing)))
 
 
@@ -450,8 +515,9 @@ def test_live_external_launch_service_opens_terminal_in_foreground_mode(tmp_path
     runner = StubForegroundRunner()
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Linux",
+        command_available=lambda command: command if command == "bash" else None,
         foreground_command_runner=runner,
-        environment_variable=lambda name: "/bin/sh" if name == "SHELL" else None,
+        environment_variable=lambda name: "bash" if name == "SHELL" else None,
     )
     service = LiveExternalLaunchService(adapter=adapter)
     path = str(tmp_path.resolve())
@@ -464,7 +530,7 @@ def test_live_external_launch_service_opens_terminal_in_foreground_mode(tmp_path
         )
     )
 
-    assert runner.executed == [(("/bin/sh", "-i"), path)]
+    assert runner.executed == [(("bash", "-i"), path)]
 
 
 def test_live_external_launch_service_copies_paths_with_expected_payload() -> None:
@@ -493,7 +559,7 @@ def test_live_external_launch_service_formats_editor_error(tmp_path) -> None:
 
     with pytest.raises(
         OSError,
-        match=f"Failed to open {missing.resolve()} in editor: Not found: ",
+        match=re.escape(f"Failed to open {missing.resolve()} in editor: Not found: "),
     ):
         service.execute(ExternalLaunchRequest(kind="open_editor", path=str(missing)))
 
@@ -510,29 +576,27 @@ def test_live_external_launch_service_formats_terminal_error_for_file(tmp_path) 
 
     with pytest.raises(
         OSError,
-        match=f"Failed to open terminal in {readme.resolve()}: Not a directory: ",
+        match=re.escape(f"Failed to open terminal in {readme.resolve()}: Not a directory: "),
     ):
         service.execute(ExternalLaunchRequest(kind="open_terminal", path=str(readme)))
 
 
-def test_live_external_launch_service_formats_windows_native_error(tmp_path) -> None:
+def test_live_external_launch_service_opens_file_on_windows(tmp_path) -> None:
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
+    runner = StubCommandRunner()
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Windows",
-        command_available=lambda command: command,
-        command_runner=StubCommandRunner(),
+        command_available=lambda command: command if command == "cmd.exe" else None,
+        command_runner=runner,
     )
     service = LiveExternalLaunchService(adapter=adapter)
 
-    with pytest.raises(
-        OSError,
-        match=(
-            f"Failed to open {readme.resolve()}: "
-            "Windows native is unsupported; run zivo from WSL"
-        ),
-    ):
-        service.execute(ExternalLaunchRequest(kind="open_file", path=str(readme)))
+    service.execute(ExternalLaunchRequest(kind="open_file", path=str(readme)))
+
+    assert runner.executed == [
+        (("cmd.exe", "/c", "start", "", str(readme.resolve())), str(tmp_path.resolve()), None)
+    ]
 
 
 def test_live_external_launch_service_formats_copy_error() -> None:


### PR DESCRIPTION
## Summary
- add Windows native support to `external_launcher` for default-app launch, window terminal launch, and clipboard read/write
- keep Windows `foreground` terminal launch out of scope for this PR and track it in follow-up issue #731
- update tests and README/config descriptions to match the Windows behavior

## Test Results
- `uv run ruff check .` ?
- `uv run pytest tests/test_services_external_launcher.py` ?
- `uv run pytest tests/test_services_config.py tests/test_state_reducer.py tests/test_app.py -k "foreground or launch_mode or clipboard or external_launch"` ?
- `uv run pytest` ?? fails on pre-existing Windows compatibility gaps already present on `feat/windows` (outside this PR scope)

## Notes
- related issue: #717
- follow-up issue for Windows foreground terminal mode: #731
