### PR TITLE
Fix #764: Remove residual split terminal code

### DIFF
--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -56,7 +56,6 @@ flowchart LR
         Archive["archive_extract.py"]
         Config["config.py"]
         Launch["external_launcher.py"]
-        Split["split_terminal.py"]
         ArchiveUtils["archive_utils.py\narchive detection / destination resolution"]
     end
 
@@ -253,7 +252,6 @@ sequenceDiagram
 - `archive_extract.py`: handles archive preflight scanning, conflict detection, safe extraction, and progress reporting
 - `config.py`: loads, validates, saves, and renders `config.toml`
 - `external_launcher.py`: handles default-app launch, terminal-editor launch, external-terminal launch, and path copy
-- `split_terminal.py`: starts PTY-backed split-terminal sessions, forwards I/O, and reports exit events
 
 ### `src/zivo/archive_utils.py`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,6 @@ flowchart LR
         Archive["archive_extract.py"]
         Config["config.py"]
         Launch["external_launcher.py"]
-        Split["split_terminal.py"]
         ArchiveUtils["archive_utils.py\narchive 判定 / 展開先解決"]
     end
 
@@ -253,7 +252,6 @@ sequenceDiagram
 - `archive_extract.py`: archive 事前走査、競合検出、安全な展開、進捗通知を担当する
 - `config.py`: `config.toml` の読み込み、検証、保存、既定値レンダリングを担当する
 - `external_launcher.py`: 既定アプリ起動、terminal editor 起動、外部 terminal 起動、パスコピーを担当する
-- `split_terminal.py`: 埋め込み split terminal の PTY セッション起動、入出力、終了通知を担当する
 
 ### `src/zivo/archive_utils.py`
 

--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -10,7 +10,6 @@ from textual.app import App, ComposeResult, ScreenStackError
 from textual.binding import Binding
 from textual.containers import Container, Vertical
 from textual.css.query import NoMatches
-from textual.message import Message
 from textual.timer import Timer
 from textual.worker import Worker
 
@@ -137,22 +136,6 @@ def _preview_scroll_delta(state: AppState, key: str) -> int | None:
 
 class zivoApp(App[None]):
     """Three-pane shell with reducer-driven file operations."""
-
-    class SplitTerminalOutput(Message):
-        """Forward PTY output from background threads into the app loop."""
-
-        def __init__(self, session_id: int, data: str) -> None:
-            self.session_id = session_id
-            self.data = data
-            super().__init__()
-
-    class SplitTerminalExitedMessage(Message):
-        """Forward PTY exit notifications into the app loop."""
-
-        def __init__(self, session_id: int, exit_code: int | None) -> None:
-            self.session_id = session_id
-            self.exit_code = exit_code
-            super().__init__()
 
     TITLE = "zivo"
     SUB_TITLE = "Three-pane shell"
@@ -412,29 +395,6 @@ class zivoApp(App[None]):
             row_region.y,
         )
 
-    def _update_split_terminal_overlay_geometry(self) -> None:
-        """Constrain the overlay terminal above the help and status bars."""
-
-        try:
-            split_terminal_layer = self.query_one("#split-terminal-layer", Container)
-            body = self.query_one("#body")
-            help_bar = self.query_one("#help-bar", HelpBar)
-        except NoMatches:
-            return
-
-        body_region = body.region
-        help_bar_region = help_bar.region
-        overlay_height = help_bar_region.y - body_region.y
-        if body_region.width <= 0 or overlay_height <= 0:
-            return
-
-        split_terminal_layer.styles.width = body_region.width
-        split_terminal_layer.styles.height = overlay_height
-        split_terminal_layer.styles.offset = (
-            body_region.x,
-            body_region.y,
-        )
-
     async def on_mount(self) -> None:
         """Load the initial directory snapshot after the UI mounts."""
 
@@ -478,7 +438,7 @@ class zivoApp(App[None]):
             event.prevent_default()
 
     async def on_paste(self, event: events.Paste) -> None:
-        """Handle clipboard paste in input dialog and split terminal modes."""
+        """Handle clipboard paste in input dialog modes."""
 
         if self._app_state.ui_mode in {"RENAME", "CREATE", "EXTRACT", "ZIP", "SYMLINK"}:
             if self._app_state.pending_input is not None:
@@ -489,21 +449,6 @@ class zivoApp(App[None]):
                 )
                 event.stop()
                 event.prevent_default()
-            return
-
-        st = self._app_state.split_terminal
-        if (
-            st.visible
-            and st.status == "running"
-            and st.focus_target == "terminal"
-        ):
-            from zivo.state.actions import SendSplitTerminalInput
-
-            await self.dispatch_actions(
-                (SendSplitTerminalInput(event.text),)
-            )
-            event.stop()
-            event.prevent_default()
 
     async def action_dispatch_bound_key(self, key: str) -> None:
         """Handle priority key bindings through the central dispatcher."""
@@ -559,10 +504,6 @@ class zivoApp(App[None]):
                 await self.query_one("#body").remove()
             except NoMatches:
                 pass
-            try:
-                await self.query_one("#split-terminal-layer").remove()
-            except NoMatches:
-                pass
         if changed or theme_changed or layout_changed:
             await self._refresh_shell(theme_changed=theme_changed)
         schedule_effects(self, effects)
@@ -603,7 +544,7 @@ class zivoApp(App[None]):
         await handle_worker_state_changed(self, event)
 
     async def on_resize(self, event: events.Resize) -> None:
-        """Keep the split-terminal PTY dimensions roughly aligned with the viewport."""
+        """Update the terminal height on resize."""
 
         await self.dispatch_actions((SetTerminalHeight(height=event.size.height),))
         self._sync_overlay_layout(event.size.width)
@@ -627,7 +568,6 @@ class zivoApp(App[None]):
         self._update_command_palette_geometry()
         self._update_config_dialog_geometry()
         self._update_input_dialog_geometry()
-        self._update_split_terminal_overlay_geometry()
 
 
 def create_app(

--- a/src/zivo/app.tcss
+++ b/src/zivo/app.tcss
@@ -174,10 +174,6 @@ Screen {
     align-horizontal: center;
 }
 
-.split-terminal-overlay-layer {
-    align: center middle;
-}
-
 .dialog-layer {
     align: center middle;
 }
@@ -319,58 +315,6 @@ Screen {
     background: $boost;
     color: $text-muted;
     text-style: bold;
-}
-
-#split-terminal {
-    display: none;
-    height: 1fr;
-    min-height: 6;
-    background: $surface;
-}
-
-#split-terminal.-visible {
-    display: block;
-}
-
-#split-terminal.-focused {
-    background: $boost;
-}
-
-#split-terminal.split-terminal-right {
-    display: none;
-    width: 2.2fr;
-    min-width: 20;
-    height: 1fr;
-    min-height: 6;
-    border: round $surface;
-    background: $surface;
-}
-
-#split-terminal.split-terminal-right.-visible {
-    display: block;
-}
-
-#split-terminal.split-terminal-right.-focused {
-    background: $boost;
-}
-
-#split-terminal.split-terminal-overlay {
-    display: none;
-    width: 1fr;
-    height: 1fr;
-    min-width: 20;
-    min-height: 6;
-    margin: 1 2;
-    border: round $surface;
-    background: $surface;
-}
-
-#split-terminal.split-terminal-overlay.-visible {
-    display: block;
-}
-
-#split-terminal.split-terminal-overlay.-focused {
-    background: $boost;
 }
 
 /* File type component styles resolved via COMPONENT_CLASSES */

--- a/src/zivo/state/actions.py
+++ b/src/zivo/state/actions.py
@@ -223,10 +223,6 @@ from .actions_runtime import (
     RequestDirectorySizes,
     ShellCommandCompleted,
     ShellCommandFailed,
-    SplitTerminalExited,
-    SplitTerminalOutputReceived,
-    SplitTerminalStarted,
-    SplitTerminalStartFailed,
     TransferPaneSnapshotFailed,
     TransferPaneSnapshotLoaded,
     UndoCompleted,
@@ -415,10 +411,6 @@ Action = (
     | ExternalLaunchFailed
     | ShellCommandCompleted
     | ShellCommandFailed
-    | SplitTerminalStarted
-    | SplitTerminalStartFailed
-    | SplitTerminalOutputReceived
-    | SplitTerminalExited
     | ConfigSaveCompleted
     | ConfigSaveFailed
 )

--- a/src/zivo/state/actions_runtime.py
+++ b/src/zivo/state/actions_runtime.py
@@ -336,38 +336,6 @@ class ShellCommandFailed:
 
 
 @dataclass(frozen=True)
-class SplitTerminalStarted:
-    """Mark the split terminal session as ready."""
-
-    session_id: int
-    cwd: str
-
-
-@dataclass(frozen=True)
-class SplitTerminalStartFailed:
-    """Apply an embedded split-terminal startup error."""
-
-    session_id: int
-    message: str
-
-
-@dataclass(frozen=True)
-class SplitTerminalOutputReceived:
-    """Append output from the active split terminal session."""
-
-    session_id: int
-    data: str
-
-
-@dataclass(frozen=True)
-class SplitTerminalExited:
-    """Apply embedded split-terminal process exit."""
-
-    session_id: int
-    exit_code: int | None
-
-
-@dataclass(frozen=True)
 class ConfigSaveCompleted:
     """Apply a successful config save."""
 

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -493,8 +493,6 @@ def format_config_field_value(field_index: int, config: AppConfig) -> str:
         return _format_bool(config.display.directories_first)
     if field_id == "display.grep_preview_context_lines":
         return str(config.display.grep_preview_context_lines)
-    if field_id == "display.split_terminal_position":
-        return config.display.split_terminal_position
     if field_id == "behavior.confirm_delete":
         return _format_bool(config.behavior.confirm_delete)
     if field_id == "behavior.paste_conflict_action":

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1306,22 +1306,6 @@ def test_select_help_bar_for_busy_mode() -> None:
     assert help_state.text == "processing..."
 
 
-def test_select_help_bar_for_split_terminal_focus() -> None:
-    state = replace(
-        build_initial_app_state(),
-        split_terminal=replace(
-            build_initial_app_state().split_terminal,
-            visible=True,
-            status="running",
-            focus_target="terminal",
-        ),
-    )
-
-    help_state = select_help_bar_state(state)
-
-    assert help_state.text == "type in terminal | ctrl+q close"
-
-
 def test_select_command_palette_state_marks_selected_and_enabled_items() -> None:
     state = _reduce_state(build_initial_app_state(), BeginCommandPalette())
 

--- a/tests/test_app_runtime.py
+++ b/tests/test_app_runtime.py
@@ -156,11 +156,7 @@ class _RecordingApp:
     _external_launch_service: Any = field(
         default_factory=lambda: SimpleNamespace(execute=lambda request: None)
     )
-    _split_terminal_service: Any = field(
-        default_factory=lambda: SimpleNamespace(start=lambda cwd, **kwargs: None)
-    )
     _undo_service: Any = field(default_factory=lambda: SimpleNamespace(execute=lambda entry: None))
-    _split_terminal_session: Any = None
     suspend_error: BaseException | None = None
     run_worker_calls: list[dict[str, Any]] = field(default_factory=list)
     set_timer_calls: list[dict[str, Any]] = field(default_factory=list)


### PR DESCRIPTION
## Summary

`split_terminal` は非サポートとなったが、`app.py` に `self._app_state.split_terminal` を参照する残存コードがあり、ペースト時に `AttributeError` を引き起こしていた。全ファイルから関連コード・CSS・アクションクラス・テスト・ドキュメント記述を除去する。

## Changes

- **`src/zivo/app.py`**: `SplitTerminalOutput`/`SplitTerminalExitedMessage` Message クラス、`_update_split_terminal_overlay_geometry` メソッド、`on_paste` 内の split_terminal 分岐、`#split-terminal-layer` remove 処理、`_sync_overlay_layout` 内の呼び出しを削除
- **`src/zivo/state/actions.py`**: `SplitTerminal*` の import と union type 参照を削除
- **`src/zivo/state/actions_runtime.py`**: `SplitTerminalStarted/StartFailed/OutputReceived/Exited` クラス定義を削除
- **`src/zivo/state/reducer_config.py`**: `display.split_terminal_position` の config field handler を削除
- **`src/zivo/app.tcss`**: `.split-terminal-overlay-layer` と `#split-terminal` 全スタイルを削除
- **`tests/test_app_runtime.py`**: `_split_terminal_service` / `_split_terminal_session` モックを削除
- **`tests/state_selectors_cases.py`**: `test_select_help_bar_for_split_terminal_focus` テストを削除
- **`docs/architecture.md` / `docs/architecture.en.md`**: `Split["split_terminal.py"]` 行と説明文を削除

## Test Results

- `ruff check .`: All checks passed
- `pytest`: 1117 passed in 71.52s