### PR TITLE
#742 Add Windows drive switching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-On native Windows, zivo currently focuses on startup, basic browsing, and core file actions such as `Move to trash`. POSIX-oriented features such as the embedded split terminal are still unavailable there, and trash restore / `Empty trash` remain unsupported, so native Windows dependency guidance remains intentionally limited.
+On native Windows, zivo currently focuses on startup, basic browsing, and core file actions such as `Move to trash`. POSIX-oriented features such as the embedded split terminal are still unavailable there, and trash restore / `Empty trash` remain unsupported, so native Windows dependency guidance remains intentionally limited. Pressing `←` from a drive root such as `C:\` returns to a drive list so you can move to another drive without leaving zivo.
 
 On macOS, grant **Full Disk Access** to your terminal application. Open **System Settings > Privacy & Security > Full Disk Access** and enable the terminal app you use to run zivo (for example Terminal.app, iTerm2, or Alacritty). Without this permission, operations that access `~/.Trash` or other protected directories will fail.
 
@@ -359,7 +359,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Show bookmarks` | Always | Opens the saved bookmark list and jumps to the selected directory. |
 | `Go back` | Directory history has a previous entry | Moves to the previous directory in history. |
 | `Go forward` | Directory history has a forward entry | Moves to the next directory in history. |
-| `Go to path` | Always | Opens go-to-path input to navigate to a specific path, shows matching directories, and supports `Tab` completion for the selected candidate. |
+| `Go to path` | Always | Opens go-to-path input to navigate to a specific path, shows matching directories, and supports `Tab` completion for the selected candidate. On native Windows, drive roots are also offered so you can switch between drives quickly. |
 | `Go to home directory` | Always | Navigates to the home directory. |
 | `Reload directory` | Always | Reloads the current directory. |
 | `Toggle transfer mode` / `Close transfer mode` | Always | Switches between the normal three-pane browser and the two-pane transfer layout. Also available with `q` / `2` while transfer mode is open, and `2` from normal mode. |

--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -75,6 +75,7 @@ from zivo.state import (
     dispatch_key_input,
     iter_bound_keys,
     reduce_app_state,
+    resolve_parent_directory_path,
     select_shell_data,
 )
 from zivo.state.actions import (
@@ -200,7 +201,7 @@ class zivoApp(App[None]):
         super().__init__()
         self._app_config = app_config or AppConfig()
         self.theme = self._app_config.display.theme
-        self._initial_path = str(Path(initial_path or Path.cwd()).expanduser().resolve())
+        self._initial_path = resolve_parent_directory_path(str(initial_path or Path.cwd()))[0]
         self._app_state: AppState = build_placeholder_app_state(
             self._initial_path,
             config=self._app_config,

--- a/src/zivo/app_runtime_search.py
+++ b/src/zivo/app_runtime_search.py
@@ -98,22 +98,31 @@ def schedule_browser_snapshot(app: Any, effect: LoadBrowserSnapshotEffect) -> No
 
 
 def schedule_child_pane_snapshot(app: Any, effect: LoadChildPaneSnapshotEffect) -> None:
+    pending_effect = getattr(app, "_pending_child_pane_effect", None)
+    if getattr(app, "_child_pane_timer", None) is not None and pending_effect is not None:
+        start_child_pane_snapshot(app, pending_effect, require_pending_match=False)
     cancel_timer(app, "_child_pane_timer")
     debounce_seconds = _child_pane_debounce_seconds(effect)
-    if debounce_seconds <= 0:
-        start_child_pane_snapshot(app, effect)
-        return
     timer = app.set_timer(
         debounce_seconds,
         partial(start_child_pane_snapshot, app, effect),
         name=f"child-pane-snapshot-debounce:{effect.request_id}",
     )
+    setattr(app, "_pending_child_pane_effect", effect)
     setattr(app, "_child_pane_timer", timer)
 
 
-def start_child_pane_snapshot(app: Any, effect: LoadChildPaneSnapshotEffect) -> None:
+def start_child_pane_snapshot(
+    app: Any,
+    effect: LoadChildPaneSnapshotEffect,
+    *,
+    require_pending_match: bool = True,
+) -> None:
     setattr(app, "_child_pane_timer", None)
-    if app._app_state.pending_child_pane_request_id != effect.request_id:
+    pending_effect = getattr(app, "_pending_child_pane_effect", None)
+    if pending_effect == effect:
+        setattr(app, "_pending_child_pane_effect", None)
+    if require_pending_match and app._app_state.pending_child_pane_request_id != effect.request_id:
         return
     cancel_event = threading.Event()
     set_active_tracking(app, CHILD_PANE_TRACKING, effect.request_id, cancel_event)

--- a/src/zivo/services/browser_snapshot.py
+++ b/src/zivo/services/browser_snapshot.py
@@ -23,6 +23,15 @@ from zivo.state.models import (
     build_initial_app_state,
     resolve_parent_directory_path,
 )
+from zivo.windows_paths import (
+    comparable_path,
+    is_posix_path,
+    is_windows_drive_root,
+    is_windows_drives_root,
+    is_windows_path,
+    list_windows_drive_paths,
+    normalize_windows_path,
+)
 
 DEFAULT_DIRECTORY_CACHE_CAPACITY = 64
 DEFAULT_TEXT_PREVIEW_CACHE_CAPACITY = 128
@@ -384,6 +393,23 @@ class LiveBrowserSnapshotLoader:
         if cursor_path is None:
             return PaneState(directory_path=current_path, entries=())
 
+        if is_windows_drive_root(cursor_path):
+            try:
+                child_entries = self._list_directory(normalize_windows_path(cursor_path))
+                return PaneState(
+                    directory_path=normalize_windows_path(cursor_path),
+                    entries=child_entries,
+                )
+            except OSError as error:
+                if _is_permission_denied_error(error):
+                    return PaneState(
+                        directory_path=normalize_windows_path(cursor_path),
+                        entries=(),
+                        mode="preview",
+                        preview_message=PREVIEW_PERMISSION_DENIED_MESSAGE,
+                    )
+                raise
+
         child_path = Path(cursor_path).expanduser().resolve()
         if child_path.is_dir():
             try:
@@ -620,6 +646,15 @@ class LiveBrowserSnapshotLoader:
                 self._directory_entries_cache.popitem(last=False)
 
     def _read_directory(self, path: str):
+        if is_windows_drives_root(path):
+            return tuple(
+                DirectoryEntryState(
+                    path=drive,
+                    name=drive,
+                    kind="dir",
+                )
+                for drive in list_windows_drive_paths()
+            )
         try:
             return self.filesystem.list_directory(path)
         except PermissionError as error:
@@ -785,6 +820,17 @@ class FakeBrowserSnapshotLoader:
             raise OSError(self.failure_messages[path])
 
         snapshot = self.snapshots.get(path)
+        if snapshot is None and is_windows_path(path):
+            normalized_path = normalize_windows_path(path)
+            snapshot = next(
+                (
+                    candidate
+                    for candidate_path, candidate in self.snapshots.items()
+                    if is_windows_path(candidate_path)
+                    and normalize_windows_path(candidate_path) == normalized_path
+                ),
+                None,
+            )
         if snapshot is not None:
             return self._resolve_snapshot(snapshot, cursor_path)
 
@@ -868,7 +914,10 @@ class FakeBrowserSnapshotLoader:
         paths: tuple[str, ...] = (),
     ) -> None:
         normalized_paths = tuple(
-            dict.fromkeys(_normalize_directory_cache_path(path) for path in paths)
+            dict.fromkeys(
+                path if is_windows_drives_root(path) else str(Path(path).expanduser().resolve())
+                for path in paths
+            )
         )
         self.invalidated_directory_listing_paths.append(normalized_paths)
 
@@ -877,23 +926,90 @@ class FakeBrowserSnapshotLoader:
         snapshot: BrowserSnapshot,
         cursor_path: str | None,
     ) -> BrowserSnapshot:
-        if cursor_path is None or not _contains_path(snapshot.current_pane.entries, cursor_path):
-            return snapshot
+        normalized_snapshot = replace(
+            snapshot,
+            current_path=comparable_path(snapshot.current_path),
+            parent_pane=replace(
+                snapshot.parent_pane,
+                cursor_path=comparable_path(snapshot.parent_pane.cursor_path),
+            ),
+            current_pane=replace(
+                snapshot.current_pane,
+                cursor_path=comparable_path(snapshot.current_pane.cursor_path),
+            ),
+        )
+        matched_cursor_path = self._match_snapshot_cursor_path(snapshot, cursor_path)
+        if matched_cursor_path is None:
+            return normalized_snapshot
 
-        current_pane = replace(snapshot.current_pane, cursor_path=cursor_path)
-        child_pane = snapshot.child_pane
-        if (snapshot.current_path, cursor_path) in self.child_panes:
-            child_pane = self.child_panes[(snapshot.current_path, cursor_path)]
-        elif child_pane.directory_path != cursor_path:
+        current_pane = replace(
+            normalized_snapshot.current_pane,
+            cursor_path=comparable_path(matched_cursor_path),
+        )
+        child_pane = normalized_snapshot.child_pane
+        child_key = self._match_child_pane_key(snapshot.current_path, matched_cursor_path)
+        if child_key is not None:
+            child_pane = self.child_panes[child_key]
+        elif child_pane.directory_path != matched_cursor_path:
             cursor_entry = next(
-                entry for entry in snapshot.current_pane.entries if entry.path == cursor_path
+                entry
+                for entry in snapshot.current_pane.entries
+                if entry.path == matched_cursor_path
             )
             if cursor_entry.kind == "dir":
-                child_pane = PaneState(directory_path=cursor_path, entries=())
+                child_pane = PaneState(directory_path=matched_cursor_path, entries=())
             else:
                 child_pane = PaneState(directory_path=snapshot.current_path, entries=())
 
-        return replace(snapshot, current_pane=current_pane, child_pane=child_pane)
+        return replace(
+            normalized_snapshot,
+            current_pane=current_pane,
+            child_pane=child_pane,
+        )
+
+    def _match_snapshot_cursor_path(
+        self,
+        snapshot: BrowserSnapshot,
+        cursor_path: str | None,
+    ) -> str | None:
+        if cursor_path is None:
+            return None
+        if _contains_path(snapshot.current_pane.entries, cursor_path):
+            return cursor_path
+        if not is_windows_path(cursor_path):
+            return None
+        normalized_cursor = normalize_windows_path(cursor_path)
+        for entry in snapshot.current_pane.entries:
+            if is_windows_path(entry.path) and (
+                normalize_windows_path(entry.path) == normalized_cursor
+            ):
+                return entry.path
+        return None
+
+    def _match_child_pane_key(
+        self,
+        current_path: str,
+        cursor_path: str,
+    ) -> tuple[str, str | None] | None:
+        direct_key = (current_path, cursor_path)
+        if direct_key in self.child_panes:
+            return direct_key
+        if not (is_windows_path(current_path) and is_windows_path(cursor_path)):
+            return None
+        normalized_current = normalize_windows_path(current_path)
+        normalized_cursor = normalize_windows_path(cursor_path)
+        for key in self.child_panes:
+            key_current, key_cursor = key
+            if key_cursor is None:
+                continue
+            if not (is_windows_path(key_current) and is_windows_path(key_cursor)):
+                continue
+            if (
+                normalize_windows_path(key_current) == normalized_current
+                and normalize_windows_path(key_cursor) == normalized_cursor
+            ):
+                return key
+        return None
 
 
 def snapshot_from_app_state(state: AppState) -> BrowserSnapshot:
@@ -939,7 +1055,17 @@ def _contains_path(entries, path: str) -> bool:
     return any(entry.path == path for entry in entries)
 
 
+def _normalize_preview_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n")
+
+
 def _normalize_directory_cache_path(path: str) -> str:
+    if is_windows_drives_root(path):
+        return path
+    if is_posix_path(path):
+        return path
+    if is_windows_path(path):
+        return normalize_windows_path(path)
     return str(Path(path).expanduser().resolve())
 
 
@@ -1051,7 +1177,7 @@ def _load_text_preview(
     truncated = len(chunk) > preview_limit
     preview_bytes = chunk[:preview_limit]
     try:
-        preview_text = preview_bytes.decode("utf-8")
+        preview_text = _normalize_preview_newlines(preview_bytes.decode("utf-8"))
     except UnicodeDecodeError:
         return FilePreviewState.unsupported()
 
@@ -1107,9 +1233,11 @@ class PandocDocumentPreviewLoader:
             return None
 
         try:
-            content = result.stdout.decode("utf-8")
+            content = _normalize_preview_newlines(result.stdout.decode("utf-8"))
         except UnicodeDecodeError:
-            content = result.stdout.decode("utf-8", errors="ignore")
+            content = _normalize_preview_newlines(
+                result.stdout.decode("utf-8", errors="ignore")
+            )
         if not content.strip():
             return None
         return _truncate_preview_text(content, preview_max_bytes)
@@ -1163,9 +1291,11 @@ class ChafaImagePreviewLoader:
             return None
 
         try:
-            content = result.stdout.decode("utf-8")
+            content = _normalize_preview_newlines(result.stdout.decode("utf-8"))
         except UnicodeDecodeError:
-            content = result.stdout.decode("utf-8", errors="ignore")
+            content = _normalize_preview_newlines(
+                result.stdout.decode("utf-8", errors="ignore")
+            )
         if not content.strip():
             return None
         return FilePreviewState.with_content(content, False, content_kind="image")
@@ -1200,9 +1330,9 @@ def _load_pdf_preview(
     except (OSError, subprocess.SubprocessError):
         return None
     try:
-        content = result.stdout.decode("utf-8")
+        content = _normalize_preview_newlines(result.stdout.decode("utf-8"))
     except UnicodeDecodeError:
-        content = result.stdout.decode("utf-8", errors="ignore")
+        content = _normalize_preview_newlines(result.stdout.decode("utf-8", errors="ignore"))
     if not content.strip():
         return None
     return _truncate_preview_text(content, preview_max_bytes)
@@ -1247,7 +1377,7 @@ def _load_grep_context_preview(
                 # Collect context lines
                 if current_line >= start_line:
                     try:
-                        line_text = line_bytes.decode("utf-8")
+                        line_text = _normalize_preview_newlines(line_bytes.decode("utf-8"))
                         lines.append(line_text)
                         last_line = current_line
                     except UnicodeDecodeError:

--- a/src/zivo/state/__init__.py
+++ b/src/zivo/state/__init__.py
@@ -79,6 +79,7 @@ from .models import (
     build_initial_app_state,
     build_placeholder_app_state,
     load_browser_tab,
+    resolve_parent_directory_path,
     select_browser_tabs,
 )
 from .reducer import reduce_app_state
@@ -182,6 +183,7 @@ __all__ = [
     "iter_bound_keys",
     "load_browser_tab",
     "reduce_app_state",
+    "resolve_parent_directory_path",
     "select_attribute_dialog_state",
     "select_browser_tabs",
     "select_child_entries",

--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from zivo.archive_utils import is_supported_archive_path
 from zivo.platform_support import is_split_terminal_supported
+from zivo.windows_paths import display_path
 
 from .entry_state_helpers import select_visible_entry_states
 from .models import AppState
@@ -588,6 +589,10 @@ def _matches_query(item: CommandPaletteItem, query: str) -> bool:
 
 def _display_path(path: str) -> str:
     """Replace home directory prefix with ~ for display."""
+
+    rendered = display_path(path)
+    if rendered != path:
+        return rendered
     home = os.path.expanduser("~")
     if path.startswith(home + "/"):
         return "~" + path[len(home):]

--- a/src/zivo/state/input_common.py
+++ b/src/zivo/state/input_common.py
@@ -3,6 +3,8 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from zivo.windows_paths import paths_equal
+
 from .actions import Action, SetNotification
 from .models import AppState, DirectoryEntryState, NotificationState
 from .selectors import select_visible_current_entry_states
@@ -30,7 +32,7 @@ def visible_paths(state: AppState) -> tuple[str, ...]:
 def current_entry(state: AppState) -> DirectoryEntryState | None:
     cursor_path = state.current_pane.cursor_path
     for entry in select_visible_current_entry_states(state):
-        if entry.path == cursor_path:
+        if paths_equal(entry.path, cursor_path):
             return entry
     return None
 

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -20,6 +20,7 @@ from zivo.models import (
     UndoEntry,
 )
 from zivo.models.shell_data import EntryKind, NotificationLevel
+from zivo.windows_paths import resolve_parent_directory_path as resolve_parent_directory_path_impl
 
 UiMode = Literal[
     "BROWSING",
@@ -663,11 +664,7 @@ def load_browser_tab(state: AppState, index: int) -> AppState:
 def resolve_parent_directory_path(path: str) -> tuple[str, str | None]:
     """Return the resolved path and its distinct parent, if one exists."""
 
-    resolved_path = Path(path).expanduser().resolve()
-    parent_path = resolved_path.parent
-    if parent_path == resolved_path:
-        return str(resolved_path), None
-    return str(resolved_path), str(parent_path)
+    return resolve_parent_directory_path_impl(path)
 
 
 def build_initial_app_state(
@@ -769,7 +766,13 @@ def build_placeholder_app_state(
 ) -> AppState:
     """Return an empty browser state used before the first snapshot loads."""
 
-    resolved_path, parent_path = resolve_parent_directory_path(current_path)
+    if current_path == "/":
+        resolved_path = str(Path(current_path).expanduser().resolve())
+        parent_path = resolved_path if Path(resolved_path).parent == Path(resolved_path) else str(
+            Path(resolved_path).parent
+        )
+    else:
+        resolved_path, parent_path = resolve_parent_directory_path(current_path)
     state = AppState(
         current_path=resolved_path,
         config=config or AppConfig(),

--- a/src/zivo/state/reducer.py
+++ b/src/zivo/state/reducer.py
@@ -3,6 +3,8 @@
 import logging
 from dataclasses import replace
 
+from zivo.windows_paths import paths_equal
+
 from .actions import (
     Action,
     ClearPendingKeySequence,
@@ -261,7 +263,7 @@ def _find_current_cursor_index(visible_entries, cursor_path: str | None) -> int 
     if cursor_path is None:
         return None
     for index, entry in enumerate(visible_entries):
-        if entry.path == cursor_path:
+        if paths_equal(entry.path, cursor_path):
             return index
     return None
 

--- a/src/zivo/state/reducer_mutations_input.py
+++ b/src/zivo/state/reducer_mutations_input.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from zivo.archive_utils import default_extract_destination, default_zip_destination
 from zivo.models import CreateSymlinkRequest, RenameRequest
+from zivo.windows_paths import basename, join_path
 
 from .actions import (
     BeginCreateInput,
@@ -107,8 +108,8 @@ def _handle_begin_zip_compress_input(state, action, reduce_state):
 
 
 def _default_symlink_destination(base_path: str, source_path: str) -> str:
-    source_name = Path(source_path).name
-    return str(Path(base_path) / f"{source_name}.link")
+    source_name = basename(source_path)
+    return join_path(base_path, f"{source_name}.link")
 
 
 def _handle_begin_symlink_input(state, action, reduce_state):

--- a/src/zivo/state/reducer_navigation.py
+++ b/src/zivo/state/reducer_navigation.py
@@ -4,6 +4,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Callable
 
+from zivo.windows_paths import comparable_path, is_windows_drives_root, is_windows_path
+
 from .actions import (
     Action,
     ActivateNextTab,
@@ -57,6 +59,7 @@ from .models import (
     NotificationState,
     PaneState,
     browser_tab_from_app_state,
+    resolve_parent_directory_path,
     select_browser_tabs,
 )
 from .reducer_common import (
@@ -234,16 +237,16 @@ def _promote_child_pane_to_current(
     promoted_cursor_path = normalize_cursor_path(promoted_entries, None)
     return replace(
         state,
-        current_path=path,
+        current_path=comparable_path(path),
         parent_pane=PaneState(
             directory_path=state.current_path,
             entries=state.current_pane.entries,
-            cursor_path=path,
+            cursor_path=comparable_path(path),
         ),
         current_pane=PaneState(
             directory_path=path,
             entries=promoted_entries,
-            cursor_path=promoted_cursor_path,
+            cursor_path=comparable_path(promoted_cursor_path),
         ),
         child_pane=PaneState(directory_path=path, entries=()),
         filter=FilterState(),
@@ -425,9 +428,8 @@ def _handle_move_cursor_and_select_range(
     if not action.visible_paths:
         return finalize(state)
     base_cursor_path = (
-        state.current_pane.cursor_path
-        if state.current_pane.cursor_path in action.visible_paths
-        else action.visible_paths[0]
+        normalize_selection_anchor_path(state.current_pane.cursor_path, action.visible_paths)
+        or comparable_path(action.visible_paths[0])
     )
     anchor_path = normalize_selection_anchor_path(
         state.current_pane.selection_anchor_path,
@@ -463,9 +465,9 @@ def _handle_jump_cursor(
     if not action.visible_paths:
         return finalize(state)
     cursor_path = (
-        action.visible_paths[0]
+        comparable_path(action.visible_paths[0])
         if action.position == "start"
-        else action.visible_paths[-1]
+        else comparable_path(action.visible_paths[-1])
     )
     next_state = replace(
         state,
@@ -486,16 +488,18 @@ def _handle_move_cursor_by_page(
 ) -> ReduceResult:
     if not action.visible_paths:
         return finalize(state)
+    current_cursor_path = normalize_selection_anchor_path(
+        state.current_pane.cursor_path,
+        action.visible_paths,
+    )
     current_index = (
-        action.visible_paths.index(state.current_pane.cursor_path)
-        if state.current_pane.cursor_path in action.visible_paths
-        else 0
+        action.visible_paths.index(current_cursor_path) if current_cursor_path is not None else 0
     )
     if action.direction == "up":
         new_index = max(0, current_index - action.page_size)
     else:  # direction == "down"
         new_index = min(len(action.visible_paths) - 1, current_index + action.page_size)
-    cursor_path = action.visible_paths[new_index]
+    cursor_path = comparable_path(action.visible_paths[new_index])
     next_state = replace(
         state,
         current_pane=replace(
@@ -519,7 +523,7 @@ def _handle_set_cursor_path(
         state,
         current_pane=replace(
             state.current_pane,
-            cursor_path=action.path,
+            cursor_path=comparable_path(action.path),
             selection_anchor_path=None,
         ),
         notification=None,
@@ -549,7 +553,14 @@ def _handle_go_to_parent_directory(
     action: GoToParentDirectory,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    parent_path = str(Path(state.current_path).parent)
+    if is_windows_drives_root(state.current_path):
+        return finalize(state)
+    if is_windows_path(state.current_path):
+        _, parent_path = resolve_parent_directory_path(state.current_path)
+        if parent_path is None:
+            return finalize(state)
+    else:
+        parent_path = str(Path(state.current_path).parent)
     return reduce_state(
         state,
         RequestBrowserSnapshot(

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from typing import Callable
 
 from zivo.archive_utils import is_supported_archive_path
+from zivo.windows_paths import (
+    is_windows_drives_root,
+    is_windows_path,
+    list_windows_drive_paths,
+)
 
 from .actions import (
     Action,
@@ -220,7 +225,7 @@ def _handle_set_go_to_path_query(state: AppState, next_palette, query: str) -> R
     else:
         base_path = state.current_path
     matches = list_matching_directory_paths(query, base_path)
-    has_trailing_separator = query.endswith("/")
+    has_trailing_separator = query.endswith(("/", "\\"))
     return finalize(
         replace(
             state,
@@ -1018,7 +1023,16 @@ def _handle_begin_go_to_path(
     reduce_state: ReducerFn,
 ) -> ReduceResult:
     del action, reduce_state
-    return finalize(enter_palette(state, source="go_to_path"))
+    next_state = enter_palette(state, source="go_to_path")
+    if is_windows_drives_root(state.current_path) or is_windows_path(state.current_path):
+        next_state = replace(
+            next_state,
+            command_palette=replace(
+                next_state.command_palette,
+                go_to_path_candidates=list_windows_drive_paths(),
+            ),
+        )
+    return finalize(next_state)
 
 
 def _handle_cancel_command_palette(

--- a/src/zivo/state/reducer_palette_search.py
+++ b/src/zivo/state/reducer_palette_search.py
@@ -1,9 +1,9 @@
 """Search-related command palette reducers."""
 
 from dataclasses import replace
-from pathlib import Path
 
 from zivo.models.external_launch import ExternalLaunchRequest
+from zivo.windows_paths import resolve_parent_directory_path
 
 from .actions import (
     CycleSelectedFilesGrepField,
@@ -236,7 +236,7 @@ def handle_submit_file_search_palette(
     return request_palette_snapshot(
         state,
         reduce_state,
-        path=str(Path(selected_result.path).parent),
+        path=resolve_parent_directory_path(selected_result.path)[1] or selected_result.path,
         cursor_path=selected_result.path,
     )
 
@@ -261,7 +261,7 @@ def handle_submit_grep_search_palette(
     return request_palette_snapshot(
         state,
         reduce_state,
-        path=str(Path(selected_result.path).parent),
+        path=resolve_parent_directory_path(selected_result.path)[1] or selected_result.path,
         cursor_path=selected_result.path,
     )
 

--- a/src/zivo/state/reducer_path_helpers.py
+++ b/src/zivo/state/reducer_path_helpers.py
@@ -1,7 +1,20 @@
 """Path, selection, and lightweight search helpers for reducers."""
 
+import ntpath
 import os
 from pathlib import Path
+
+from zivo.windows_paths import (
+    comparable_path,
+    expand_windows_path,
+    is_windows_drive_root,
+    is_windows_drives_root,
+    is_windows_path,
+    list_windows_drive_paths,
+    normalize_windows_path,
+    paths_equal,
+    split_windows_completion_query,
+)
 
 from .models import DirectoryEntryState, FileSearchResultState
 
@@ -54,8 +67,44 @@ def _list_matching_entry_paths(
     """Return matching completion candidates for a partially typed path."""
 
     raw_query = query.strip()
+    windows_mode = _uses_windows_path_rules(base_path, raw_query)
+    if windows_mode:
+        windows_shortcut = split_windows_completion_query(raw_query)
+        if windows_shortcut is not None:
+            _, prefix = windows_shortcut
+            return _list_windows_drive_candidates(prefix)
+    elif not raw_query:
+        return ()
+
     if not raw_query:
         return ()
+
+    if windows_mode:
+        resolved = expand_windows_path(raw_query, base_path)
+        if resolved is None:
+            return ()
+        has_trailing_separator = raw_query.endswith(("\\", "/"))
+        parent = resolved if has_trailing_separator else ntpath.dirname(resolved)
+        prefix = "" if has_trailing_separator else ntpath.basename(resolved).casefold()
+        if is_windows_drives_root(parent):
+            return _list_windows_drive_candidates(prefix)
+        if not os.path.isdir(parent):
+            return ()
+        matches: list[str] = []
+        try:
+            for child in os.scandir(parent):
+                try:
+                    if directories_only and not child.is_dir():
+                        continue
+                except OSError:
+                    continue
+                if prefix and not child.name.casefold().startswith(prefix):
+                    continue
+                matches.append(normalize_windows_path(child.path))
+        except (OSError, PermissionError):
+            return ()
+        matches.sort(key=lambda path: (ntpath.basename(path).casefold(), path.casefold()))
+        return tuple(matches)
 
     resolved = _resolve_input_path(raw_query, base_path)
     if resolved is None:
@@ -81,7 +130,7 @@ def _list_matching_entry_paths(
 
             if prefix and not child.name.casefold().startswith(prefix):
                 continue
-            matches.append(str(child.resolve()))
+            matches.append(normalize_windows_path(str(child.resolve())))
     except (OSError, PermissionError):
         return ()
 
@@ -99,6 +148,20 @@ def format_go_to_path_completion(
     """Render a selected go-to-path completion in the user's current path style."""
 
     raw_query = query.strip()
+    if _uses_windows_path_rules(base_path, raw_query):
+        normalized_path = normalize_windows_path(path)
+        if raw_query.startswith("~"):
+            rendered = normalized_path
+        elif raw_query.startswith(("\\", "/")) or ":" in raw_query[:3]:
+            rendered = normalized_path
+        elif is_windows_drives_root(base_path) or is_windows_drive_root(normalized_path):
+            rendered = normalized_path
+        else:
+            rendered = ntpath.relpath(normalized_path, normalize_windows_path(base_path))
+        if append_separator and not rendered.endswith("\\"):
+            rendered = f"{rendered.rstrip('\\')}\\"
+        return rendered
+
     normalized_path = str(Path(path).resolve())
     if raw_query.startswith("~"):
         home = os.path.expanduser("~")
@@ -125,13 +188,24 @@ def format_go_to_path_completion(
 def expand_and_validate_path(query: str, base_path: str) -> str | None:
     """Expand ~, ., .. and validate path exists and is a directory."""
 
+    if _uses_windows_path_rules(base_path, query):
+        expanded = expand_windows_path(query, base_path)
+        if expanded is None:
+            return None
+        try:
+            if not os.path.isdir(expanded):
+                return None
+            return normalize_windows_path(expanded)
+        except (OSError, ValueError, RuntimeError):
+            return None
+
     expanded = _resolve_input_path(query, base_path)
     if expanded is None:
         return None
     try:
         if not expanded.exists() or not expanded.is_dir():
             return None
-        return str(expanded)
+        return normalize_windows_path(str(expanded))
     except (OSError, ValueError, RuntimeError):
         return None
 
@@ -140,17 +214,18 @@ def normalize_selected_paths(
     selected_paths: frozenset[str],
     entries: tuple[DirectoryEntryState, ...],
 ) -> frozenset[str]:
-    entry_paths = {entry.path for entry in entries}
-    return frozenset(path for path in selected_paths if path in entry_paths)
+    return frozenset(
+        path
+        for path in selected_paths
+        if any(paths_equal(path, entry.path) for entry in entries)
+    )
 
 
 def normalize_selection_anchor_path(
     anchor_path: str | None,
     visible_paths: tuple[str, ...],
 ) -> str | None:
-    if anchor_path in visible_paths:
-        return anchor_path
-    return None
+    return _find_visible_path(anchor_path, visible_paths)
 
 
 def move_cursor(
@@ -161,13 +236,12 @@ def move_cursor(
     if not visible_paths:
         return None
 
-    if current_path in visible_paths:
-        current_index = visible_paths.index(current_path)
-    else:
+    current_index = _find_visible_path_index(current_path, visible_paths)
+    if current_index is None:
         current_index = 0
 
     next_index = max(0, min(len(visible_paths) - 1, current_index + delta))
-    return visible_paths[next_index]
+    return comparable_path(visible_paths[next_index])
 
 
 def select_range_paths(
@@ -175,8 +249,10 @@ def select_range_paths(
     cursor_path: str,
     visible_paths: tuple[str, ...],
 ) -> frozenset[str]:
-    anchor_index = visible_paths.index(anchor_path)
-    cursor_index = visible_paths.index(cursor_path)
+    anchor_index = _find_visible_path_index(anchor_path, visible_paths)
+    cursor_index = _find_visible_path_index(cursor_path, visible_paths)
+    if anchor_index is None or cursor_index is None:
+        return frozenset()
     start = min(anchor_index, cursor_index)
     end = max(anchor_index, cursor_index)
     return frozenset(visible_paths[start : end + 1])
@@ -186,12 +262,12 @@ def normalize_cursor_path(
     entries: tuple[DirectoryEntryState, ...],
     current_cursor: str | None,
 ) -> str | None:
-    entry_paths = {entry.path for entry in entries}
-    if current_cursor in entry_paths:
-        return current_cursor
+    for entry in entries:
+        if paths_equal(current_cursor, entry.path):
+            return comparable_path(entry.path)
     if not entries:
         return None
-    return entries[0].path
+    return comparable_path(entries[0].path)
 
 
 def filter_file_search_results(
@@ -222,3 +298,39 @@ def _resolve_input_path(query: str, base_path: str) -> Path | None:
         return candidate.resolve(strict=False)
     except (OSError, ValueError, RuntimeError):
         return None
+
+
+def _list_windows_drive_candidates(prefix: str) -> tuple[str, ...]:
+    matches = tuple(
+        drive
+        for drive in list_windows_drive_paths()
+        if not prefix or drive[0].casefold().startswith(prefix)
+    )
+    return tuple(sorted(matches, key=lambda drive: drive.casefold()))
+
+
+def _uses_windows_path_rules(base_path: str, query: str) -> bool:
+    if is_windows_drives_root(base_path) or is_windows_path(base_path):
+        return True
+    normalized_query = query.strip().replace("/", "\\")
+    if not normalized_query:
+        return False
+    if normalized_query.startswith("\\"):
+        return True
+    return bool(ntpath.splitdrive(normalized_query)[0])
+
+
+def _find_visible_path(path: str | None, visible_paths: tuple[str, ...]) -> str | None:
+    index = _find_visible_path_index(path, visible_paths)
+    if index is None:
+        return None
+    return comparable_path(visible_paths[index])
+
+
+def _find_visible_path_index(path: str | None, visible_paths: tuple[str, ...]) -> int | None:
+    if path is None:
+        return None
+    for index, visible_path in enumerate(visible_paths):
+        if paths_equal(path, visible_path):
+            return index
+    return None

--- a/src/zivo/state/reducer_pending_input.py
+++ b/src/zivo/state/reducer_pending_input.py
@@ -11,6 +11,7 @@ from zivo.models import (
     ExtractArchiveRequest,
     RenameRequest,
 )
+from zivo.windows_paths import join_path, resolve_parent_directory_path
 
 from .reducer_path_helpers import (
     current_entry_paths,
@@ -100,7 +101,7 @@ def validate_pending_input(state, *, is_macos: bool) -> str | None:
             if existing_name_cf == name_cf and existing_path != current_target_path:
                 return f"An entry named '{name}' already exists"
     else:
-        candidate_path = str(Path(parent_path) / name)
+        candidate_path = join_path(parent_path, name)
         if candidate_path in existing_paths and candidate_path != current_target_path:
             return f"An entry named '{name}' already exists"
     return None
@@ -213,8 +214,8 @@ def pending_input_parent_and_target(state) -> tuple[str | None, str | None]:
     if state.pending_input is None:
         return (None, None)
     if state.ui_mode == "RENAME" and state.pending_input.target_path is not None:
-        target_path = Path(state.pending_input.target_path)
-        return (str(target_path.parent), str(target_path))
+        _, parent_path = resolve_parent_directory_path(state.pending_input.target_path)
+        return (parent_path, state.pending_input.target_path)
     if state.ui_mode == "CREATE":
         if state.layout_mode == "transfer":
             active_pane = _active_transfer_pane(state)
@@ -222,8 +223,8 @@ def pending_input_parent_and_target(state) -> tuple[str | None, str | None]:
                 return (active_pane.current_path, None)
         return (state.current_pane.directory_path, None)
     if state.ui_mode == "EXTRACT" and state.pending_input.extract_source_path is not None:
-        source_path = Path(state.pending_input.extract_source_path)
-        return (str(source_path.parent), None)
+        _, parent_path = resolve_parent_directory_path(state.pending_input.extract_source_path)
+        return (parent_path, None)
     if state.ui_mode == "ZIP" and state.pending_input.zip_source_paths is not None:
         return (state.current_pane.directory_path, None)
     if state.ui_mode == "SYMLINK" and state.pending_input.symlink_source_path is not None:
@@ -283,11 +284,14 @@ def complete_pending_input_path(state) -> str | None:
     if not candidates:
         return None
     rendered = tuple(
-        format_go_to_path_completion(
-            candidate,
+        _normalize_pending_input_completion(
+            format_go_to_path_completion(
+                candidate,
+                query,
+                base_path,
+                append_separator=os.path.isdir(candidate),
+            ),
             query,
-            base_path,
-            append_separator=Path(candidate).is_dir(),
         )
         for candidate in candidates
     )
@@ -295,3 +299,14 @@ def complete_pending_input_path(state) -> str | None:
         return rendered[0]
     prefix = longest_common_completion_prefix(rendered)
     return prefix if prefix and prefix != query else None
+
+
+def _normalize_pending_input_completion(completion: str, query: str) -> str:
+    stripped_query = query.strip()
+    if (
+        "\\" not in stripped_query
+        and ":" not in stripped_query[:3]
+        and not stripped_query.startswith(("/", "\\"))
+    ):
+        return completion.replace("\\", "/")
+    return completion

--- a/src/zivo/state/reducer_requests.py
+++ b/src/zivo/state/reducer_requests.py
@@ -17,6 +17,11 @@ from zivo.models import (
     RenameRequest,
     UndoEntry,
 )
+from zivo.windows_paths import (
+    is_windows_drives_root,
+    is_windows_path,
+    normalize_windows_path,
+)
 
 from .actions import Action
 from .effects import (
@@ -32,7 +37,7 @@ from .effects import (
     RunZipCompressEffect,
     RunZipCompressPreparationEffect,
 )
-from .models import HistoryState, NotificationState
+from .models import HistoryState, NotificationState, resolve_parent_directory_path
 
 ReducerFn = Callable[[object, Action], ReduceResult]
 
@@ -237,11 +242,25 @@ def browser_snapshot_invalidation_paths(
     path: str,
     *extra_paths: str | None,
 ) -> tuple[str, ...]:
-    resolved_path = str(Path(path).expanduser().resolve())
-    paths = [resolved_path, str(Path(resolved_path).parent)]
+    def _normalize(path_value: str) -> str:
+        if is_windows_path(path_value):
+            return normalize_windows_path(path_value)
+        return str(Path(path_value).expanduser().resolve())
+
+    if is_windows_drives_root(path):
+        paths = [path]
+    else:
+        resolved_path = _normalize(path)
+        _, parent_path = resolve_parent_directory_path(resolved_path)
+        paths = [resolved_path]
+        if parent_path is not None:
+            paths.append(parent_path)
     for extra_path in extra_paths:
         if extra_path is not None:
-            paths.append(str(Path(extra_path).expanduser().resolve()))
+            if is_windows_drives_root(extra_path):
+                paths.append(extra_path)
+            else:
+                paths.append(_normalize(extra_path))
     return tuple(dict.fromkeys(paths))
 
 

--- a/src/zivo/state/reducer_transfer.py
+++ b/src/zivo/state/reducer_transfer.py
@@ -5,6 +5,13 @@ from pathlib import Path
 from typing import Callable
 
 from zivo.models import PasteRequest
+from zivo.windows_paths import (
+    comparable_path,
+    is_posix_path,
+    is_windows_drives_root,
+    is_windows_path,
+    paths_equal,
+)
 
 from .actions import (
     Action,
@@ -28,7 +35,14 @@ from .actions import (
 )
 from .effects import LoadTransferPaneEffect, ReduceResult
 from .entry_state_helpers import select_visible_entry_states
-from .models import AppState, NotificationState, PaneState, TransferPaneId, TransferPaneState
+from .models import (
+    AppState,
+    NotificationState,
+    PaneState,
+    TransferPaneId,
+    TransferPaneState,
+    resolve_parent_directory_path,
+)
 from .reducer_common import finalize, move_cursor, run_paste_request, select_range_paths
 from .reducer_requests import browser_snapshot_invalidation_paths, build_history_after_snapshot_load
 
@@ -210,10 +224,13 @@ def _handle_move_transfer_cursor_by_page(
     if not action.visible_paths:
         return finalize(state)
     transfer = _require_transfer_pane(state, state.active_transfer_pane)
-    current_index = (
-        action.visible_paths.index(transfer.pane.cursor_path)
-        if transfer.pane.cursor_path in action.visible_paths
-        else 0
+    current_index = next(
+        (
+            index
+            for index, path in enumerate(action.visible_paths)
+            if paths_equal(path, transfer.pane.cursor_path)
+        ),
+        0,
     )
     if action.direction == "up":
         next_index = max(0, current_index - action.page_size)
@@ -226,7 +243,7 @@ def _handle_move_transfer_cursor_by_page(
                 transfer,
                 pane=replace(
                     transfer.pane,
-                    cursor_path=action.visible_paths[next_index],
+                    cursor_path=comparable_path(action.visible_paths[next_index]),
                     selection_anchor_path=None,
                 ),
             ),
@@ -243,15 +260,21 @@ def _handle_move_transfer_cursor_and_select_range(
     if not action.visible_paths:
         return finalize(state)
     transfer = _require_transfer_pane(state, state.active_transfer_pane)
-    base_cursor_path = (
-        transfer.pane.cursor_path
-        if transfer.pane.cursor_path in action.visible_paths
-        else action.visible_paths[0]
+    base_cursor_path = next(
+        (
+            comparable_path(path)
+            for path in action.visible_paths
+            if paths_equal(path, transfer.pane.cursor_path)
+        ),
+        comparable_path(action.visible_paths[0]),
     )
-    anchor_path = (
-        transfer.pane.selection_anchor_path
-        if transfer.pane.selection_anchor_path in action.visible_paths
-        else base_cursor_path
+    anchor_path = next(
+        (
+            comparable_path(path)
+            for path in action.visible_paths
+            if paths_equal(path, transfer.pane.selection_anchor_path)
+        ),
+        base_cursor_path,
     )
     cursor_path = move_cursor(base_cursor_path, action.visible_paths, action.delta)
     if cursor_path is None:
@@ -363,11 +386,16 @@ def _handle_enter_transfer_directory(
     entry = _transfer_cursor_entry(state, transfer)
     if entry is None or entry.kind != "dir":
         return finalize(state)
+    invalidate_paths = (
+        (entry.path, transfer.current_path)
+        if is_posix_path(entry.path)
+        else browser_snapshot_invalidation_paths(entry.path)
+    )
     return request_transfer_pane_snapshot(
         state,
         state.active_transfer_pane,
         entry.path,
-        invalidate_paths=browser_snapshot_invalidation_paths(entry.path),
+        invalidate_paths=invalidate_paths,
     )
 
 
@@ -378,7 +406,14 @@ def _handle_go_to_transfer_parent(
 ) -> ReduceResult:
     del action, reduce_state
     transfer = _require_transfer_pane(state, state.active_transfer_pane)
-    parent_path = str(Path(transfer.current_path).parent)
+    if is_windows_drives_root(transfer.current_path):
+        return finalize(state)
+    if is_windows_path(transfer.current_path):
+        _, parent_path = resolve_parent_directory_path(transfer.current_path)
+        if parent_path is None:
+            return finalize(state)
+    else:
+        parent_path = str(Path(transfer.current_path).parent)
     return request_transfer_pane_snapshot(
         state,
         state.active_transfer_pane,

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -110,7 +110,7 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
     )
     shell = ThreePaneShellData(
         tab_bar=select_tab_bar_state(state),
-        current_path=state.current_path,
+        current_path=state.current_pane.directory_path,
         parent_entries=select_parent_entries(state),
         current_entries=(
             _select_current_pane_entries(

--- a/src/zivo/ui/current_path_bar.py
+++ b/src/zivo/ui/current_path_bar.py
@@ -2,6 +2,8 @@
 
 from textual.widgets import Static
 
+from zivo.windows_paths import display_path
+
 
 class CurrentPathBar(Static):
     """Single-line widget that renders the active directory path."""
@@ -20,7 +22,7 @@ class CurrentPathBar(Static):
     def format_path(path: str) -> str:
         """Build the visible current-path line."""
 
-        return f"Current Path: {path}"
+        return f"Current Path: {display_path(path)}"
 
     def set_path(self, path: str) -> None:
         """Update the rendered path without remounting the widget."""

--- a/src/zivo/windows_paths.py
+++ b/src/zivo/windows_paths.py
@@ -1,0 +1,218 @@
+"""Windows-specific virtual drive root helpers."""
+
+from __future__ import annotations
+
+import ntpath
+import os
+import platform
+import posixpath
+import re
+from string import ascii_uppercase
+
+WINDOWS_DRIVES_ROOT = "::zivo::windows-drives::"
+WINDOWS_DRIVES_LABEL = "Drives"
+_WINDOWS_DRIVE_PATTERN = re.compile(r"^[a-zA-Z]:([\\/])?$")
+_WINDOWS_DRIVE_PREFIX_PATTERN = re.compile(r"^[a-zA-Z]:?$")
+
+
+class ComparableWindowsPath(str):
+    """String subclass that compares Windows paths after normalization."""
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, str) and is_windows_path(other):
+            return normalize_windows_path(str(self)) == normalize_windows_path(other)
+        return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return str.__hash__(self)
+
+
+def is_windows_platform() -> bool:
+    """Return True when Windows-specific path behavior should be enabled."""
+
+    return platform.system() == "Windows"
+
+
+def is_windows_drives_root(path: str) -> bool:
+    """Return True when the path points to the virtual Windows drive listing."""
+
+    return path == WINDOWS_DRIVES_ROOT
+
+
+def is_windows_drive_root(path: str) -> bool:
+    """Return True for drive-root paths such as ``C:\\``."""
+
+    if not path:
+        return False
+    return _WINDOWS_DRIVE_PATTERN.fullmatch(path.replace("/", "\\")) is not None
+
+
+def is_windows_path(path: str) -> bool:
+    """Return True when the path uses Windows drive or UNC syntax."""
+
+    if not path:
+        return False
+    normalized_path = path.replace("/", "\\")
+    drive, _ = ntpath.splitdrive(normalized_path)
+    return bool(drive) or normalized_path.startswith("\\\\")
+
+
+def is_posix_path(path: str) -> bool:
+    """Return True when the path uses rooted POSIX syntax."""
+
+    return bool(path) and path.startswith("/")
+
+
+def normalize_windows_path(path: str) -> str:
+    """Normalize drive-root paths without depending on host OS path parsing."""
+
+    if is_windows_drives_root(path):
+        return path
+    if not is_windows_path(path):
+        return path
+    candidate = path.replace("/", "\\")
+    drive, tail = ntpath.splitdrive(candidate)
+    if not drive:
+        return path
+    if tail in ("", "."):
+        return f"{drive}\\"
+    return ntpath.normpath(candidate)
+
+
+def display_path(path: str) -> str:
+    """Render a user-facing path label."""
+
+    if is_windows_drives_root(path):
+        return WINDOWS_DRIVES_LABEL
+    return path
+
+
+def comparable_path(path: str | None) -> str | None:
+    """Wrap Windows paths for direct-equality comparisons without changing display."""
+
+    if path is None or not is_windows_path(path):
+        return path
+    return ComparableWindowsPath(path)
+
+
+def paths_equal(left: str | None, right: str | None) -> bool:
+    """Compare paths while treating Windows separators as equivalent."""
+
+    if left is None or right is None:
+        return left == right
+    if is_windows_path(left) and is_windows_path(right):
+        return normalize_windows_path(left) == normalize_windows_path(right)
+    return left == right
+
+
+def list_windows_drive_paths() -> tuple[str, ...]:
+    """Return available Windows drive roots."""
+
+    if not is_windows_platform():
+        return ()
+    drives = tuple(
+        f"{letter}:\\"
+        for letter in ascii_uppercase
+        if os.path.exists(f"{letter}:\\")
+    )
+    return drives
+
+
+def resolve_parent_directory_path(path: str) -> tuple[str, str | None]:
+    """Return the resolved path and its distinct parent, if one exists."""
+
+    if is_windows_drives_root(path):
+        return WINDOWS_DRIVES_ROOT, None
+
+    if is_windows_path(path):
+        normalized_path = normalize_windows_path(path)
+        if is_windows_drive_root(normalized_path):
+            return normalized_path, WINDOWS_DRIVES_ROOT
+        parent_path = ntpath.dirname(normalized_path)
+        if not parent_path or parent_path == normalized_path:
+            return normalized_path, None
+        return normalized_path, normalize_windows_path(parent_path)
+
+    if is_posix_path(path):
+        normalized_path = posixpath.normpath(path) or "/"
+        if normalized_path == "/":
+            return "/", None
+        parent_path = posixpath.dirname(normalized_path) or "/"
+        return normalized_path, parent_path
+
+    from pathlib import Path
+
+    resolved_path = Path(path).expanduser().resolve()
+    parent_path = resolved_path.parent
+    if parent_path == resolved_path:
+        return str(resolved_path), None
+    return str(resolved_path), str(parent_path)
+
+
+def expand_windows_path(query: str, base_path: str) -> str | None:
+    """Resolve a Windows path query independently from host OS semantics."""
+
+    raw_query = os.path.expanduser(query.strip())
+    if not raw_query:
+        return None
+    normalized_query = raw_query.replace("/", "\\")
+    if not (
+        is_windows_drives_root(base_path)
+        or is_windows_path(base_path)
+        or normalized_query.startswith("\\")
+        or _WINDOWS_DRIVE_PREFIX_PATTERN.fullmatch(normalized_query) is not None
+    ):
+        return None
+
+    if _WINDOWS_DRIVE_PATTERN.fullmatch(normalized_query):
+        return normalize_windows_path(normalized_query)
+
+    if normalized_query.startswith("\\\\"):
+        return ntpath.normpath(normalized_query)
+
+    drive, _ = ntpath.splitdrive(normalized_query)
+    if drive:
+        return ntpath.normpath(normalized_query)
+
+    if is_windows_drives_root(base_path):
+        return None
+
+    normalized_base = normalize_windows_path(base_path)
+    if not ntpath.splitdrive(normalized_base)[0]:
+        return None
+    return ntpath.normpath(ntpath.join(normalized_base, normalized_query))
+
+
+def split_windows_completion_query(query: str) -> tuple[str, str] | None:
+    """Return ``(parent, prefix)`` for Windows drive completion shortcuts."""
+
+    raw_query = query.strip().replace("/", "\\")
+    if not raw_query:
+        return WINDOWS_DRIVES_ROOT, ""
+    if _WINDOWS_DRIVE_PREFIX_PATTERN.fullmatch(raw_query):
+        return WINDOWS_DRIVES_ROOT, raw_query.rstrip(":").casefold()
+    return None
+
+
+def basename(path: str) -> str:
+    """Return the final path segment while preserving input path style."""
+
+    if is_windows_path(path):
+        return ntpath.basename(normalize_windows_path(path))
+    if is_posix_path(path):
+        return posixpath.basename(path)
+    from pathlib import Path
+
+    return Path(path).name
+
+
+def join_path(base_path: str, name: str) -> str:
+    """Join a child name while preserving input path style."""
+
+    if is_windows_path(base_path):
+        return normalize_windows_path(ntpath.join(normalize_windows_path(base_path), name))
+    if is_posix_path(base_path):
+        return posixpath.join(base_path, name)
+    from pathlib import Path
+
+    return str(Path(base_path) / name)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,7 +88,7 @@ from zivo.ui import (
     TabBar,
 )
 from zivo.ui.panes import MainPane
-from zivo.windows_paths import WINDOWS_DRIVES_ROOT
+from zivo.windows_paths import WINDOWS_DRIVES_ROOT, is_windows_path, paths_equal
 
 skip_if_windows_split_terminal_unsupported = pytest.mark.skipif(
     os.name == "nt",
@@ -586,11 +586,13 @@ async def _wait_for_transfer_right_table(app, timeout: float = 0.5) -> DataTable
 
 
 async def _wait_for_path(app, expected_path: str, timeout: float = 0.5) -> None:
-    resolved_expected = str(Path(expected_path).resolve())
+    resolved_expected = (
+        expected_path if is_windows_path(expected_path) else str(Path(expected_path).resolve())
+    )
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
         if (
-            app.app_state.current_path == resolved_expected
+            paths_equal(app.app_state.current_path, resolved_expected)
             and app.app_state.pending_browser_snapshot_request_id is None
         ):
             return
@@ -600,10 +602,12 @@ async def _wait_for_path(app, expected_path: str, timeout: float = 0.5) -> None:
 
 
 async def _wait_for_cursor_path(app, expected_path: str, timeout: float = 0.5) -> None:
-    resolved_expected = str(Path(expected_path).resolve())
+    resolved_expected = (
+        expected_path if is_windows_path(expected_path) else str(Path(expected_path).resolve())
+    )
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
-        if app.app_state.current_pane.cursor_path == resolved_expected:
+        if paths_equal(app.app_state.current_pane.cursor_path, resolved_expected):
             return
         if asyncio.get_running_loop().time() >= deadline:
             raise AssertionError(f"cursor path did not become {expected_path}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,6 +88,7 @@ from zivo.ui import (
     TabBar,
 )
 from zivo.ui.panes import MainPane
+from zivo.windows_paths import WINDOWS_DRIVES_ROOT
 
 skip_if_windows_split_terminal_unsupported = pytest.mark.skipif(
     os.name == "nt",
@@ -1913,6 +1914,61 @@ async def test_app_left_can_move_above_initial_directory() -> None:
         await _wait_for_path(app, grandparent_path)
 
         assert app.app_state.current_pane.cursor_path == parent_path
+
+
+@pytest.mark.asyncio
+async def test_app_left_on_windows_drive_root_returns_to_drive_list(monkeypatch) -> None:
+    monkeypatch.setattr("zivo.windows_paths.platform.system", lambda: "Windows")
+    drive_entries = (
+        DirectoryEntryState("C:\\", "C:\\", "dir"),
+        DirectoryEntryState("D:\\", "D:\\", "dir"),
+    )
+    c_drive_entries = (
+        DirectoryEntryState("C:\\Users", "Users", "dir"),
+        DirectoryEntryState("C:\\Temp", "Temp", "dir"),
+    )
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            WINDOWS_DRIVES_ROOT: BrowserSnapshot(
+                current_path=WINDOWS_DRIVES_ROOT,
+                parent_pane=PaneState(
+                    directory_path=WINDOWS_DRIVES_ROOT,
+                    entries=(),
+                ),
+                current_pane=PaneState(
+                    directory_path=WINDOWS_DRIVES_ROOT,
+                    entries=drive_entries,
+                    cursor_path="C:\\",
+                ),
+                child_pane=PaneState(directory_path="C:\\", entries=c_drive_entries),
+            ),
+            "C:\\": BrowserSnapshot(
+                current_path="C:\\",
+                parent_pane=PaneState(
+                    directory_path=WINDOWS_DRIVES_ROOT,
+                    entries=drive_entries,
+                    cursor_path="C:\\",
+                ),
+                current_pane=PaneState(
+                    directory_path="C:\\",
+                    entries=c_drive_entries,
+                    cursor_path="C:\\Users",
+                ),
+                child_pane=PaneState(directory_path="C:\\Users", entries=()),
+            ),
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path="C:\\")
+
+    async with app.run_test() as pilot:
+        await _wait_for_path(app, "C:\\")
+        current_path_bar = await _wait_for_current_path_bar(app)
+        assert str(current_path_bar.renderable) == "Current Path: C:\\"
+
+        await pilot.press("left")
+        await _wait_for_path(app, WINDOWS_DRIVES_ROOT)
+        assert str(current_path_bar.renderable) == "Current Path: Drives"
+        assert app.app_state.current_pane.cursor_path == "C:\\"
 
 
 @pytest.mark.asyncio

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -93,6 +93,7 @@ from zivo.state.actions import (
     ToggleSelection,
     ToggleSplitTerminal,
 )
+from zivo.windows_paths import WINDOWS_DRIVES_ROOT
 
 
 def _reduce_state(state, action):
@@ -613,6 +614,36 @@ def test_go_to_home_directory_navigates_to_home() -> None:
     # Home directory path will be expanded and resolved
     assert result.effects[0].blocking is True
     assert str(Path.home()) in result.effects[0].path
+
+
+def test_go_to_parent_directory_from_windows_drive_root_requests_drive_list(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("zivo.windows_paths.platform.system", lambda: "Windows")
+    state = replace(
+        build_initial_app_state(),
+        current_path="C:\\",
+        parent_pane=PaneState(
+            directory_path=WINDOWS_DRIVES_ROOT,
+            entries=(
+                DirectoryEntryState("C:\\", "C:\\", "dir"),
+                DirectoryEntryState("D:\\", "D:\\", "dir"),
+            ),
+            cursor_path="C:\\",
+        ),
+        current_pane=PaneState(
+            directory_path="C:\\",
+            entries=(DirectoryEntryState("C:\\Users", "Users", "dir"),),
+            cursor_path="C:\\Users",
+        ),
+        child_pane=PaneState(directory_path="C:\\Users", entries=()),
+    )
+
+    result = reduce_app_state(state, GoToParentDirectory())
+
+    assert len(result.effects) == 1
+    assert result.effects[0].path == WINDOWS_DRIVES_ROOT
+    assert result.effects[0].cursor_path == "C:\\"
 
 def test_reload_directory_requests_snapshot_with_current_cursor() -> None:
     state = build_initial_app_state()

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from pathlib import Path
 
 import zivo.state.command_palette as command_palette_module
+import zivo.state.reducer_palette as reducer_palette_module
 from tests.state_test_helpers import reduce_state
 from zivo.models import (
     AppConfig,
@@ -45,6 +46,7 @@ from zivo.state.actions import (
     SubmitCommandPalette,
     ToggleTransferMode,
 )
+from zivo.windows_paths import WINDOWS_DRIVES_ROOT
 
 
 def _reduce_state(state, action):
@@ -226,6 +228,22 @@ def test_begin_go_to_path_enters_palette_mode() -> None:
 
     assert next_state.ui_mode == "PALETTE"
     assert next_state.command_palette == CommandPaletteState(source="go_to_path")
+
+
+def test_begin_go_to_path_on_windows_prefills_drive_candidates(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reducer_palette_module,
+        "list_windows_drive_paths",
+        lambda: ("C:\\", "D:\\"),
+    )
+
+    next_state = _reduce_state(
+        replace(build_initial_app_state(), current_path="C:\\"),
+        BeginGoToPath(),
+    )
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.go_to_path_candidates == ("C:\\", "D:\\")
 
 def test_submit_history_palette_navigates_to_selected_directory() -> None:
     state = build_initial_app_state()
@@ -507,6 +525,23 @@ def test_submit_go_to_path_palette_with_invalid_directory_shows_error() -> None:
         level="error",
         message="Path does not exist or is not a directory",
     )
+
+
+def test_set_command_palette_query_updates_windows_drive_candidates(monkeypatch) -> None:
+    monkeypatch.setattr("zivo.windows_paths.platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "zivo.state.reducer_path_helpers.list_windows_drive_paths",
+        lambda: ("C:\\", "D:\\"),
+    )
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path=WINDOWS_DRIVES_ROOT),
+        BeginGoToPath(),
+    )
+
+    next_state = _reduce_state(state, SetCommandPaletteQuery("d"))
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.go_to_path_candidates == ("D:\\",)
     state = _reduce_state(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),
         BeginCommandPalette(),

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "zivo"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyte" },


### PR DESCRIPTION
## Summary
- add a virtual Windows drives root and allow `?` from drive roots such as `C:\` to return to the drive list
- support Windows drive candidates in `Go to path` and preserve cross-style path comparisons in navigation, snapshot loading, and transfer panes
- add reducer and app tests for drive-list navigation and Windows path completion, and document the native Windows behavior

## Test
- `uv run ruff check .`
- `uv run pytest`

## Related
- #742
