### PR TITLE
Implement Empty trash for Windows via PowerShell Clear-RecycleBin (#737)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -144,7 +144,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-Windows ネイティブでは、現時点では起動、基本的なブラウズ、`Move to trash` のような主要ファイル操作を主な対象としています。埋め込み split terminal のような POSIX 前提の機能は引き続き利用できず、trash restore や `Empty trash` も未対応のため、Windows ネイティブ実行向けの依存ツール案内は対象外です。
+Windows ネイティブでは、現時点では起動、基本的なブラウズ、`Move to trash` のような主要ファイル操作を主な対象としています。埋め込み split terminal のような POSIX 前提の機能は引き続き利用できず、trash restore は未対応のため、Windows ネイティブ実行向けの依存ツール案内は対象外です。
 
 macOS では、使用しているターミナルアプリに **フルディスクアクセス** 権限を付与してください。**システム設定 > プライバシーとセキュリティ > フルディスクアクセス** を開き、zivo を実行するターミナルアプリ（Terminal.app、iTerm2、Alacritty など）を有効にしてください。この権限がない場合、`~/.Trash` などの保護されたディレクトリにアクセスする操作が失敗します。
 
@@ -362,7 +362,7 @@ Transferモードでは、アクティブな転送ペインで実行できるコ
 | `Open in editor` | 単一ファイルが選択中またはフォーカス中のとき | フォーカス中のファイルを `editor.command` -> `$EDITOR` -> 組み込み既定値の順でターミナルエディタで開きます。 |
 | `Copy path` | 対象が 1 件以上あるとき | 選択中のパス一覧、または未選択時はフォーカス中のパスをシステムクリップボードへコピーします。`C` でも実行できます。 |
 | `Move to trash` | 対象が 1 件以上あるとき | 選択中の項目、またはフォーカス項目をゴミ箱へ移動します（既定では確認あり、設定で変更可能）。Windows では `send2trash` 経由で Recycle Bin を使いますが、undo restore は利用できません。 |
-| `Empty trash` | 常に表示（Linux/macOSのみ） | ゴミ箱内のすべての項目を完全に削除します。実行前に確認ダイアログを表示します。Windows での対応はまだありません。 |
+| `Empty trash` | 常に表示 | ゴミ箱内のすべての項目を完全に削除します。実行前に確認ダイアログを表示します。Windows では PowerShell の `Clear-RecycleBin` を使用してごみ箱を空にします。 |
 | `Open in file manager` | 常に表示 | 現在ディレクトリを OS のファイルマネージャで開きます。`M` でも実行できます。 |
 | `Open terminal` | 常に表示 | `config.toml` の設定を優先しつつ、zivo の current directory を起点に外部ターミナルを起動します。`T` と `t` でも実行できます。 |
 | `Run shell command` | 常に表示 | 1 行シェルコマンド入力ダイアログを開き、現在ディレクトリでバックグラウンド実行します。完了後は先頭の出力行、または失敗要約を status bar に表示します。Windows では `powershell.exe`、次に `pwsh`、最後に `cmd.exe` を優先するため、構文は選ばれた Windows shell に従います。`!` でも実行できます。 |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ sudo apt install chafa pandoc poppler-utils ripgrep wslu
 brew install chafa pandoc poppler ripgrep
 ```
 
-On native Windows, zivo currently focuses on startup, basic browsing, and core file actions such as `Move to trash`. POSIX-oriented features such as the embedded split terminal are still unavailable there, and trash restore / `Empty trash` remain unsupported, so native Windows dependency guidance remains intentionally limited. Pressing `←` from a drive root such as `C:\` returns to a drive list so you can move to another drive without leaving zivo.
+On native Windows, zivo currently focuses on startup, basic browsing, and core file actions such as `Move to trash`. POSIX-oriented features such as the embedded split terminal are still unavailable there, and trash restore remains unsupported, so native Windows dependency guidance remains intentionally limited. Pressing `←` from a drive root such as `C:\` returns to a drive list so you can move to another drive without leaving zivo.
 
 On macOS, grant **Full Disk Access** to your terminal application. Open **System Settings > Privacy & Security > Full Disk Access** and enable the terminal app you use to run zivo (for example Terminal.app, iTerm2, or Alacritty). Without this permission, operations that access `~/.Trash` or other protected directories will fail.
 
@@ -358,7 +358,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Open in editor` | Exactly one file is selected or focused | Opens the focused file in a terminal editor, using `editor.command` -> `$EDITOR` -> built-in defaults. |
 | `Copy path` | At least one target is selected or focused | Copies the selected path list, or the focused path when nothing is selected, to the system clipboard. Also available with `C`. |
 | `Move to trash` | At least one target is selected or focused | Moves the selected items, or the focused item, to trash (confirmation is enabled by default and can be configured). On Windows this uses the Recycle Bin via `send2trash`, but undo restore is not available there. |
-| `Empty trash` | Always (Linux/macOS only) | Permanently deletes all items from the trash. Shows a confirmation dialog before emptying. Windows support is not available yet. |
+| `Empty trash` | Always | Permanently deletes all items from the trash. Shows a confirmation dialog before emptying. On Windows this uses PowerShell's `Clear-RecycleBin` to empty the Recycle Bin. |
 | `Open in file manager` | Always | Opens the current directory in the OS file manager. Also available with `M`. |
 | `Open terminal` | Always | Launches an external terminal rooted at zivo's current directory, using `config.toml` templates before built-in fallbacks. Also available with `T` and `t`. |
 | `Run shell command` | Always | Opens a one-line shell command dialog, runs the command in the current directory in the background, and returns the first output line or failure summary in the status bar. On Windows, zivo prefers `powershell.exe`, then `pwsh`, then `cmd.exe`, so command syntax follows the selected Windows shell rather than POSIX `sh`. Also available with `!`. |

--- a/src/zivo/services/trash_operations.py
+++ b/src/zivo/services/trash_operations.py
@@ -239,7 +239,15 @@ class WindowsTrashService:
         return None
 
     def empty_trash(self) -> tuple[int, str]:
-        return 0, "Empty trash is not supported on Windows yet"
+        result = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-Command", "Clear-RecycleBin -Force"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return 0, "Failed to empty Recycle Bin"
+        return 1, ""
 
     def capture_restorable_trash(
         self,

--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -672,7 +672,7 @@ def _transfer_single_target_entry(state: AppState):
 
 def _is_empty_trash_supported() -> bool:
     """Check if empty trash is supported on current platform."""
-    return platform.system() in ("Linux", "Darwin")
+    return platform.system() in ("Linux", "Darwin", "Windows")
 
 
 def _is_split_terminal_supported() -> bool:

--- a/src/zivo/state/reducer_mutations_common.py
+++ b/src/zivo/state/reducer_mutations_common.py
@@ -20,7 +20,7 @@ MutationHandler = Callable[[AppState, Action, ReducerFn], ReduceResult | None]
 _UNDO_STACK_LIMIT = 20
 
 
-def detect_platform() -> Literal["linux", "darwin"] | None:
+def detect_platform() -> Literal["linux", "darwin", "windows"] | None:
     """Detect the current platform."""
     import platform as platform_module
 
@@ -29,6 +29,8 @@ def detect_platform() -> Literal["linux", "darwin"] | None:
         return "linux"
     if system == "Darwin":
         return "darwin"
+    if system == "Windows":
+        return "windows"
     return None
 
 

--- a/src/zivo/state/reducer_mutations_delete.py
+++ b/src/zivo/state/reducer_mutations_delete.py
@@ -62,7 +62,7 @@ def _handle_begin_delete_targets(state, action, reduce_state):
 
 def _handle_begin_empty_trash(state, action, reduce_state):
     platform_kind = detect_platform()
-    if platform_kind not in ("linux", "darwin"):
+    if platform_kind not in ("linux", "darwin", "windows"):
         return finalize(
             replace(
                 state,

--- a/tests/test_services_trash_operations.py
+++ b/tests/test_services_trash_operations.py
@@ -287,11 +287,32 @@ def test_windows_trash_service_sends_to_trash_without_restore_metadata() -> None
     assert record is None
 
 
-def test_windows_trash_service_reports_empty_trash_as_unsupported() -> None:
+def test_windows_empty_trash_powershell_success(monkeypatch) -> None:
+    mock_run = MagicMock(return_value=MagicMock(returncode=0, stderr=""))
+    monkeypatch.setattr("zivo.services.trash_operations.subprocess.run", mock_run)
+
+    count, error = WindowsTrashService().empty_trash()
+
+    assert count == 1
+    assert error == ""
+    mock_run.assert_called_once_with(
+        ["powershell.exe", "-NoProfile", "-Command", "Clear-RecycleBin -Force"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_windows_empty_trash_powershell_failure(monkeypatch) -> None:
+    mock_run = MagicMock(
+        return_value=MagicMock(returncode=1, stderr="access denied")
+    )
+    monkeypatch.setattr("zivo.services.trash_operations.subprocess.run", mock_run)
+
     count, error = WindowsTrashService().empty_trash()
 
     assert count == 0
-    assert error == "Empty trash is not supported on Windows yet"
+    assert error == "Failed to empty Recycle Bin"
 
 
 def test_windows_trash_service_restore_is_unsupported() -> None:

--- a/tests/test_state_reducer_mutations_delete.py
+++ b/tests/test_state_reducer_mutations_delete.py
@@ -200,17 +200,18 @@ def test_begin_empty_trash_enters_confirm_mode(monkeypatch) -> None:
     assert next_state.pending_input is None
 
 
-def test_begin_empty_trash_on_windows_shows_error(monkeypatch) -> None:
+def test_begin_empty_trash_on_windows_enters_confirm_mode(monkeypatch) -> None:
     monkeypatch.setattr("platform.system", lambda: "Windows")
 
-    next_state = _reduce_state(build_initial_app_state(), BeginEmptyTrash())
+    state = build_initial_app_state()
 
-    assert next_state.ui_mode == "BROWSING"
-    assert next_state.empty_trash_confirmation is None
-    assert next_state.notification == NotificationState(
-        level="error",
-        message="Empty trash is not supported on this platform",
-    )
+    next_state = _reduce_state(state, BeginEmptyTrash())
+
+    assert next_state.ui_mode == "CONFIRM"
+    assert next_state.empty_trash_confirmation is not None
+    assert next_state.empty_trash_confirmation.platform == "windows"
+    assert next_state.command_palette is None
+    assert next_state.pending_input is None
 
 
 def test_cancel_empty_trash_confirmation_returns_to_browsing() -> None:

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -924,14 +924,13 @@ def test_submit_command_palette_deletes_targets() -> None:
     assert result.state.delete_confirmation is not None
 
 
-def test_command_palette_hides_empty_trash_on_windows(monkeypatch) -> None:
+def test_command_palette_shows_empty_trash_on_windows(monkeypatch) -> None:
     monkeypatch.setattr(command_palette_module.platform, "system", lambda: "Windows")
     state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
 
-    palette_state = select_command_palette_state(state)
+    items = command_palette_module.get_command_palette_items(state)
 
-    assert palette_state is not None
-    assert "Empty trash" not in [item.label for item in palette_state.items]
+    assert "Empty trash" in [item.label for item in items]
 
 def test_submit_command_palette_uses_selected_paths_for_copy_path() -> None:
     initial_state = build_initial_app_state()


### PR DESCRIPTION
## Summary

- Windows `Empty trash` を PowerShell の `Clear-RecycleBin -Force` で実装
- コマンドパレットの `Empty trash` 項目を Windows でも有効化
- 確認ダイアログ経由でごみ箱を空にできるように修正

## Changes

| File | Change |
|---|---|
| `src/zivo/services/trash_operations.py` | `WindowsTrashService.empty_trash()` を PowerShell 実装に置き換え |
| `src/zivo/state/reducer_mutations_common.py` | `detect_platform()` に `"windows"` を追加 |
| `src/zivo/state/reducer_mutations_delete.py` | `_handle_begin_empty_trash()` の platform check に `"windows"` を追加 |
| `src/zivo/state/command_palette.py` | `_is_empty_trash_supported()` に `"Windows"` を追加 |
| `README.md` / `README.ja.md` | Windows の Empty trash 非サポート記述を更新 |
| `tests/*` | 既存 Windows テストを新実装に合わせて更新 |

## Test Results

```
1136 passed, 5 skipped in 85.29s
```

Closes #737