### PR TITLE
#750 Windows対応: ターミナルエディタとしてeditをサポートする

### DIFF
--- a/src/zivo/adapters/external_launcher.py
+++ b/src/zivo/adapters/external_launcher.py
@@ -23,7 +23,10 @@ EnvironmentVariableReader = Callable[[str], str | None]
 TextFileReader = Callable[[str], str]
 PlatformKind = Literal["linux", "wsl", "darwin", "windows"]
 TERMINAL_EDITOR_NAMES = frozenset(
-    {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
+    {"edit", "emacs", "helix", "hx", "kak", "micro", "msedit", "nano", "nvim", "vi", "vim"}
+)
+EMBEDDED_LINE_NUMBER_EDITOR_NAMES = frozenset(
+    {"edit", "msedit"}
 )
 
 _PLATFORM_TEMPLATE_KEYS: dict[PlatformKind, tuple[str, ...]] = {
@@ -270,11 +273,14 @@ class LocalExternalLaunchAdapter:
         path: str,
         line_number: int | None = None,
     ) -> tuple[tuple[str, ...], ...]:
+        is_windows = self._platform_kind() == "windows"
         commands: list[tuple[str, ...]] = []
         configured_editor_command = self.editor_command_template.command
         if configured_editor_command:
             candidate = _build_command_candidate(
-                tuple(shlex.split(configured_editor_command)), path, line_number
+                tuple(shlex.split(configured_editor_command, posix=not is_windows)),
+                path,
+                line_number,
             )
             if candidate is not None:
                 commands.append(candidate)
@@ -282,7 +288,9 @@ class LocalExternalLaunchAdapter:
         editor_command = self.environment_variable("EDITOR")
         if editor_command:
             try:
-                parsed_command = tuple(shlex.split(editor_command))
+                parsed_command = tuple(
+                    shlex.split(editor_command, posix=not is_windows)
+                )
             except ValueError as error:
                 raise OSError(f"Invalid EDITOR value: {error}") from error
             candidate = _build_command_candidate(parsed_command, path, line_number)
@@ -298,7 +306,7 @@ class LocalExternalLaunchAdapter:
         line_number: int | None = None,
     ) -> tuple[tuple[str, ...], ...]:
         if line_number is not None:
-            return (
+            commands = (
                 ("nvim", f"+{line_number}", path),
                 ("vim", f"+{line_number}", path),
                 ("nano", f"+{line_number}", path),
@@ -306,14 +314,21 @@ class LocalExternalLaunchAdapter:
                 ("micro", f"+{line_number}", path),
                 ("emacs", "-nw", f"+{line_number}", path),
             )
-        return (
-            ("nvim", path),
-            ("vim", path),
-            ("nano", path),
-            ("hx", path),
-            ("micro", path),
-            ("emacs", "-nw", path),
-        )
+        else:
+            commands = (
+                ("nvim", path),
+                ("vim", path),
+                ("nano", path),
+                ("hx", path),
+                ("micro", path),
+                ("emacs", "-nw", path),
+            )
+        if self._platform_kind() == "windows":
+            if line_number is not None:
+                commands = commands + (("edit", f"{path}:{line_number}"),)
+            else:
+                commands = commands + (("edit", path),)
+        return commands
 
     def _command_exists(self, command: str) -> bool:
         command_path = Path(command)
@@ -576,6 +591,9 @@ def _build_command_candidate(
     if not parsed_command or not _is_terminal_editor_command(parsed_command[0]):
         return None
     if line_number is not None:
+        editor_name = Path(parsed_command[0]).name.casefold()
+        if editor_name in EMBEDDED_LINE_NUMBER_EDITOR_NAMES:
+            return parsed_command + (f"{path}:{line_number}",)
         return parsed_command + (f"+{line_number}", path)
     return parsed_command + (path,)
 

--- a/src/zivo/app_runtime_execution.py
+++ b/src/zivo/app_runtime_execution.py
@@ -1,9 +1,11 @@
 """Runtime scheduling helpers for execution-oriented effects."""
 
+import sys
 import threading
 from concurrent.futures import CancelledError as FutureCancelledError
 from contextlib import nullcontext
 from functools import partial
+from pathlib import Path
 from typing import Any
 
 from textual.app import SuspendNotSupported
@@ -203,17 +205,8 @@ def run_foreground_external_launch(app: Any, effect: RunExternalLaunchEffect) ->
     suspend_context = nullcontext()
     try:
         suspend_context = app.suspend()
-    except SuspendNotSupported as error:
-        app.call_next(
-            app.dispatch_actions,
-            (
-                ExternalLaunchFailed(
-                    request_id=effect.request_id,
-                    request=effect.request,
-                    message=str(error),
-                ),
-            ),
-        )
+    except SuspendNotSupported:
+        _run_detached_external_launch(app, effect)
         return
 
     try:
@@ -243,6 +236,55 @@ def run_foreground_external_launch(app: Any, effect: RunExternalLaunchEffect) ->
             ),
         ),
     )
+
+
+def _run_detached_external_launch(app: Any, effect: RunExternalLaunchEffect) -> None:
+    import subprocess
+
+    request = effect.request
+    try:
+        adapter = getattr(app._external_launch_service, "adapter", None)
+        if adapter is None or not hasattr(adapter, "_editor_candidates"):
+            raise OSError("Editor launch not supported on this terminal")
+        path = request.path
+        line_number = request.line_number
+        commands = adapter._editor_candidates(path, line_number)
+        if not commands:
+            raise OSError("No supported terminal editor found")
+        cmd = list(commands[0])
+        cwd = str(Path(path).parent)
+        try:
+            subprocess.run(
+                cmd,
+                cwd=cwd,
+                check=True,
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            )
+            app.call_next(
+                app.dispatch_actions,
+                (
+                    ExternalLaunchCompleted(
+                        request_id=effect.request_id,
+                        request=effect.request,
+                    ),
+                ),
+            )
+            return
+        except subprocess.CalledProcessError as error:
+            raise OSError(str(error) or f"{cmd[0]} failed") from error
+    except OSError as error:
+        app.call_next(
+            app.dispatch_actions,
+            (
+                ExternalLaunchFailed(
+                    request_id=effect.request_id,
+                    request=effect.request,
+                    message=str(error) or "Editor launch failed",
+                ),
+            ),
+        )
 
 
 def run_copy_paths(app: Any, effect: RunExternalLaunchEffect) -> None:

--- a/src/zivo/services/config/shared.py
+++ b/src/zivo/services/config/shared.py
@@ -11,7 +11,7 @@ VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
 VALID_PASTE_ACTIONS = frozenset({"overwrite", "skip", "rename", "prompt"})
 VALID_PREVIEW_MAX_KIB = frozenset({64, 128, 256, 512, 1024})
 VALID_TERMINAL_EDITOR_NAMES = frozenset(
-    {"emacs", "helix", "hx", "kak", "micro", "nano", "nvim", "vi", "vim"}
+    {"edit", "emacs", "helix", "hx", "kak", "micro", "msedit", "nano", "nvim", "vi", "vim"}
 )
 VALIDATION_PATH = "/tmp/zivo"
 

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -13,7 +13,7 @@ CONFIG_PREVIEW_SYNTAX_THEMES = SUPPORTED_PREVIEW_SYNTAX_THEMES
 CONFIG_PREVIEW_MAX_KIB = (64, 128, 256, 512, 1024)
 CONFIG_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 CONFIG_PASTE_ACTIONS = ("prompt", "overwrite", "skip", "rename")
-CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw")
+CONFIG_EDITOR_COMMANDS = (None, "nvim", "vim", "nano", "hx", "micro", "emacs -nw", "edit")
 CONFIG_FILE_SEARCH_MAX_RESULTS = (None, 100, 500, 1000, 5000, 10000)
 
 
@@ -515,6 +515,6 @@ def _format_bool(value: bool) -> str:
 def _format_editor_command_value(command: str | None) -> str:
     if command is None:
         return "system default"
-    if command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw"}:
+    if command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw", "edit"}:
         return command
     return "custom (raw config only)"

--- a/src/zivo/state/selectors_shared.py
+++ b/src/zivo/state/selectors_shared.py
@@ -634,14 +634,14 @@ def _format_permissions_detail_label(entry: DirectoryEntryState) -> str:
 def _format_editor_command_value(command: str | None) -> str:
     if command is None:
         return "system default"
-    if command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw"}:
+    if command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw", "edit"}:
         return command
     return "custom (raw config only)"
 
 
 def _format_custom_editor_hint(command: str | None) -> str:
-    if command is None or command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw"}:
-        return "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw"
+    if command is None or command in {"nvim", "vim", "nano", "hx", "micro", "emacs -nw", "edit"}:
+        return "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw, edit"
     return f"Custom editor command: {command}"
 
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1971,7 +1971,8 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     assert "  Sets the application theme used by the panes, dialogs, and status UI." in dialog.lines
     assert "  Changing this here previews the theme immediately before saving." in dialog.lines
     assert "  Current behavior: `textual-dark`." in dialog.lines
-    assert "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw" in dialog.lines
+    hint = "Editor presets: system default, nvim, vim, nano, hx, micro, emacs -nw, edit"
+    assert hint in dialog.lines
     assert "Terminal launch templates: edit config.toml with e" in dialog.lines
     assert dialog.options == (
         "↑↓/Ctrl+n/p choose",

--- a/tests/test_app_runtime.py
+++ b/tests/test_app_runtime.py
@@ -781,7 +781,7 @@ def test_run_foreground_external_launch_maps_suspend_failures() -> None:
         ExternalLaunchFailed(
             request_id=8,
             request=request,
-            message="suspend unavailable",
+            message="Editor launch not supported on this terminal",
         ),
     )
 

--- a/tests/test_services_external_launcher.py
+++ b/tests/test_services_external_launcher.py
@@ -806,6 +806,62 @@ def test_build_command_candidate_returns_none_for_gui_editor() -> None:
     assert result is None
 
 
+def test_build_command_candidate_for_edit_with_line_number() -> None:
+    result = _build_command_candidate(("edit",), "/tmp/file.py", line_number=42)
+    assert result == ("edit", "/tmp/file.py:42")
+
+
+def test_build_command_candidate_for_edit_without_line_number() -> None:
+    result = _build_command_candidate(("edit",), "/tmp/file.py")
+    assert result == ("edit", "/tmp/file.py")
+
+
+def test_build_command_candidate_for_msedit_with_line_number() -> None:
+    result = _build_command_candidate(("msedit",), "/tmp/file.py", line_number=10)
+    assert result == ("msedit", "/tmp/file.py:10")
+
+
+# --- Tests for Windows editor support ---
+
+
+def test_windows_default_editor_commands_include_edit(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command if command == "edit" else None,
+        foreground_command_runner=runner,
+        environment_variable=lambda _name: None,
+        editor_command_template=EditorConfig(command=None),
+    )
+
+    adapter.open_in_editor(str(readme))
+
+    assert runner.executed == [
+        (("edit", str(readme.resolve())), str(tmp_path.resolve()))
+    ]
+
+
+def test_windows_default_editor_commands_include_edit_with_line_number(tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("plain\n", encoding="utf-8")
+    runner = StubForegroundRunner()
+    adapter = LocalExternalLaunchAdapter(
+        system_name_resolver=lambda: "Windows",
+        command_available=lambda command: command if command == "edit" else None,
+        foreground_command_runner=runner,
+        environment_variable=lambda _name: None,
+        editor_command_template=EditorConfig(command=None),
+    )
+
+    adapter.open_in_editor(str(readme), line_number=42)
+
+    assert runner.executed == [
+        (("edit", f"{str(readme.resolve())}:42"), str(tmp_path.resolve()))
+    ]
+
+
 # --- Tests for _command_exists ---
 
 


### PR DESCRIPTION
## Summary

- Microsoft `edit` を Windows 向けデフォルトターミナルエディタとして追加
- `edit` の line_number 引数形式（`FILE:LINE`）に対応
- Windows 環境での `shlex.split()` を `posix=False` で呼び分け
- `app.suspend()` 未対応端末向けに detached launch フォールバック
- Config エディタ UI に `edit` 選択肢と表示ラベルを追加

## Changes

| File | Change |
|------|--------|
| `src/zivo/adapters/external_launcher.py` | `TERMINAL_EDITOR_NAMES`/`EMBEDDED_LINE_NUMBER_EDITOR_NAMES` に `edit`/`msedit` 追加、`_default_terminal_editor_commands()` に Windows `edit` フォールバック追加、`_build_command_candidate()` で `path:N` 形式対応、`_terminal_editor_commands()` で `shlex.split(posix=False)` |
| `src/zivo/app_runtime_execution.py` | `SuspendNotSupported` 時に detached launch でフォールバックする `_run_detached_external_launch()` を追加 |
| `src/zivo/services/config/shared.py` | `VALID_TERMINAL_EDITOR_NAMES` に `edit`/`msedit` 追加 |
| `src/zivo/state/reducer_config.py` | `CONFIG_EDITOR_COMMANDS` に `"edit"` 追加、`_format_editor_command_value()` で `"edit"` 表示対応 |
| `src/zivo/state/selectors_shared.py` | `_format_editor_command_value()` と `_format_custom_editor_hint()` で `"edit"` 表示対応 |
| テスト 4ファイル | Windows `edit` 起動、Config editor ヒント文字列、SuspendNotSupported フォールバックのテスト追加・更新 |

## Test Results

```
1145 passed, 5 skipped
```
