### PR TITLE
#720 Clarify Windows trash support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -91,7 +91,7 @@ Overlay表示:
 | Ubuntu | サポート | 現時点で主要な動作確認対象です。 |
 | Ubuntu (WSL) | サポート | WSL 上の Ubuntu を動作確認対象としています。 |
 | macOS | サポート | ゴミ箱操作にはターミナルへのフルディスクアクセス権限が必要です。 |
-| Windows | 一部対応 | 最低限の起動と基本的なブラウズは利用できますが、Windows ネイティブ実行はまだ完全な機能互換ではありません。 |
+| Windows | 一部対応 | Windows ネイティブでも起動、基本ブラウズ、`Move to trash` は利用できますが、まだ完全な機能互換ではありません。 |
 
 ## インストール
 
@@ -156,7 +156,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-Windows ネイティブでは、現時点では最低限の起動と基本的なブラウズを主な対象としています。埋め込み split terminal のような POSIX 前提の機能は引き続き利用できず、`t` を押した場合も起動を試みずに非対応メッセージを表示します。そのため、Windows ネイティブ実行向けの依存ツール案内は対象外です。
+Windows ネイティブでは、現時点では起動、基本的なブラウズ、`Move to trash` のような主要ファイル操作を主な対象としています。埋め込み split terminal のような POSIX 前提の機能は引き続き利用できず、trash restore や `Empty trash` も未対応のため、Windows ネイティブ実行向けの依存ツール案内は対象外です。
 
 macOS では、使用しているターミナルアプリに **フルディスクアクセス** 権限を付与してください。**システム設定 > プライバシーとセキュリティ > フルディスクアクセス** を開き、zivo を実行するターミナルアプリ（Terminal.app、iTerm2、Alacritty など）を有効にしてください。この権限がない場合、`~/.Trash` などの保護されたディレクトリにアクセスする操作が失敗します。
 
@@ -367,7 +367,7 @@ Transferモードでは、アクティブな転送ペインで実行できるコ
 | `Go to home directory` | 常に表示 | ホームディレクトリへ移動します。 |
 | `Reload directory` | 常に表示 | 現在ディレクトリを再読み込みします。 |
 | `Toggle transfer mode` / `Close transfer mode` | 常に表示 | 通常の 3 ペインブラウザと 2 ペイン転送レイアウトを切り替えます。転送モード中は `q` / `2`、通常モードからは `2` でも実行できます。 |
-| `Undo last file operation` | Undo 履歴があるとき | 直前の Undo 対象リネーム、貼り付け、ゴミ箱移動を取り消します。`z` でも実行できます。ゴミ箱からの復元は現在 Linux のみ対応です。 |
+| `Undo last file operation` | Undo 履歴があるとき | 直前の Undo 対象リネーム、貼り付け、ゴミ箱移動を取り消します。`z` でも実行できます。ゴミ箱からの復元は現在 Linux と macOS で対応し、Windows では未対応です。 |
 | `Toggle split terminal` | POSIX 環境 | 埋め込み split terminal を開閉します。Windows ネイティブではコマンドパレット上でも無効表示のままで、`t` の直接入力でも非対応メッセージを表示します。 |
 | `Select all` | 現在ディレクトリに表示中の項目が 1 件以上あるとき | 現在ディレクトリで表示中の項目をすべて選択します。 |
 | `Replace text in selected files` | ファイルがフォーカス中、または現在ディレクトリで 1 件以上のファイルが選択中のとき | 選択中のファイル、または未選択時はフォーカス中のファイルを対象に 2 フィールドの置換パレットを開きます。一致したファイル一覧がパレットに表示され、`↑↓` と `Ctrl+n` / `Ctrl+p` で移動すると右ペインに選択中ファイルの diff を表示します。`Enter` で一括置換を実行します。`Shift+↑` / `Shift+↓` で diff preview をスクロールします。 |
@@ -380,8 +380,8 @@ Transferモードでは、アクティブな転送ペインで実行できるコ
 | `Extract archive` | 単一の対応アーカイブファイルが選択中またはフォーカス中のとき | `.zip` / `.tar` / `.tar.gz` / `.tar.bz2` の展開を開始します。展開先入力は絶対パスと相対パスの両方に対応し、相対パスはアーカイブ親ディレクトリ基準で解決されます。初期値はアーカイブと同じ階層にある同名ディレクトリの絶対パスです。既存パスとの衝突がある場合は事前確認し、展開中は status bar に entry 件数ベースの進捗を表示します。 |
 | `Open in editor` | 単一ファイルが選択中またはフォーカス中のとき | フォーカス中のファイルを `editor.command` -> `$EDITOR` -> 組み込み既定値の順でターミナルエディタで開きます。 |
 | `Copy path` | 対象が 1 件以上あるとき | 選択中のパス一覧、または未選択時はフォーカス中のパスをシステムクリップボードへコピーします。`C` でも実行できます。 |
-| `Move to trash` | 対象が 1 件以上あるとき | 選択中の項目、またはフォーカス項目をゴミ箱へ移動します（既定では確認あり、設定で変更可能）。 |
-| `Empty trash` | 常に表示（Linux/macOSのみ） | ゴミ箱内のすべての項目を完全に削除します。実行前に確認ダイアログを表示します。Windows では利用できません。 |
+| `Move to trash` | 対象が 1 件以上あるとき | 選択中の項目、またはフォーカス項目をゴミ箱へ移動します（既定では確認あり、設定で変更可能）。Windows では `send2trash` 経由で Recycle Bin を使いますが、undo restore は利用できません。 |
+| `Empty trash` | 常に表示（Linux/macOSのみ） | ゴミ箱内のすべての項目を完全に削除します。実行前に確認ダイアログを表示します。Windows での対応はまだありません。 |
 | `Open in file manager` | 常に表示 | 現在ディレクトリを OS のファイルマネージャで開きます。`M` でも実行できます。 |
 | `Open terminal` | 常に表示 | `config.toml` の設定を優先しつつ、zivo の current directory を起点に外部ターミナルを起動します。別ウィンドウ起動と前面起動を設定で切り替えられます。Windows では `window` のみ対応し、`foreground` を選ぶと `window` を使うよう案内付きで失敗します。`T` でも実行できます。 |
 | `Run shell command` | 常に表示 | 1 行シェルコマンド入力ダイアログを開き、現在ディレクトリでバックグラウンド実行します。完了後は先頭の出力行、または失敗要約を status bar に表示します。Windows では `powershell.exe`、次に `pwsh`、最後に `cmd.exe` を優先するため、構文は選ばれた Windows shell に従います。`!` でも実行できます。 |
@@ -397,7 +397,7 @@ zivo は起動時にユーザー設定用の `config.toml` を読み込みます
 
 - Linux: `${XDG_CONFIG_HOME:-~/.config}/zivo/config.toml`
 - macOS: `~/Library/Application Support/zivo/config.toml`
-- Windows 向けの設定パスも予約していますが、Windows ネイティブ実行自体は引き続き非対応です
+- Windows 向けの設定パスをサポートしており、Windows ネイティブ実行でも利用できます
 
 設定できる項目は次のとおりです。
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Overlay display:
 | Ubuntu | Supported | Primary verified environment at the moment. |
 | Ubuntu (WSL) | Supported | WSL running Ubuntu is part of the verified environments. |
 | macOS | Supported | Grant Full Disk Access to your terminal for trash operations. |
-| Windows | Partial | Minimum startup and basic browsing are supported, but native Windows still lacks full feature parity. |
+| Windows | Partial | Native Windows supports startup, basic browsing, and `Move to trash`, but still lacks full feature parity. |
 
 ## Installation
 
@@ -152,7 +152,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-On native Windows, zivo currently focuses on minimum startup and basic browsing. POSIX-oriented features such as the embedded split terminal are still unavailable there, and pressing `t` shows a non-supported warning instead of trying to launch it, so native Windows dependency guidance remains intentionally limited.
+On native Windows, zivo currently focuses on startup, basic browsing, and core file actions such as `Move to trash`. POSIX-oriented features such as the embedded split terminal are still unavailable there, and trash restore / `Empty trash` remain unsupported, so native Windows dependency guidance remains intentionally limited.
 
 On macOS, grant **Full Disk Access** to your terminal application. Open **System Settings > Privacy & Security > Full Disk Access** and enable the terminal app you use to run zivo (for example Terminal.app, iTerm2, or Alacritty). Without this permission, operations that access `~/.Trash` or other protected directories will fail.
 
@@ -363,7 +363,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Go to home directory` | Always | Navigates to the home directory. |
 | `Reload directory` | Always | Reloads the current directory. |
 | `Toggle transfer mode` / `Close transfer mode` | Always | Switches between the normal three-pane browser and the two-pane transfer layout. Also available with `q` / `2` while transfer mode is open, and `2` from normal mode. |
-| `Undo last file operation` | Undo history is not empty | Reverses the most recent undoable rename, paste, or trash operation. Also available with `z`. Trash restore is currently Linux-only. |
+| `Undo last file operation` | Undo history is not empty | Reverses the most recent undoable rename, paste, or trash operation. Also available with `z`. Trash restore is currently supported on Linux and macOS, but not on Windows. |
 | `Toggle split terminal` | POSIX environments | Opens or closes the embedded split terminal. It stays disabled in the command palette on native Windows, and direct `t` input shows an unavailable warning. |
 | `Select all` | Current directory has at least one visible entry | Selects every currently visible entry in the current directory, respecting hidden-file visibility and any active filter. |
 | `Replace text in selected files` | A file is focused or one or more files are selected in the current directory | Opens a two-field replacement palette for the selected files, or the focused file when nothing is explicitly selected. Matching files appear in the palette, `↑↓` and `Ctrl+n` / `Ctrl+p` move between them, and the right pane shows the selected file's diff before `Enter` applies the replacement. `Shift+↑` / `Shift+↓` scrolls the diff preview. |
@@ -376,8 +376,8 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Extract archive` | Exactly one supported archive file is selected or focused | Starts archive extraction for `.zip`, `.tar`, `.tar.gz`, or `.tar.bz2`. The destination input accepts absolute and relative paths. Relative paths are resolved from the archive file's parent directory, and the default value is a same-name directory next to the archive. Existing destination paths are confirmed before extraction, and the status bar shows entry-count progress while the extraction runs. |
 | `Open in editor` | Exactly one file is selected or focused | Opens the focused file in a terminal editor, using `editor.command` -> `$EDITOR` -> built-in defaults. |
 | `Copy path` | At least one target is selected or focused | Copies the selected path list, or the focused path when nothing is selected, to the system clipboard. Also available with `C`. |
-| `Move to trash` | At least one target is selected or focused | Moves the selected items, or the focused item, to trash (confirmation is enabled by default and can be configured). |
-| `Empty trash` | Always (Linux/macOS only) | Permanently deletes all items from the trash. Shows a confirmation dialog before emptying. Not available on Windows. |
+| `Move to trash` | At least one target is selected or focused | Moves the selected items, or the focused item, to trash (confirmation is enabled by default and can be configured). On Windows this uses the Recycle Bin via `send2trash`, but undo restore is not available there. |
+| `Empty trash` | Always (Linux/macOS only) | Permanently deletes all items from the trash. Shows a confirmation dialog before emptying. Windows support is not available yet. |
 | `Open in file manager` | Always | Opens the current directory in the OS file manager. Also available with `M`. |
 | `Open terminal` | Always | Launches an external terminal rooted at zivo's current directory, using `config.toml` templates before built-in fallbacks. The launch mode can be switched between a separate window and foreground terminal handoff. On Windows, `window` mode is supported and `foreground` is rejected with guidance to switch back to `window`. Also available with `T`. |
 | `Run shell command` | Always | Opens a one-line shell command dialog, runs the command in the current directory in the background, and returns the first output line or failure summary in the status bar. On Windows, zivo prefers `powershell.exe`, then `pwsh`, then `cmd.exe`, so command syntax follows the selected Windows shell rather than POSIX `sh`. Also available with `!`. |

--- a/src/zivo/services/trash_operations.py
+++ b/src/zivo/services/trash_operations.py
@@ -232,8 +232,30 @@ class MacOsTrashService:
 
 
 @dataclass(frozen=True)
+class WindowsTrashService:
+    """Trash operations for native Windows."""
+
+    def get_trash_path(self) -> str | None:
+        return None
+
+    def empty_trash(self) -> tuple[int, str]:
+        return 0, "Empty trash is not supported on Windows yet"
+
+    def capture_restorable_trash(
+        self,
+        path: str,
+        send_to_trash: Callable[[], None],
+    ) -> TrashRestoreRecord | None:
+        send_to_trash()
+        return None
+
+    def restore(self, record: TrashRestoreRecord) -> str:
+        raise OSError("Trash restore is not supported on Windows")
+
+
+@dataclass(frozen=True)
 class UnsupportedPlatformTrashService:
-    """Placeholder for unsupported platforms."""
+    """Placeholder for platforms without any trash integration."""
 
     def get_trash_path(self) -> str | None:
         return None
@@ -296,7 +318,12 @@ def _write_restore_metadata(
 ) -> Path:
     """Write a restore metadata file and return its path."""
     timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
-    safe_name = original_path.replace("/", "_").lstrip("_")
+    safe_name = (
+        original_path.replace("\\", "_")
+        .replace("/", "_")
+        .replace(":", "_")
+        .lstrip("_")
+    )
     metadata_path = metadata_dir / f"{timestamp}_{safe_name}.restoreinfo"
 
     content = (
@@ -310,7 +337,7 @@ def _write_restore_metadata(
 
 
 def resolve_trash_service(
-) -> LinuxTrashService | MacOsTrashService | UnsupportedPlatformTrashService:
+) -> LinuxTrashService | MacOsTrashService | WindowsTrashService | UnsupportedPlatformTrashService:
     """Return appropriate trash service based on platform."""
 
     system = platform.system()
@@ -318,4 +345,6 @@ def resolve_trash_service(
         return LinuxTrashService()
     if system == "Darwin":
         return MacOsTrashService()
+    if system == "Windows":
+        return WindowsTrashService()
     return UnsupportedPlatformTrashService()

--- a/tests/test_services_file_mutations.py
+++ b/tests/test_services_file_mutations.py
@@ -1,6 +1,5 @@
 import os
 from dataclasses import dataclass, field
-from pathlib import Path
 
 import pytest
 
@@ -10,7 +9,7 @@ from zivo.services.trash_operations import WindowsTrashService
 
 
 def _absolute(path: str) -> str:
-    return str(Path(path).resolve())
+    return os.path.abspath(os.path.expanduser(path))
 
 
 @dataclass

--- a/tests/test_services_file_mutations.py
+++ b/tests/test_services_file_mutations.py
@@ -1,10 +1,16 @@
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 
 from zivo.models import CreatePathRequest, CreateSymlinkRequest, DeleteRequest, RenameRequest
 from zivo.services import LiveFileMutationService
+from zivo.services.trash_operations import WindowsTrashService
+
+
+def _absolute(path: str) -> str:
+    return str(Path(path).resolve())
 
 
 @dataclass
@@ -73,6 +79,19 @@ def test_file_mutation_service_trashes_single_path() -> None:
     assert result.removed_paths == ("/tmp/zivo/docs",)
 
 
+def test_file_mutation_service_does_not_create_trash_restore_record_on_windows() -> None:
+    adapter = StubFileOperationAdapter()
+    service = LiveFileMutationService(
+        adapter=adapter,
+        trash_service=WindowsTrashService(),
+    )
+
+    result = service.execute(DeleteRequest(paths=("C:/Users/test/docs",), mode="trash"))
+
+    assert adapter.trashed_paths == ["C:/Users/test/docs"]
+    assert result.trash_records == ()
+
+
 def test_file_mutation_service_renames_single_path() -> None:
     adapter = StubFileOperationAdapter()
     service = LiveFileMutationService(adapter=adapter)
@@ -81,11 +100,12 @@ def test_file_mutation_service_renames_single_path() -> None:
         RenameRequest(source_path="/tmp/zivo/docs", new_name="docs-old")
     )
 
-    assert adapter.moved_paths == [("/tmp/zivo/docs", "/tmp/zivo/docs-old")]
-    assert result.path == "/tmp/zivo/docs-old"
+    assert adapter.moved_paths == [(_absolute("/tmp/zivo/docs"), _absolute("/tmp/zivo/docs-old"))]
+    assert result.path == _absolute("/tmp/zivo/docs-old")
     assert result.message == "Renamed to docs-old"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_file_mutation_service_renames_symlink_without_following_target(tmp_path) -> None:
     target = tmp_path / "target.txt"
     target.write_text("secret\n", encoding="utf-8")
@@ -106,7 +126,7 @@ def test_file_mutation_service_renames_symlink_without_following_target(tmp_path
 
 
 def test_file_mutation_service_raises_rename_error() -> None:
-    adapter = StubFileOperationAdapter(failing_paths={"/tmp/zivo/docs-old"})
+    adapter = StubFileOperationAdapter(failing_paths={_absolute("/tmp/zivo/docs-old")})
     service = LiveFileMutationService(adapter=adapter)
 
     with pytest.raises(OSError, match="rename failed"):
@@ -121,8 +141,8 @@ def test_file_mutation_service_creates_file() -> None:
         CreatePathRequest(parent_dir="/tmp/zivo", name="README.md", kind="file")
     )
 
-    assert adapter.created_files == ["/tmp/zivo/README.md"]
-    assert result.path == "/tmp/zivo/README.md"
+    assert adapter.created_files == [_absolute("/tmp/zivo/README.md")]
+    assert result.path == _absolute("/tmp/zivo/README.md")
     assert result.message == "Created file README.md"
 
 
@@ -132,8 +152,8 @@ def test_file_mutation_service_creates_directory() -> None:
 
     result = service.execute(CreatePathRequest(parent_dir="/tmp/zivo", name="docs", kind="dir"))
 
-    assert adapter.created_directories == ["/tmp/zivo/docs"]
-    assert result.path == "/tmp/zivo/docs"
+    assert adapter.created_directories == [_absolute("/tmp/zivo/docs")]
+    assert result.path == _absolute("/tmp/zivo/docs")
     assert result.message == "Created directory docs"
 
 
@@ -148,11 +168,14 @@ def test_file_mutation_service_creates_symlink() -> None:
         )
     )
 
-    assert adapter.created_symlinks == [("/tmp/zivo/docs", "/tmp/zivo/docs.link", False)]
-    assert result.path == "/tmp/zivo/docs.link"
+    assert adapter.created_symlinks == [
+        (_absolute("/tmp/zivo/docs"), _absolute("/tmp/zivo/docs.link"), False)
+    ]
+    assert result.path == _absolute("/tmp/zivo/docs.link")
     assert result.message == "Created symlink docs.link"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_file_mutation_service_creates_relative_symlink_on_disk(tmp_path) -> None:
     target = tmp_path / "docs"
     target.mkdir()
@@ -169,6 +192,7 @@ def test_file_mutation_service_creates_relative_symlink_on_disk(tmp_path) -> Non
     assert result.path == str(destination)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_file_mutation_service_overwrites_existing_symlink_destination(tmp_path) -> None:
     target = tmp_path / "docs"
     target.mkdir()
@@ -191,7 +215,7 @@ def test_file_mutation_service_overwrites_existing_symlink_destination(tmp_path)
 
 
 def test_file_mutation_service_raises_create_file_error() -> None:
-    adapter = StubFileOperationAdapter(failing_paths={"/tmp/zivo/README.md"})
+    adapter = StubFileOperationAdapter(failing_paths={_absolute("/tmp/zivo/README.md")})
     service = LiveFileMutationService(adapter=adapter)
 
     with pytest.raises(OSError, match="file creation failed"):
@@ -199,7 +223,7 @@ def test_file_mutation_service_raises_create_file_error() -> None:
 
 
 def test_file_mutation_service_raises_create_directory_error() -> None:
-    adapter = StubFileOperationAdapter(failing_paths={"/tmp/zivo/docs"})
+    adapter = StubFileOperationAdapter(failing_paths={_absolute("/tmp/zivo/docs")})
     service = LiveFileMutationService(adapter=adapter)
 
     with pytest.raises(OSError, match="directory creation failed"):
@@ -227,6 +251,7 @@ def test_file_mutation_service_raises_when_all_deletes_fail() -> None:
         service.execute(DeleteRequest(paths=("/tmp/zivo/docs",), mode="trash"))
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_file_mutation_service_trashes_symlink_without_following_target(tmp_path) -> None:
     target = tmp_path / "target.txt"
     target.write_text("secret\n", encoding="utf-8")
@@ -275,6 +300,7 @@ def test_file_mutation_service_raises_when_all_permanent_deletes_fail() -> None:
         service.execute(DeleteRequest(paths=("/tmp/zivo/docs",), mode="permanent"))
 
 
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
 def test_file_mutation_service_permanently_deletes_symlink_without_following_target(
     tmp_path,
 ) -> None:

--- a/tests/test_services_trash_operations.py
+++ b/tests/test_services_trash_operations.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from zivo.models import TrashRestoreRecord
-from zivo.services.trash_operations import LinuxTrashService, MacOsTrashService
+from zivo.services.trash_operations import LinuxTrashService, MacOsTrashService, WindowsTrashService
 
 
 def test_linux_trash_service_captures_restorable_metadata(tmp_path, monkeypatch) -> None:
@@ -272,3 +272,34 @@ def test_macos_capture_returns_none_when_no_new_entry(
     record = service.capture_restorable_trash(str(original_path), lambda: None)
 
     assert record is None
+
+
+def test_windows_trash_service_sends_to_trash_without_restore_metadata() -> None:
+    sent_to_trash: list[str] = []
+
+    service = WindowsTrashService()
+    record = service.capture_restorable_trash(
+        "C:/Users/test/docs",
+        lambda: sent_to_trash.append("C:/Users/test/docs"),
+    )
+
+    assert sent_to_trash == ["C:/Users/test/docs"]
+    assert record is None
+
+
+def test_windows_trash_service_reports_empty_trash_as_unsupported() -> None:
+    count, error = WindowsTrashService().empty_trash()
+
+    assert count == 0
+    assert error == "Empty trash is not supported on Windows yet"
+
+
+def test_windows_trash_service_restore_is_unsupported() -> None:
+    record = TrashRestoreRecord(
+        original_path="C:/Users/test/docs",
+        trashed_path="C:/$Recycle.Bin/docs",
+        metadata_path="",
+    )
+
+    with pytest.raises(OSError, match="Trash restore is not supported on Windows"):
+        WindowsTrashService().restore(record)

--- a/tests/test_state_reducer_mutations_delete.py
+++ b/tests/test_state_reducer_mutations_delete.py
@@ -200,6 +200,19 @@ def test_begin_empty_trash_enters_confirm_mode(monkeypatch) -> None:
     assert next_state.pending_input is None
 
 
+def test_begin_empty_trash_on_windows_shows_error(monkeypatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+
+    next_state = _reduce_state(build_initial_app_state(), BeginEmptyTrash())
+
+    assert next_state.ui_mode == "BROWSING"
+    assert next_state.empty_trash_confirmation is None
+    assert next_state.notification == NotificationState(
+        level="error",
+        message="Empty trash is not supported on this platform",
+    )
+
+
 def test_cancel_empty_trash_confirmation_returns_to_browsing() -> None:
     state = replace(
         build_initial_app_state(),

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -931,6 +931,16 @@ def test_submit_command_palette_deletes_targets() -> None:
     assert result.state.command_palette is None
     assert result.state.delete_confirmation is not None
 
+
+def test_command_palette_hides_empty_trash_on_windows(monkeypatch) -> None:
+    monkeypatch.setattr(command_palette_module.platform, "system", lambda: "Windows")
+    state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
+
+    palette_state = select_command_palette_state(state)
+
+    assert palette_state is not None
+    assert "Empty trash" not in [item.label for item in palette_state.items]
+
 def test_submit_command_palette_uses_selected_paths_for_copy_path() -> None:
     initial_state = build_initial_app_state()
     state = replace(


### PR DESCRIPTION
﻿## Summary
- closes #720
- clarify Windows trash support by introducing an explicit Windows trash service
- document that Windows supports `Move to trash` but not trash restore or `Empty trash`
- add regression tests for Windows trash behavior and command-palette visibility

## Testing
- `uv run ruff check .`
- `uv run pytest tests/test_services_trash_operations.py tests/test_services_file_mutations.py tests/test_state_reducer_palette_commands.py tests/test_state_reducer_mutations_delete.py`
- `uv run pytest` *(fails on existing Windows-wide issues outside #720, including symlink privilege assumptions and `/tmp`/path-normalization expectations tracked by other Windows issues)*
