### PR TITLE
#719 Disable split terminal on native Windows

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -91,7 +91,7 @@ Overlay表示:
 | Ubuntu | サポート | 現時点で主要な動作確認対象です。 |
 | Ubuntu (WSL) | サポート | WSL 上の Ubuntu を動作確認対象としています。 |
 | macOS | サポート | ゴミ箱操作にはターミナルへのフルディスクアクセス権限が必要です。 |
-| Windows | 現時点では未サポート | Windows ネイティブ実行は未サポートです。 |
+| Windows | 一部対応 | 最低限の起動と基本的なブラウズは利用できますが、Windows ネイティブ実行はまだ完全な機能互換ではありません。 |
 
 ## インストール
 
@@ -156,7 +156,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-Windows は現時点では未サポートのため、Windows ネイティブ実行向けの依存ツール案内は対象外です。
+Windows ネイティブでは、現時点では最低限の起動と基本的なブラウズを主な対象としています。埋め込み split terminal のような POSIX 前提の機能は引き続き利用できず、`t` を押した場合も起動を試みずに非対応メッセージを表示します。そのため、Windows ネイティブ実行向けの依存ツール案内は対象外です。
 
 macOS では、使用しているターミナルアプリに **フルディスクアクセス** 権限を付与してください。**システム設定 > プライバシーとセキュリティ > フルディスクアクセス** を開き、zivo を実行するターミナルアプリ（Terminal.app、iTerm2、Alacritty など）を有効にしてください。この権限がない場合、`~/.Trash` などの保護されたディレクトリにアクセスする操作が失敗します。
 
@@ -226,7 +226,7 @@ zivo-cd
 | `.` | 隠しファイル表示を切り替え |
 | `s` | ソート順を循環切り替え |
 | `R` | ディレクトリを再読み込み |
-| `t` | 分割ターミナルを切り替え |
+| `t` | 分割ターミナルを切り替え（POSIX のみ。Windows ネイティブでは非対応メッセージを表示） |
 | `T` | 現在のディレクトリでターミナルを開く |
 | `o` | 新しいタブを開く |
 | `w` | 現在のタブを閉じる |
@@ -368,7 +368,7 @@ Transferモードでは、アクティブな転送ペインで実行できるコ
 | `Reload directory` | 常に表示 | 現在ディレクトリを再読み込みします。 |
 | `Toggle transfer mode` / `Close transfer mode` | 常に表示 | 通常の 3 ペインブラウザと 2 ペイン転送レイアウトを切り替えます。転送モード中は `q` / `2`、通常モードからは `2` でも実行できます。 |
 | `Undo last file operation` | Undo 履歴があるとき | 直前の Undo 対象リネーム、貼り付け、ゴミ箱移動を取り消します。`z` でも実行できます。ゴミ箱からの復元は現在 Linux のみ対応です。 |
-| `Toggle split terminal` | 常に表示 | 埋め込み split terminal を開閉します。 |
+| `Toggle split terminal` | POSIX 環境 | 埋め込み split terminal を開閉します。Windows ネイティブではコマンドパレット上でも無効表示のままで、`t` の直接入力でも非対応メッセージを表示します。 |
 | `Select all` | 現在ディレクトリに表示中の項目が 1 件以上あるとき | 現在ディレクトリで表示中の項目をすべて選択します。 |
 | `Replace text in selected files` | ファイルがフォーカス中、または現在ディレクトリで 1 件以上のファイルが選択中のとき | 選択中のファイル、または未選択時はフォーカス中のファイルを対象に 2 フィールドの置換パレットを開きます。一致したファイル一覧がパレットに表示され、`↑↓` と `Ctrl+n` / `Ctrl+p` で移動すると右ペインに選択中ファイルの diff を表示します。`Enter` で一括置換を実行します。`Shift+↑` / `Shift+↓` で diff preview をスクロールします。 |
 | `Replace text in found files` | 常に表示 | 3 フィールドの置換パレット（filename、find、replace）を開きます。ファイル名パターンでファイルを検索し、find/replace テキストで置換をプレビューします。`Tab` / `Shift+Tab` でフィールドを切り替えます。右ペインに diff preview を表示し、`Enter` で置換を適用します。 |
@@ -473,7 +473,7 @@ paths = ["/home/user/src", "/home/user/docs"]
 
 - サポート状況は上記の「サポートOS」セクションを参照してください。
 - 既定アプリ起動、ファイルマネージャ起動、ターミナル起動などの GUI 連携は、主に Ubuntu と WSL 上の Ubuntu で確認しています。
-- 埋め込み split terminal は現状 POSIX 環境、特に Ubuntu/Linux と WSL を前提にしています。
+- 埋め込み split terminal は現状 POSIX 環境、特に Ubuntu/Linux と WSL を前提にしており、Windows ネイティブでは利用できません。Windows ネイティブで `t` を押した場合は、起動を試みずに非対応メッセージを表示します。
 - `config.toml` でターミナルエディタやターミナル起動コマンドを指定した場合は、その設定を組み込みフォールバックより優先します。
 - WSL では、優先ブリッジ動作に使う `wslview` を利用できるよう `wslu` のインストールを推奨します。
 - WSL では `wslview`、`explorer.exe`、`clip.exe` のような Windows 側ブリッジを優先し、WSLg や Linux デスクトップ向けのフォールバックも維持します。

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-On native Windows, zivo currently focuses on minimum startup and basic browsing. POSIX-oriented features such as the embedded split terminal are still unavailable there, so native Windows dependency guidance remains intentionally limited.
+On native Windows, zivo currently focuses on minimum startup and basic browsing. POSIX-oriented features such as the embedded split terminal are still unavailable there, and pressing `t` shows a non-supported warning instead of trying to launch it, so native Windows dependency guidance remains intentionally limited.
 
 On macOS, grant **Full Disk Access** to your terminal application. Open **System Settings > Privacy & Security > Full Disk Access** and enable the terminal app you use to run zivo (for example Terminal.app, iTerm2, or Alacritty). Without this permission, operations that access `~/.Trash` or other protected directories will fail.
 
@@ -222,7 +222,7 @@ When a file is focused, press `e` to switch into a terminal editor in the curren
 | `.` | Toggle hidden files |
 | `s` | Cycle sort |
 | `R` | Reload directory |
-| `t` | Toggle split terminal (POSIX only) |
+| `t` | Toggle split terminal (POSIX only; native Windows shows an unavailable warning) |
 | `T` | Open terminal at current directory |
 | `o` | Open new tab |
 | `w` | Close current tab |
@@ -364,7 +364,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Reload directory` | Always | Reloads the current directory. |
 | `Toggle transfer mode` / `Close transfer mode` | Always | Switches between the normal three-pane browser and the two-pane transfer layout. Also available with `q` / `2` while transfer mode is open, and `2` from normal mode. |
 | `Undo last file operation` | Undo history is not empty | Reverses the most recent undoable rename, paste, or trash operation. Also available with `z`. Trash restore is currently Linux-only. |
-| `Toggle split terminal` | POSIX environments | Opens or closes the embedded split terminal. Not available on native Windows. |
+| `Toggle split terminal` | POSIX environments | Opens or closes the embedded split terminal. It stays disabled in the command palette on native Windows, and direct `t` input shows an unavailable warning. |
 | `Select all` | Current directory has at least one visible entry | Selects every currently visible entry in the current directory, respecting hidden-file visibility and any active filter. |
 | `Replace text in selected files` | A file is focused or one or more files are selected in the current directory | Opens a two-field replacement palette for the selected files, or the focused file when nothing is explicitly selected. Matching files appear in the palette, `↑↓` and `Ctrl+n` / `Ctrl+p` move between them, and the right pane shows the selected file's diff before `Enter` applies the replacement. `Shift+↑` / `Shift+↓` scrolls the diff preview. |
 | `Replace text in found files` | Always | Opens a three-field replacement palette (filename, find, replace). Type a filename pattern to search for files, then type find/replace text to preview replacements. `Tab` / `Shift+Tab` cycle between fields. The right pane shows the diff preview, and `Enter` applies the replacement. |
@@ -476,7 +476,7 @@ The accepted `display.preview_syntax_theme` values are `auto` plus the Pygments 
 
 - Refer to the "Supported OS" section above for current support status.
 - GUI integration such as default-app launch, file-manager launch, and external terminal launch is currently verified mainly on Ubuntu and Ubuntu running under WSL.
-- The embedded split terminal currently targets POSIX environments, especially Ubuntu/Linux and WSL, and is not available on native Windows.
+- The embedded split terminal currently targets POSIX environments, especially Ubuntu/Linux and WSL, and is not available on native Windows. On native Windows, direct `t` input shows a warning instead of attempting startup.
 - `config.toml` can override both the preferred terminal editor and external terminal launch commands before built-in fallbacks are used.
 - On WSL, `wslu` is recommended so `wslview` is available for the preferred bridge behavior.
 - On WSL, zivo prefers Windows-side bridges such as `wslview`, `explorer.exe`, and `clip.exe` when available, while keeping Linux-side fallbacks for WSLg and desktop Linux environments.

--- a/src/zivo/platform_support.py
+++ b/src/zivo/platform_support.py
@@ -1,0 +1,26 @@
+"""Helpers for platform-specific feature availability."""
+
+from __future__ import annotations
+
+import os
+import platform
+
+
+def is_native_windows() -> bool:
+    """Return True when running on native Windows."""
+
+    return platform.system() == "Windows"
+
+
+def is_split_terminal_supported() -> bool:
+    """Return whether the embedded split terminal is supported here."""
+
+    return os.name == "posix" and not is_native_windows()
+
+
+def split_terminal_unavailable_message() -> str:
+    """Return a user-facing split-terminal availability message."""
+
+    if is_native_windows():
+        return "Split terminal is not available on native Windows"
+    return "Split terminal is not available on this platform"

--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -5,6 +5,7 @@ import platform
 from dataclasses import dataclass
 
 from zivo.archive_utils import is_supported_archive_path
+from zivo.platform_support import is_split_terminal_supported
 
 from .entry_state_helpers import select_visible_entry_states
 from .models import AppState
@@ -677,4 +678,4 @@ def _is_empty_trash_supported() -> bool:
 
 def _is_split_terminal_supported() -> bool:
     """Check if the embedded split terminal is available on this platform."""
-    return os.name == "posix" and platform.system() != "Windows"
+    return is_split_terminal_supported()

--- a/src/zivo/state/input_browsing.py
+++ b/src/zivo/state/input_browsing.py
@@ -1,5 +1,10 @@
 """Browsing-mode key bindings and dispatcher."""
 
+from zivo.platform_support import (
+    is_split_terminal_supported,
+    split_terminal_unavailable_message,
+)
+
 from .actions import (
     Action,
     ActivateNextTab,
@@ -335,6 +340,12 @@ def handle_open_file_manager(state: AppState, _ctx: BrowsingCtx) -> DispatchedAc
     return supported(OpenPathWithDefaultApp(state.current_path))
 
 
+def handle_toggle_split_terminal(_state: AppState, _ctx: BrowsingCtx) -> DispatchedActions:
+    if not is_split_terminal_supported():
+        return warn(split_terminal_unavailable_message())
+    return supported(ToggleSplitTerminal())
+
+
 def handle_cursor_up(state: AppState, ctx: BrowsingCtx) -> DispatchedActions:
     if state.current_pane.selection_anchor_path is not None:
         return supported(ClearSelection(), MoveCursor(delta=-1, visible_paths=ctx.visible_paths))
@@ -416,7 +427,6 @@ BROWSING_SIMPLE_DISPATCH: dict[str, type[Action]] = {
     "begin_history_search": BeginHistorySearch,
     "begin_go_to_path": BeginGoToPath,
     "go_to_home_directory": GoToHomeDirectory,
-    "toggle_split_terminal": ToggleSplitTerminal,
     "reload_directory": ReloadDirectory,
     "go_back": GoBack,
     "go_forward": GoForward,
@@ -464,6 +474,7 @@ BROWSING_COMPLEX_DISPATCH: dict[str, BrowsingHandler] = {
     "permanent_delete_targets": handle_permanent_delete_targets,
     "open_in_editor": handle_open_in_editor,
     "enter_directory": handle_enter_directory,
+    "toggle_split_terminal": handle_toggle_split_terminal,
 }
 
 BROWSING_COMMAND_DISPATCH: dict[str, BrowsingHandler] = {

--- a/src/zivo/state/reducer_terminal_config.py
+++ b/src/zivo/state/reducer_terminal_config.py
@@ -5,6 +5,10 @@ from textwrap import shorten
 from typing import Callable
 
 from zivo.models import BookmarkConfig, ExternalLaunchRequest, HelpBarConfig
+from zivo.platform_support import (
+    is_split_terminal_supported,
+    split_terminal_unavailable_message,
+)
 
 from .actions import (
     Action,
@@ -440,6 +444,16 @@ def _handle_toggle_split_terminal(
     action: ToggleSplitTerminal,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
+    if not is_split_terminal_supported():
+        return finalize(
+            replace(
+                state,
+                notification=NotificationState(
+                    level="warning",
+                    message=split_terminal_unavailable_message(),
+                ),
+            )
+        )
     if state.split_terminal.visible:
         next_state = replace(
             state,

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -1,6 +1,5 @@
 """Status, palette, and dialog selectors."""
 
-import os
 from pathlib import Path
 
 from zivo.models import (
@@ -16,6 +15,7 @@ from zivo.models import (
     SplitTerminalViewState,
     StatusBarState,
 )
+from zivo.platform_support import is_split_terminal_supported
 
 from .models import AppState
 from .reducer_config import (
@@ -212,7 +212,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         )
     if state.config.help_bar.browsing:
         return HelpBarState(state.config.help_bar.browsing)
-    split_terminal_hint = " | t term" if os.name == "posix" else ""
+    split_terminal_hint = " | t term" if is_split_terminal_supported() else ""
     browsing_shortcuts = (
         "n new-file | N new-dir | H history | "
         f"b bookmarks{split_terminal_hint} | : palette | q quit"

--- a/tests/input_dispatch_browsing_cases.py
+++ b/tests/input_dispatch_browsing_cases.py
@@ -1,5 +1,9 @@
 # ruff: noqa: F403,F405
 
+import os
+
+import zivo.state.input_browsing as input_browsing_module
+
 from .input_dispatch_helpers import *
 
 
@@ -575,12 +579,36 @@ def test_browsing_colon_opens_command_palette() -> None:
     assert actions == (SetNotification(None), BeginCommandPalette())
 
 
-def test_browsing_lowercase_t_toggles_split_terminal() -> None:
+def test_browsing_lowercase_t_toggles_split_terminal(monkeypatch) -> None:
     state = build_initial_app_state()
+    monkeypatch.setattr(input_browsing_module, "is_split_terminal_supported", lambda: True)
 
     actions = dispatch_key_input(state, key="t")
 
     assert actions == (SetNotification(None), ToggleSplitTerminal())
+
+
+def test_browsing_lowercase_t_warns_when_split_terminal_is_unsupported(
+    monkeypatch,
+) -> None:
+    state = build_initial_app_state()
+    monkeypatch.setattr(input_browsing_module, "is_split_terminal_supported", lambda: False)
+    monkeypatch.setattr(
+        input_browsing_module,
+        "split_terminal_unavailable_message",
+        lambda: "Split terminal is not available on native Windows",
+    )
+
+    actions = dispatch_key_input(state, key="t")
+
+    assert actions == (
+        SetNotification(
+            NotificationState(
+                level="warning",
+                message="Split terminal is not available on native Windows",
+            )
+        ),
+    )
 
 
 def test_browsing_o_opens_new_tab() -> None:
@@ -754,7 +782,7 @@ def test_go_to_path_palette_tab_appends_separator_for_single_candidate() -> None
 
     actions = dispatch_key_input(state, key="tab")
 
-    assert actions == (SetNotification(None), SetCommandPaletteQuery("docs/"))
+    assert actions == (SetNotification(None), SetCommandPaletteQuery(f"docs{os.sep}"))
 
 
 def test_go_to_path_palette_tab_warns_without_candidates() -> None:

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1,6 +1,7 @@
 from dataclasses import replace
 from pathlib import Path
 
+import zivo.state.reducer_terminal_config as reducer_terminal_config_module
 from tests.state_test_helpers import reduce_state
 from zivo.models import (
     AppConfig,
@@ -562,7 +563,7 @@ def test_go_to_parent_directory_restores_cursor_to_previous_child() -> None:
     assert result.state.pending_browser_snapshot_request_id == 1
     assert result.state.ui_mode == "BUSY"
     assert len(result.effects) == 1
-    assert result.effects[0].path == "/home/tadashi/develop"
+    assert result.effects[0].path == str(Path("/home/tadashi/develop/zivo").parent)
     assert result.effects[0].cursor_path == "/home/tadashi/develop/zivo"
     assert result.effects[0].blocking is True
 
@@ -598,7 +599,7 @@ def test_go_to_parent_directory_uses_current_path_parent() -> None:
     result = reduce_app_state(state, GoToParentDirectory())
 
     assert len(result.effects) == 1
-    assert result.effects[0].path == "/tmp/work"
+    assert result.effects[0].path == str(Path("/tmp/work/project").parent)
     assert result.effects[0].cursor_path == "/tmp/work/project"
 
 def test_go_to_home_directory_navigates_to_home() -> None:
@@ -1328,7 +1329,10 @@ def test_open_path_in_editor_allows_non_browser_file_path() -> None:
         ),
     )
 
-def test_toggle_split_terminal_starts_embedded_session() -> None:
+def test_toggle_split_terminal_starts_embedded_session(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reducer_terminal_config_module, "is_split_terminal_supported", lambda: True
+    )
     result = reduce_app_state(build_initial_app_state(), ToggleSplitTerminal())
 
     assert result.state.split_terminal.visible is True
@@ -1342,7 +1346,10 @@ def test_toggle_split_terminal_starts_embedded_session() -> None:
         ),
     )
 
-def test_toggle_split_terminal_closes_active_session() -> None:
+def test_toggle_split_terminal_closes_active_session(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reducer_terminal_config_module, "is_split_terminal_supported", lambda: True
+    )
     state = replace(
         build_initial_app_state(),
         split_terminal=replace(
@@ -1374,11 +1381,34 @@ def test_focus_split_terminal_switches_focus_target() -> None:
 
     assert next_state.split_terminal.focus_target == "terminal"
 
-def test_toggle_split_terminal_opens_with_terminal_focus() -> None:
+def test_toggle_split_terminal_opens_with_terminal_focus(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reducer_terminal_config_module, "is_split_terminal_supported", lambda: True
+    )
     result = reduce_app_state(build_initial_app_state(), ToggleSplitTerminal())
 
     assert result.state.split_terminal.visible is True
     assert result.state.split_terminal.focus_target == "terminal"
+
+
+def test_toggle_split_terminal_warns_when_unsupported(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reducer_terminal_config_module, "is_split_terminal_supported", lambda: False
+    )
+    monkeypatch.setattr(
+        reducer_terminal_config_module,
+        "split_terminal_unavailable_message",
+        lambda: "Split terminal is not available on native Windows",
+    )
+
+    result = reduce_app_state(build_initial_app_state(), ToggleSplitTerminal())
+
+    assert result.state.split_terminal.visible is False
+    assert result.effects == ()
+    assert result.state.notification == NotificationState(
+        level="warning",
+        message="Split terminal is not available on native Windows",
+    )
 
 def test_send_split_terminal_input_emits_write_effect() -> None:
     state = replace(

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import replace
 from pathlib import Path
 
+import zivo.state.command_palette as command_palette_module
 from tests.state_test_helpers import reduce_state
 from zivo.models import (
     AppConfig,
@@ -889,6 +890,25 @@ def test_submit_command_palette_toggles_split_terminal() -> None:
     assert result.state.split_terminal.visible is True
     assert len(result.effects) == 1
     assert isinstance(result.effects[0], StartSplitTerminalEffect)
+
+
+def test_submit_command_palette_toggle_split_terminal_stays_disabled_when_unsupported(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(command_palette_module, "is_split_terminal_supported", lambda: False)
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+    state = _reduce_state(state, SetCommandPaletteQuery("split terminal"))
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.ui_mode == "PALETTE"
+    assert result.state.command_palette is not None
+    assert result.state.split_terminal.visible is False
+    assert result.effects == ()
+    assert result.state.notification == NotificationState(
+        level="warning",
+        message="Toggle split terminal is not available yet",
+    )
 
 def test_submit_command_palette_begins_rename_with_single_target() -> None:
     state = _reduce_state(build_initial_app_state(), BeginCommandPalette())


### PR DESCRIPTION
Related issue: #719

## Summary
- disable embedded split terminal startup on native Windows
- keep command palette and help text aligned with the unsupported state
- document that direct `t` input shows a warning on native Windows

## Testing
- uv run ruff check .
- uv run pytest tests/input_dispatch_browsing_cases.py tests/test_state_reducer.py tests/test_state_reducer_palette_commands.py
- uv run pytest  # fails on pre-existing Windows-wide path/symlink issues unrelated to this PR