### PR TITLE
feat: Windows foreground terminal launch (closes #731)

### DIFF
--- a/src/zivo/adapters/external_launcher.py
+++ b/src/zivo/adapters/external_launcher.py
@@ -323,9 +323,10 @@ class LocalExternalLaunchAdapter:
 
     def _foreground_terminal_command(self, platform_kind: PlatformKind) -> tuple[str, ...]:
         if platform_kind == "windows":
-            raise OSError(
-                "Foreground terminal launch is unavailable on Windows; use window mode instead"
-            )
+            powershell = self.command_available("powershell.exe")
+            if powershell is not None:
+                return (powershell, "-NoExit", "-NoLogo")
+            return ("cmd.exe", "/k")
         shell = self.environment_variable("SHELL")
         if shell:
             try:

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -332,15 +332,35 @@ def test_local_external_launch_adapter_runs_terminal_in_foreground_mode(tmp_path
     assert runner.executed == [(("bash", "-i"), str(tmp_path))]
 
 
-def test_local_external_launch_adapter_rejects_windows_foreground_terminal_mode(tmp_path) -> None:
+def test_windows_foreground_terminal_uses_powershell(tmp_path) -> None:
+    runner = StubForegroundRunner()
+    pwsh = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
     adapter = LocalExternalLaunchAdapter(
         system_name_resolver=lambda: "Windows",
-        command_available=lambda command: command,
-        foreground_command_runner=StubForegroundRunner(),
+        command_available=lambda command: pwsh
+        if command == "powershell.exe"
+        else None,
+        foreground_command_runner=runner,
     )
 
-    with pytest.raises(OSError, match="unavailable on Windows; use window mode instead"):
-        adapter.open_terminal(str(tmp_path), launch_mode="foreground")
+    adapter.open_terminal(str(tmp_path), launch_mode="foreground")
+
+    assert runner.executed == [
+        ((pwsh, "-NoExit", "-NoLogo"), str(tmp_path))
+    ]
+
+
+def test_windows_foreground_terminal_falls_back_to_cmd(tmp_path) -> None:
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: None,
+        foreground_command_runner=runner,
+    )
+
+    adapter.open_terminal(str(tmp_path), launch_mode="foreground")
+
+    assert runner.executed == [(("cmd.exe", "/k"), str(tmp_path))]
 
 
 def test_local_external_launch_adapter_copies_to_clipboard_on_linux() -> None:
@@ -531,6 +551,32 @@ def test_live_external_launch_service_opens_terminal_in_foreground_mode(tmp_path
     )
 
     assert runner.executed == [(("bash", "-i"), path)]
+
+
+def test_live_external_launch_service_opens_terminal_in_windows_foreground_mode(tmp_path) -> None:
+    runner = StubForegroundRunner()
+    pwsh = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: pwsh
+        if command == "powershell.exe"
+        else None,
+        foreground_command_runner=runner,
+    )
+    service = LiveExternalLaunchService(adapter=adapter)
+    path = str(tmp_path.resolve())
+
+    service.execute(
+        ExternalLaunchRequest(
+            kind="open_terminal",
+            path=path,
+            terminal_launch_mode="foreground",
+        )
+    )
+
+    assert runner.executed == [
+        ((pwsh, "-NoExit", "-NoLogo"), path)
+    ]
 
 
 def test_live_external_launch_service_copies_paths_with_expected_payload() -> None:


### PR DESCRIPTION
## Summary

- Windows ネイティブ環境で Open terminal の foreground mode を実装
- _foreground_terminal_command() の Windows 分岐を OSError から実際の起動処理に差し替え
- 優先順位: powershell.exe -NoExit -NoLogo → cmd.exe /k
- 既存の _run_foreground_command() 経由でカレントディレクトリも正しく維持

## Related Issue

Closes #731

## Test Results

- test_windows_foreground_terminal_uses_powershell: powershell.exe 優先の確認
- test_windows_foreground_terminal_falls_back_to_cmd: cmd.exe へのフォールバック確認
- test_live_external_launch_service_opens_terminal_in_windows_foreground_mode: Service 経由の起動確認
- 全 1135 tests passed, 5 skipped, ruff lint 通過

## Notes

- Textual の app.suspend() が Windows で動作するかは未確認のため、suspend 失敗時は既存の SuspendNotSupported エラーハンドリングに委ねる