### PR TITLE
[#767] Refactor external launcher platform modules

### DIFF
--- a/src/zivo/adapters/external_launcher.py
+++ b/src/zivo/adapters/external_launcher.py
@@ -1,40 +1,43 @@
 """OS adapter for launching default applications, terminals, and clipboard commands."""
 
+from __future__ import annotations
+
 import os
 import platform
-import shlex
 import shutil
 import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Literal, Protocol
 
+from zivo.adapters.platforms import (
+    PlatformAdapterContext,
+    PlatformKind,
+    resolve_platform_adapter,
+    resolve_platform_kind,
+)
+from zivo.adapters.platforms.base import (
+    ClipboardFallback,
+    ClipboardReader,
+    CommandAvailability,
+    CommandRunner,
+    EnvironmentVariableReader,
+    ForegroundCommandRunner,
+    TextFileReader,
+)
+from zivo.adapters.platforms.base import (
+    _build_command_candidate as _base_build_command_candidate,
+)
+from zivo.adapters.platforms.base import (
+    is_wsl_environment as _base_is_wsl_environment,
+)
 from zivo.models import EditorConfig, TerminalConfig
 
-CommandRunner = Callable[[Sequence[str], str | None, str | None], None]
-ForegroundCommandRunner = Callable[[Sequence[str], str | None], None]
-CommandAvailability = Callable[[str], str | None]
 SystemNameResolver = Callable[[], str]
-ClipboardFallback = Callable[[str], None]
-ClipboardReader = Callable[[], str]
-EnvironmentVariableReader = Callable[[str], str | None]
-TextFileReader = Callable[[str], str]
-PlatformKind = Literal["linux", "wsl", "darwin", "windows"]
-TERMINAL_EDITOR_NAMES = frozenset(
-    {"edit", "emacs", "helix", "hx", "kak", "micro", "msedit", "nano", "nvim", "vi", "vim"}
-)
-EMBEDDED_LINE_NUMBER_EDITOR_NAMES = frozenset(
-    {"edit", "msedit"}
-)
-
-_PLATFORM_TEMPLATE_KEYS: dict[PlatformKind, tuple[str, ...]] = {
-    "linux": ("linux",),
-    "darwin": ("macos",),
-    "wsl": ("windows", "linux"),
-    "windows": ("windows",),
-}
+CommandOutputReader = Callable[[Sequence[str]], str]
+_build_command_candidate = _base_build_command_candidate
+_is_wsl_environment = _base_is_wsl_environment
 
 
 class ExternalLaunchAdapter(Protocol):
@@ -42,7 +45,7 @@ class ExternalLaunchAdapter(Protocol):
 
     def open_with_default_app(self, path: str) -> None: ...
 
-    def open_in_editor(self, path: str) -> None: ...
+    def open_in_editor(self, path: str, line_number: int | None = None) -> None: ...
 
     def open_terminal(
         self, path: str, launch_mode: Literal["window", "foreground"] = "window"
@@ -58,10 +61,13 @@ class LocalExternalLaunchAdapter:
     """Launch applications and terminals via OS-specific commands."""
 
     system_name_resolver: SystemNameResolver = platform.system
-    command_available: CommandAvailability = shutil.which
+    command_available: CommandAvailability = field(default_factory=lambda: shutil.which)
     command_runner: CommandRunner = field(default_factory=lambda: _run_detached_command)
     foreground_command_runner: ForegroundCommandRunner = field(
         default_factory=lambda: _run_foreground_command
+    )
+    clipboard_command_reader: CommandOutputReader = field(
+        default_factory=lambda: _read_command_output
     )
     environment_variable: EnvironmentVariableReader = field(
         default_factory=lambda: os.environ.get
@@ -77,392 +83,48 @@ class LocalExternalLaunchAdapter:
     editor_command_template: EditorConfig = field(default_factory=EditorConfig)
 
     def open_with_default_app(self, path: str) -> None:
-        resolved_path = _resolve_existing_path(path)
-        platform_kind = self._platform_kind()
-        candidates = self._default_app_candidates(platform_kind, str(resolved_path))
-        cwd = str(resolved_path if resolved_path.is_dir() else resolved_path.parent)
-        self._run_first_available(candidates, context=f"open {resolved_path}", cwd=cwd)
+        self._platform_adapter().open_with_default_app(path)
 
     def open_in_editor(self, path: str, line_number: int | None = None) -> None:
-        resolved_path = _resolve_existing_path(path)
-        candidates = self._editor_candidates(str(resolved_path), line_number)
-        errors: list[str] = []
-        for command in candidates:
-            try:
-                self.foreground_command_runner(command, str(resolved_path.parent))
-                return
-            except OSError as error:
-                errors.append(str(error) or f"{command[0]} failed")
-
-        raise OSError(errors[-1] if errors else f"Failed to open {resolved_path} in editor")
+        self._platform_adapter().open_in_editor(path, line_number)
 
     def open_terminal(
         self, path: str, launch_mode: Literal["window", "foreground"] = "window"
     ) -> None:
-        resolved_path = _resolve_directory_path(path)
-        platform_kind = self._platform_kind()
-        if launch_mode == "foreground":
-            command = self._foreground_terminal_command(platform_kind)
-            self.foreground_command_runner(command, str(resolved_path))
-            return
-        candidates = self._terminal_candidates(platform_kind, str(resolved_path))
-        self._run_first_available(
-            candidates,
-            context=f"open terminal in {resolved_path}",
-            cwd=str(resolved_path),
-        )
+        self._platform_adapter().open_terminal(path, launch_mode)
 
     def copy_to_clipboard(self, text: str) -> None:
-        candidates = self._clipboard_candidates(self._platform_kind())
-        available_candidates = [
-            command for command in candidates if self.command_available(command[0]) is not None
-        ]
-        if available_candidates:
-            self._run_first_available(
-                available_candidates,
-                context="copy to clipboard",
-                input_text=text,
-            )
-            return
-
-        fallback_errors: list[str] = []
-        for fallback in self.clipboard_fallbacks:
-            try:
-                fallback(text)
-                return
-            except OSError as error:
-                fallback_errors.append(str(error) or "clipboard fallback failed")
-
-        if fallback_errors:
-            raise OSError(fallback_errors[-1])
-        raise OSError("No supported command found to copy to clipboard")
+        self._platform_adapter().copy_to_clipboard(text)
 
     def get_from_clipboard(self) -> str:
-        platform_kind = self._platform_kind()
-        candidates = self._clipboard_read_candidates(platform_kind)
-        available_candidates = [
-            command for command in candidates if self._command_exists(command[0])
-        ]
-        if available_candidates:
-            return self._read_first_available(available_candidates)
-
-        fallback_errors: list[str] = []
-        for reader in self.clipboard_readers:
-            try:
-                return reader()
-            except OSError as error:
-                fallback_errors.append(str(error) or "clipboard reader failed")
-
-        if fallback_errors:
-            raise OSError(fallback_errors[-1])
-        raise OSError("No supported command found to read from clipboard")
-
-    def _read_first_available(
-        self,
-        candidates: tuple[tuple[str, ...], ...],
-    ) -> str:
-        errors: list[str] = []
-        for command in candidates:
-            try:
-                result = subprocess.run(
-                    list(command),
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                return result.stdout
-            except subprocess.CalledProcessError as error:
-                errors.append(str(error) or f"{command[0]} failed")
-
-        raise OSError(errors[-1] if errors else "Failed to read from clipboard")
-
-    def _run_first_available(
-        self,
-        candidates: tuple[tuple[str, ...], ...],
-        *,
-        context: str,
-        cwd: str | None = None,
-        input_text: str | None = None,
-    ) -> None:
-        available_candidates = [
-            command for command in candidates if self._command_exists(command[0])
-        ]
-        if not available_candidates:
-            raise OSError(f"No supported command found to {context}")
-
-        errors: list[str] = []
-        for command in available_candidates:
-            try:
-                self.command_runner(command, cwd, input_text)
-                return
-            except OSError as error:
-                errors.append(str(error) or f"{command[0]} failed")
-
-        raise OSError(errors[-1] if errors else f"Failed to {context}")
+        return self._platform_adapter().get_from_clipboard()
 
     def _platform_kind(self) -> PlatformKind:
-        system_name = self.system_name_resolver()
-        if system_name == "Darwin":
-            return "darwin"
-        if system_name == "Linux":
-            if _is_wsl_environment(self.environment_variable, self.text_file_reader):
-                return "wsl"
-            return "linux"
-        if system_name == "Windows":
-            return "windows"
-        raise OSError(f"Unsupported operating system: {system_name}")
-
-    def _platform_candidates(
-        self,
-        platform_kind: PlatformKind,
-        *,
-        linux: tuple[tuple[str, ...], ...] = (),
-        wsl: tuple[tuple[str, ...], ...] = (),
-        darwin: tuple[tuple[str, ...], ...] = (),
-        windows: tuple[tuple[str, ...], ...] = (),
-    ) -> tuple[tuple[str, ...], ...]:
-        if platform_kind == "linux":
-            return linux
-        if platform_kind == "wsl":
-            return wsl + linux
-        if platform_kind == "darwin":
-            return darwin
-        if platform_kind == "windows":
-            return windows
-        raise OSError(f"Unsupported platform kind: {platform_kind}")
-
-    def _default_app_candidates(
-        self,
-        platform_kind: PlatformKind,
-        path: str,
-    ) -> tuple[tuple[str, ...], ...]:
-        return self._platform_candidates(
-            platform_kind,
-            linux=(
-                ("xdg-open", path),
-                ("gio", "open", path),
-            ),
-            wsl=(
-                ("wslview", path),
-                ("explorer.exe", path),
-            ),
-            darwin=(("open", path),),
-            windows=(
-                ("cmd.exe", "/c", "start", "", path),
-                ("powershell.exe", "-NoProfile", "-Command", "Start-Process", path),
-            ),
+        return resolve_platform_kind(
+            self.system_name_resolver(),
+            environment_variable=self.environment_variable,
+            text_file_reader=self.text_file_reader,
         )
 
-    def _editor_candidates(
-        self,
-        path: str,
-        line_number: int | None = None,
-    ) -> tuple[tuple[str, ...], ...]:
-        editor_commands = [
-            command
-            for command in self._terminal_editor_commands(path, line_number)
-            if self._command_exists(command[0])
-        ]
-        if not editor_commands:
-            raise OSError("No supported terminal editor found")
+    def _platform_adapter(self):
+        return resolve_platform_adapter(self._platform_kind(), self._platform_context())
 
-        return tuple(editor_commands)
-
-    def _terminal_editor_commands(
-        self,
-        path: str,
-        line_number: int | None = None,
-    ) -> tuple[tuple[str, ...], ...]:
-        is_windows = self._platform_kind() == "windows"
-        commands: list[tuple[str, ...]] = []
-        configured_editor_command = self.editor_command_template.command
-        if configured_editor_command:
-            candidate = _build_command_candidate(
-                tuple(shlex.split(configured_editor_command, posix=not is_windows)),
-                path,
-                line_number,
-            )
-            if candidate is not None:
-                commands.append(candidate)
-
-        editor_command = self.environment_variable("EDITOR")
-        if editor_command:
-            try:
-                parsed_command = tuple(
-                    shlex.split(editor_command, posix=not is_windows)
-                )
-            except ValueError as error:
-                raise OSError(f"Invalid EDITOR value: {error}") from error
-            candidate = _build_command_candidate(parsed_command, path, line_number)
-            if candidate is not None:
-                commands.append(candidate)
-
-        commands.extend(self._default_terminal_editor_commands(path, line_number))
-        return _dedupe_commands(commands)
-
-    def _default_terminal_editor_commands(
-        self,
-        path: str,
-        line_number: int | None = None,
-    ) -> tuple[tuple[str, ...], ...]:
-        if line_number is not None:
-            commands = (
-                ("nvim", f"+{line_number}", path),
-                ("vim", f"+{line_number}", path),
-                ("nano", f"+{line_number}", path),
-                ("hx", f"+{line_number}", path),
-                ("micro", f"+{line_number}", path),
-                ("emacs", "-nw", f"+{line_number}", path),
-            )
-        else:
-            commands = (
-                ("nvim", path),
-                ("vim", path),
-                ("nano", path),
-                ("hx", path),
-                ("micro", path),
-                ("emacs", "-nw", path),
-            )
-        if self._platform_kind() == "windows":
-            if line_number is not None:
-                commands = commands + (("edit", f"{path}:{line_number}"),)
-            else:
-                commands = commands + (("edit", path),)
-        return commands
+    def _platform_context(self) -> PlatformAdapterContext:
+        return PlatformAdapterContext(
+            command_available=self.command_available,
+            command_runner=self.command_runner,
+            foreground_command_runner=self.foreground_command_runner,
+            clipboard_command_reader=self.clipboard_command_reader,
+            environment_variable=self.environment_variable,
+            text_file_reader=self.text_file_reader,
+            clipboard_fallbacks=self.clipboard_fallbacks,
+            clipboard_readers=self.clipboard_readers,
+            terminal_command_templates=self.terminal_command_templates,
+            editor_command_template=self.editor_command_template,
+        )
 
     def _command_exists(self, command: str) -> bool:
-        command_path = Path(command)
-        if command_path.is_absolute():
-            return command_path.exists()
-        return self.command_available(command) is not None
-
-    def _foreground_terminal_command(self, platform_kind: PlatformKind) -> tuple[str, ...]:
-        if platform_kind == "windows":
-            powershell = self.command_available("powershell.exe")
-            if powershell is not None:
-                return (powershell, "-NoExit", "-NoLogo")
-            return ("cmd.exe", "/k")
-        shell = self.environment_variable("SHELL")
-        if shell:
-            try:
-                parsed = tuple(shlex.split(shell))
-            except ValueError as error:
-                raise OSError(f"Invalid SHELL value: {error}") from error
-            if parsed and self._command_exists(parsed[0]):
-                return (*parsed, "-i")
-        if self._command_exists("/bin/bash"):
-            return ("/bin/bash", "-i")
-        raise OSError("No supported interactive shell found for foreground terminal mode")
-
-    def _terminal_candidates(
-        self,
-        platform_kind: PlatformKind,
-        path: str,
-    ) -> tuple[tuple[str, ...], ...]:
-        configured_commands = self._configured_terminal_commands(platform_kind, path)
-        return configured_commands + self._platform_candidates(
-            platform_kind,
-            linux=(
-                ("kgx",),
-                ("gnome-console",),
-                ("gnome-terminal",),
-                ("xfce4-terminal",),
-                ("mate-terminal",),
-                ("tilix",),
-                ("konsole",),
-                ("lxterminal",),
-                ("x-terminal-emulator",),
-                ("xterm",),
-            ),
-            wsl=(
-                ("wt.exe", "wsl.exe", "--cd", path),
-                ("cmd.exe", "/c", "start", "", "wsl.exe", "--cd", path),
-            ),
-            darwin=(("open", "-a", "Terminal", path),),
-            windows=(
-                ("wt.exe", "-d", path),
-                (
-                    "cmd.exe",
-                    "/c",
-                    "start",
-                    "",
-                    "powershell.exe",
-                    "-NoExit",
-                    "-Command",
-                    _windows_set_location_command(path),
-                ),
-                (
-                    "cmd.exe",
-                    "/c",
-                    "start",
-                    "",
-                    "cmd.exe",
-                    "/k",
-                    _windows_cd_command(path),
-                ),
-            ),
-        )
-
-    def _configured_terminal_commands(
-        self,
-        platform_kind: PlatformKind,
-        path: str,
-    ) -> tuple[tuple[str, ...], ...]:
-        template_keys = _PLATFORM_TEMPLATE_KEYS.get(platform_kind)
-        if template_keys is None:
-            raise OSError(f"Unsupported platform kind: {platform_kind}")
-
-        template_map = {
-            "linux": self.terminal_command_templates.linux,
-            "macos": self.terminal_command_templates.macos,
-            "windows": self.terminal_command_templates.windows,
-        }
-        template_specs: list[tuple[str, str]] = []
-        for key in template_keys:
-            template_specs.extend((template, key) for template in template_map[key])
-
-        commands: list[tuple[str, ...]] = []
-        for template, template_key in template_specs:
-            try:
-                rendered = template.format(path=_render_template_path(path, template_key))
-                parsed_command = tuple(shlex.split(rendered, posix=template_key != "windows"))
-            except (IndexError, KeyError, ValueError):
-                continue
-            if parsed_command:
-                commands.append(parsed_command)
-        return _dedupe_commands(commands)
-
-    def _clipboard_candidates(self, platform_kind: PlatformKind) -> tuple[tuple[str, ...], ...]:
-        return self._platform_candidates(
-            platform_kind,
-            linux=(
-                ("wl-copy",),
-                ("xclip", "-in", "-selection", "clipboard"),
-                ("xsel", "--clipboard", "--input"),
-            ),
-            wsl=(("clip.exe",),),
-            darwin=(("pbcopy",),),
-            windows=(
-                ("clip.exe",),
-                ("powershell.exe", "-NoProfile", "-Command", "Set-Clipboard"),
-            ),
-        )
-
-    def _clipboard_read_candidates(
-        self,
-        platform_kind: PlatformKind,
-    ) -> tuple[tuple[str, ...], ...]:
-        return self._platform_candidates(
-            platform_kind,
-            linux=(
-                ("wl-paste", "--no-newline"),
-                ("xclip", "-out", "-selection", "clipboard"),
-                ("xsel", "--clipboard", "--output"),
-            ),
-            wsl=(("powershell.exe", "-noprofile", "-command", "Get-Clipboard"),),
-            darwin=(("pbpaste",),),
-            windows=(("powershell.exe", "-NoProfile", "-Command", "Get-Clipboard"),),
-        )
+        return self._platform_adapter()._command_exists(command)
 
 
 def _run_detached_command(command: Sequence[str], cwd: str | None, input_text: str | None) -> None:
@@ -505,6 +167,19 @@ def _run_foreground_command(command: Sequence[str], cwd: str | None) -> None:
         raise OSError(str(error) or f"{command[0]} failed") from error
 
 
+def _read_command_output(command: Sequence[str]) -> str:
+    try:
+        result = subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise OSError(str(error) or f"{command[0]} failed") from error
+    return result.stdout
+
+
 def _copy_to_clipboard_with_tkinter(text: str) -> None:
     try:
         import tkinter
@@ -545,81 +220,6 @@ def _read_from_clipboard_with_tkinter() -> str:
 
 
 def _read_text_file(path: str) -> str:
+    from pathlib import Path
+
     return Path(path).read_text(encoding="utf-8")
-
-
-def _render_template_path(path: str, template_key: str) -> str:
-    if template_key == "windows":
-        return subprocess.list2cmdline([path])
-    return shlex.quote(path)
-
-
-def _windows_set_location_command(path: str) -> str:
-    escaped_path = path.replace("'", "''")
-    return f"Set-Location -LiteralPath '{escaped_path}'"
-
-
-def _windows_cd_command(path: str) -> str:
-    escaped_path = path.replace('"', '""')
-    return f'cd /d "{escaped_path}"'
-
-
-def _resolve_existing_path(path: str) -> Path:
-    resolved_path = Path(path).expanduser().resolve()
-    if not resolved_path.exists():
-        raise OSError(f"Not found: {resolved_path}")
-    return resolved_path
-
-
-def _resolve_directory_path(path: str) -> Path:
-    resolved_path = _resolve_existing_path(path)
-    if not resolved_path.is_dir():
-        raise OSError(f"Not a directory: {resolved_path}")
-    return resolved_path
-
-
-def _is_terminal_editor_command(command: str) -> bool:
-    return Path(command).name.casefold() in TERMINAL_EDITOR_NAMES
-
-
-def _build_command_candidate(
-    parsed_command: tuple[str, ...],
-    path: str,
-    line_number: int | None = None,
-) -> tuple[str, ...] | None:
-    """Build a terminal editor command candidate. Returns None for non-terminal editors."""
-    if not parsed_command or not _is_terminal_editor_command(parsed_command[0]):
-        return None
-    if line_number is not None:
-        editor_name = Path(parsed_command[0]).name.casefold()
-        if editor_name in EMBEDDED_LINE_NUMBER_EDITOR_NAMES:
-            return parsed_command + (f"{path}:{line_number}",)
-        return parsed_command + (f"+{line_number}", path)
-    return parsed_command + (path,)
-
-
-def _dedupe_commands(commands: Sequence[tuple[str, ...]]) -> tuple[tuple[str, ...], ...]:
-    seen: set[tuple[str, ...]] = set()
-    unique_commands: list[tuple[str, ...]] = []
-    for command in commands:
-        if command in seen:
-            continue
-        seen.add(command)
-        unique_commands.append(command)
-    return tuple(unique_commands)
-
-
-def _is_wsl_environment(
-    environment_variable: EnvironmentVariableReader,
-    text_file_reader: TextFileReader,
-) -> bool:
-    if environment_variable("WSL_DISTRO_NAME") is not None:
-        return True
-    if environment_variable("WSL_INTEROP") is not None:
-        return True
-
-    try:
-        proc_version = text_file_reader("/proc/version")
-    except OSError:
-        return False
-    return "microsoft" in proc_version.casefold()

--- a/src/zivo/adapters/platforms/__init__.py
+++ b/src/zivo/adapters/platforms/__init__.py
@@ -1,0 +1,44 @@
+"""Platform-specific external launcher implementations."""
+
+from __future__ import annotations
+
+from .base import (
+    BasePlatformLaunchAdapter,
+    PlatformAdapterContext,
+    PlatformKind,
+    is_wsl_environment,
+)
+from .linux import LinuxPlatformLaunchAdapter
+from .macos import MacOSPlatformLaunchAdapter
+from .windows import WindowsPlatformLaunchAdapter
+from .wsl import WslPlatformLaunchAdapter
+
+
+def resolve_platform_kind(
+    system_name: str,
+    *,
+    environment_variable,
+    text_file_reader,
+) -> PlatformKind:
+    if system_name == "Darwin":
+        return "darwin"
+    if system_name == "Linux":
+        if is_wsl_environment(environment_variable, text_file_reader):
+            return "wsl"
+        return "linux"
+    if system_name == "Windows":
+        return "windows"
+    raise OSError(f"Unsupported operating system: {system_name}")
+
+
+def resolve_platform_adapter(
+    kind: PlatformKind,
+    context: PlatformAdapterContext,
+) -> BasePlatformLaunchAdapter:
+    if kind == "linux":
+        return LinuxPlatformLaunchAdapter(context)
+    if kind == "wsl":
+        return WslPlatformLaunchAdapter(context)
+    if kind == "darwin":
+        return MacOSPlatformLaunchAdapter(context)
+    return WindowsPlatformLaunchAdapter(context)

--- a/src/zivo/adapters/platforms/base.py
+++ b/src/zivo/adapters/platforms/base.py
@@ -1,0 +1,392 @@
+"""Shared platform launcher infrastructure."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from zivo.models import EditorConfig, TerminalConfig
+
+PlatformKind = Literal["linux", "wsl", "darwin", "windows"]
+CommandRunner = Callable[[Sequence[str], str | None, str | None], None]
+ForegroundCommandRunner = Callable[[Sequence[str], str | None], None]
+CommandAvailability = Callable[[str], str | None]
+CommandOutputReader = Callable[[Sequence[str]], str]
+ClipboardFallback = Callable[[str], None]
+ClipboardReader = Callable[[], str]
+EnvironmentVariableReader = Callable[[str], str | None]
+TextFileReader = Callable[[str], str]
+
+TERMINAL_EDITOR_NAMES = frozenset(
+    {"edit", "emacs", "helix", "hx", "kak", "micro", "msedit", "nano", "nvim", "vi", "vim"}
+)
+EMBEDDED_LINE_NUMBER_EDITOR_NAMES = frozenset({"edit", "msedit"})
+
+_PLATFORM_TEMPLATE_KEYS: dict[PlatformKind, tuple[str, ...]] = {
+    "linux": ("linux",),
+    "darwin": ("macos",),
+    "wsl": ("windows", "linux"),
+    "windows": ("windows",),
+}
+
+
+@dataclass(frozen=True)
+class PlatformAdapterContext:
+    """Dependencies shared by all platform-specific launcher implementations."""
+
+    command_available: CommandAvailability
+    command_runner: CommandRunner
+    foreground_command_runner: ForegroundCommandRunner
+    clipboard_command_reader: CommandOutputReader
+    environment_variable: EnvironmentVariableReader
+    text_file_reader: TextFileReader
+    clipboard_fallbacks: tuple[ClipboardFallback, ...]
+    clipboard_readers: tuple[ClipboardReader, ...]
+    terminal_command_templates: TerminalConfig
+    editor_command_template: EditorConfig
+
+
+@dataclass(frozen=True)
+class BasePlatformLaunchAdapter:
+    """Common external launch behavior with platform-specific candidate hooks."""
+
+    context: PlatformAdapterContext
+
+    @property
+    def platform_kind(self) -> PlatformKind:
+        raise NotImplementedError
+
+    def open_with_default_app(self, path: str) -> None:
+        resolved_path = _resolve_existing_path(path)
+        cwd = str(resolved_path if resolved_path.is_dir() else resolved_path.parent)
+        self._run_first_available(
+            self.default_app_candidates(str(resolved_path)),
+            context=f"open {resolved_path}",
+            cwd=cwd,
+        )
+
+    def open_in_editor(self, path: str, line_number: int | None = None) -> None:
+        resolved_path = _resolve_existing_path(path)
+        candidates = self._editor_candidates(str(resolved_path), line_number)
+        errors: list[str] = []
+        for command in candidates:
+            try:
+                self.context.foreground_command_runner(command, str(resolved_path.parent))
+                return
+            except OSError as error:
+                errors.append(str(error) or f"{command[0]} failed")
+
+        raise OSError(errors[-1] if errors else f"Failed to open {resolved_path} in editor")
+
+    def open_terminal(
+        self,
+        path: str,
+        launch_mode: Literal["window", "foreground"] = "window",
+    ) -> None:
+        resolved_path = _resolve_directory_path(path)
+        if launch_mode == "foreground":
+            command = self._foreground_terminal_command()
+            self.context.foreground_command_runner(command, str(resolved_path))
+            return
+
+        self._run_first_available(
+            self.terminal_candidates(str(resolved_path)),
+            context=f"open terminal in {resolved_path}",
+            cwd=str(resolved_path),
+        )
+
+    def copy_to_clipboard(self, text: str) -> None:
+        available_candidates = [
+            command
+            for command in self.clipboard_candidates()
+            if self.context.command_available(command[0]) is not None
+        ]
+        if available_candidates:
+            self._run_first_available(
+                tuple(available_candidates),
+                context="copy to clipboard",
+                input_text=text,
+            )
+            return
+
+        fallback_errors: list[str] = []
+        for fallback in self.context.clipboard_fallbacks:
+            try:
+                fallback(text)
+                return
+            except OSError as error:
+                fallback_errors.append(str(error) or "clipboard fallback failed")
+
+        if fallback_errors:
+            raise OSError(fallback_errors[-1])
+        raise OSError("No supported command found to copy to clipboard")
+
+    def get_from_clipboard(self) -> str:
+        available_candidates = [
+            command
+            for command in self.clipboard_read_candidates()
+            if self._command_exists(command[0])
+        ]
+        if available_candidates:
+            return self._read_first_available(tuple(available_candidates))
+
+        fallback_errors: list[str] = []
+        for reader in self.context.clipboard_readers:
+            try:
+                return reader()
+            except OSError as error:
+                fallback_errors.append(str(error) or "clipboard reader failed")
+
+        if fallback_errors:
+            raise OSError(fallback_errors[-1])
+        raise OSError("No supported command found to read from clipboard")
+
+    def default_app_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        raise NotImplementedError
+
+    def terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return self._configured_terminal_commands(path) + self.default_terminal_candidates(path)
+
+    def default_terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        raise NotImplementedError
+
+    def clipboard_candidates(self) -> tuple[tuple[str, ...], ...]:
+        raise NotImplementedError
+
+    def clipboard_read_candidates(self) -> tuple[tuple[str, ...], ...]:
+        raise NotImplementedError
+
+    def _run_first_available(
+        self,
+        candidates: tuple[tuple[str, ...], ...],
+        *,
+        context: str,
+        cwd: str | None = None,
+        input_text: str | None = None,
+    ) -> None:
+        available_candidates = [
+            command for command in candidates if self._command_exists(command[0])
+        ]
+        if not available_candidates:
+            raise OSError(f"No supported command found to {context}")
+
+        errors: list[str] = []
+        for command in available_candidates:
+            try:
+                self.context.command_runner(command, cwd, input_text)
+                return
+            except OSError as error:
+                errors.append(str(error) or f"{command[0]} failed")
+
+        raise OSError(errors[-1] if errors else f"Failed to {context}")
+
+    def _read_first_available(self, candidates: tuple[tuple[str, ...], ...]) -> str:
+        errors: list[str] = []
+        for command in candidates:
+            try:
+                return self.context.clipboard_command_reader(command)
+            except OSError as error:
+                errors.append(str(error) or f"{command[0]} failed")
+
+        raise OSError(errors[-1] if errors else "Failed to read from clipboard")
+
+    def _editor_candidates(
+        self,
+        path: str,
+        line_number: int | None = None,
+    ) -> tuple[tuple[str, ...], ...]:
+        editor_commands = [
+            command
+            for command in self._terminal_editor_commands(path, line_number)
+            if self._command_exists(command[0])
+        ]
+        if not editor_commands:
+            raise OSError("No supported terminal editor found")
+        return tuple(editor_commands)
+
+    def _terminal_editor_commands(
+        self,
+        path: str,
+        line_number: int | None = None,
+    ) -> tuple[tuple[str, ...], ...]:
+        is_windows = self.platform_kind == "windows"
+        commands: list[tuple[str, ...]] = []
+
+        configured_editor_command = self.context.editor_command_template.command
+        if configured_editor_command:
+            candidate = _build_command_candidate(
+                tuple(shlex.split(configured_editor_command, posix=not is_windows)),
+                path,
+                line_number,
+            )
+            if candidate is not None:
+                commands.append(candidate)
+
+        editor_command = self.context.environment_variable("EDITOR")
+        if editor_command:
+            try:
+                parsed_command = tuple(shlex.split(editor_command, posix=not is_windows))
+            except ValueError as error:
+                raise OSError(f"Invalid EDITOR value: {error}") from error
+            candidate = _build_command_candidate(parsed_command, path, line_number)
+            if candidate is not None:
+                commands.append(candidate)
+
+        commands.extend(self._default_terminal_editor_commands(path, line_number))
+        return _dedupe_commands(commands)
+
+    def _default_terminal_editor_commands(
+        self,
+        path: str,
+        line_number: int | None = None,
+    ) -> tuple[tuple[str, ...], ...]:
+        if line_number is not None:
+            commands = (
+                ("nvim", f"+{line_number}", path),
+                ("vim", f"+{line_number}", path),
+                ("nano", f"+{line_number}", path),
+                ("hx", f"+{line_number}", path),
+                ("micro", f"+{line_number}", path),
+                ("emacs", "-nw", f"+{line_number}", path),
+            )
+        else:
+            commands = (
+                ("nvim", path),
+                ("vim", path),
+                ("nano", path),
+                ("hx", path),
+                ("micro", path),
+                ("emacs", "-nw", path),
+            )
+        if self.platform_kind == "windows":
+            edit_command = ("edit", f"{path}:{line_number}") if line_number is not None else (
+                "edit",
+                path,
+            )
+            commands = commands + (edit_command,)
+        return commands
+
+    def _command_exists(self, command: str) -> bool:
+        command_path = Path(command)
+        if command_path.is_absolute():
+            return command_path.exists()
+        return self.context.command_available(command) is not None
+
+    def _foreground_terminal_command(self) -> tuple[str, ...]:
+        if self.platform_kind == "windows":
+            powershell = self.context.command_available("powershell.exe")
+            if powershell is not None:
+                return (powershell, "-NoExit", "-NoLogo")
+            return ("cmd.exe", "/k")
+
+        shell = self.context.environment_variable("SHELL")
+        if shell:
+            try:
+                parsed = tuple(shlex.split(shell))
+            except ValueError as error:
+                raise OSError(f"Invalid SHELL value: {error}") from error
+            if parsed and self._command_exists(parsed[0]):
+                return (*parsed, "-i")
+        if self._command_exists("/bin/bash"):
+            return ("/bin/bash", "-i")
+        raise OSError("No supported interactive shell found for foreground terminal mode")
+
+    def _configured_terminal_commands(self, path: str) -> tuple[tuple[str, ...], ...]:
+        template_keys = _PLATFORM_TEMPLATE_KEYS[self.platform_kind]
+        template_map = {
+            "linux": self.context.terminal_command_templates.linux,
+            "macos": self.context.terminal_command_templates.macos,
+            "windows": self.context.terminal_command_templates.windows,
+        }
+        commands: list[tuple[str, ...]] = []
+        for key in template_keys:
+            for template in template_map[key]:
+                try:
+                    rendered = template.format(path=_render_template_path(path, key))
+                    parsed_command = tuple(shlex.split(rendered, posix=key != "windows"))
+                except (IndexError, KeyError, ValueError):
+                    continue
+                if parsed_command:
+                    commands.append(parsed_command)
+        return _dedupe_commands(commands)
+
+
+def _resolve_existing_path(path: str) -> Path:
+    resolved_path = Path(path).expanduser().resolve()
+    if not resolved_path.exists():
+        raise OSError(f"Not found: {resolved_path}")
+    return resolved_path
+
+
+def _resolve_directory_path(path: str) -> Path:
+    resolved_path = _resolve_existing_path(path)
+    if not resolved_path.is_dir():
+        raise OSError(f"Not a directory: {resolved_path}")
+    return resolved_path
+
+
+def _render_template_path(path: str, template_key: str) -> str:
+    if template_key == "windows":
+        import subprocess
+
+        return subprocess.list2cmdline([path])
+    return shlex.quote(path)
+
+
+def _windows_set_location_command(path: str) -> str:
+    escaped_path = path.replace("'", "''")
+    return f"Set-Location -LiteralPath '{escaped_path}'"
+
+
+def _windows_cd_command(path: str) -> str:
+    escaped_path = path.replace('"', '""')
+    return f'cd /d "{escaped_path}"'
+
+
+def _is_terminal_editor_command(command: str) -> bool:
+    return Path(command).name.casefold() in TERMINAL_EDITOR_NAMES
+
+
+def _build_command_candidate(
+    parsed_command: tuple[str, ...],
+    path: str,
+    line_number: int | None = None,
+) -> tuple[str, ...] | None:
+    if not parsed_command or not _is_terminal_editor_command(parsed_command[0]):
+        return None
+    if line_number is not None:
+        editor_name = Path(parsed_command[0]).name.casefold()
+        if editor_name in EMBEDDED_LINE_NUMBER_EDITOR_NAMES:
+            return parsed_command + (f"{path}:{line_number}",)
+        return parsed_command + (f"+{line_number}", path)
+    return parsed_command + (path,)
+
+
+def _dedupe_commands(commands: Sequence[tuple[str, ...]]) -> tuple[tuple[str, ...], ...]:
+    seen: set[tuple[str, ...]] = set()
+    unique_commands: list[tuple[str, ...]] = []
+    for command in commands:
+        if command in seen:
+            continue
+        seen.add(command)
+        unique_commands.append(command)
+    return tuple(unique_commands)
+
+
+def is_wsl_environment(
+    environment_variable: EnvironmentVariableReader,
+    text_file_reader: TextFileReader,
+) -> bool:
+    if environment_variable("WSL_DISTRO_NAME") is not None:
+        return True
+    if environment_variable("WSL_INTEROP") is not None:
+        return True
+
+    try:
+        proc_version = text_file_reader("/proc/version")
+    except OSError:
+        return False
+    return "microsoft" in proc_version.casefold()

--- a/src/zivo/adapters/platforms/linux.py
+++ b/src/zivo/adapters/platforms/linux.py
@@ -1,0 +1,45 @@
+"""Linux-specific external launcher commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import BasePlatformLaunchAdapter
+
+
+@dataclass(frozen=True)
+class LinuxPlatformLaunchAdapter(BasePlatformLaunchAdapter):
+    @property
+    def platform_kind(self) -> str:
+        return "linux"
+
+    def default_app_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (("xdg-open", path), ("gio", "open", path))
+
+    def default_terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("kgx",),
+            ("gnome-console",),
+            ("gnome-terminal",),
+            ("xfce4-terminal",),
+            ("mate-terminal",),
+            ("tilix",),
+            ("konsole",),
+            ("lxterminal",),
+            ("x-terminal-emulator",),
+            ("xterm",),
+        )
+
+    def clipboard_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("wl-copy",),
+            ("xclip", "-in", "-selection", "clipboard"),
+            ("xsel", "--clipboard", "--input"),
+        )
+
+    def clipboard_read_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("wl-paste", "--no-newline"),
+            ("xclip", "-out", "-selection", "clipboard"),
+            ("xsel", "--clipboard", "--output"),
+        )

--- a/src/zivo/adapters/platforms/macos.py
+++ b/src/zivo/adapters/platforms/macos.py
@@ -1,0 +1,26 @@
+"""macOS-specific external launcher commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import BasePlatformLaunchAdapter
+
+
+@dataclass(frozen=True)
+class MacOSPlatformLaunchAdapter(BasePlatformLaunchAdapter):
+    @property
+    def platform_kind(self) -> str:
+        return "darwin"
+
+    def default_app_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (("open", path),)
+
+    def default_terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (("open", "-a", "Terminal", path),)
+
+    def clipboard_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (("pbcopy",),)
+
+    def clipboard_read_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (("pbpaste",),)

--- a/src/zivo/adapters/platforms/windows.py
+++ b/src/zivo/adapters/platforms/windows.py
@@ -1,0 +1,53 @@
+"""Windows-specific external launcher commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import BasePlatformLaunchAdapter, _windows_cd_command, _windows_set_location_command
+
+
+@dataclass(frozen=True)
+class WindowsPlatformLaunchAdapter(BasePlatformLaunchAdapter):
+    @property
+    def platform_kind(self) -> str:
+        return "windows"
+
+    def default_app_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("cmd.exe", "/c", "start", "", path),
+            ("powershell.exe", "-NoProfile", "-Command", "Start-Process", path),
+        )
+
+    def default_terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("wt.exe", "-d", path),
+            (
+                "cmd.exe",
+                "/c",
+                "start",
+                "",
+                "powershell.exe",
+                "-NoExit",
+                "-Command",
+                _windows_set_location_command(path),
+            ),
+            (
+                "cmd.exe",
+                "/c",
+                "start",
+                "",
+                "cmd.exe",
+                "/k",
+                _windows_cd_command(path),
+            ),
+        )
+
+    def clipboard_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (
+            ("clip.exe",),
+            ("powershell.exe", "-NoProfile", "-Command", "Set-Clipboard"),
+        )
+
+    def clipboard_read_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (("powershell.exe", "-NoProfile", "-Command", "Get-Clipboard"),)

--- a/src/zivo/adapters/platforms/wsl.py
+++ b/src/zivo/adapters/platforms/wsl.py
@@ -1,0 +1,31 @@
+"""WSL-specific external launcher commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import BasePlatformLaunchAdapter
+from .linux import LinuxPlatformLaunchAdapter
+
+
+@dataclass(frozen=True)
+class WslPlatformLaunchAdapter(BasePlatformLaunchAdapter):
+    @property
+    def platform_kind(self) -> str:
+        return "wsl"
+
+    def default_app_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        return (("wslview", path), ("explorer.exe", path))
+
+    def default_terminal_candidates(self, path: str) -> tuple[tuple[str, ...], ...]:
+        linux_defaults = LinuxPlatformLaunchAdapter(self.context).default_terminal_candidates(path)
+        return (
+            ("wt.exe", "wsl.exe", "--cd", path),
+            ("cmd.exe", "/c", "start", "", "wsl.exe", "--cd", path),
+        ) + linux_defaults
+
+    def clipboard_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (("clip.exe",),)
+
+    def clipboard_read_candidates(self) -> tuple[tuple[str, ...], ...]:
+        return (("powershell.exe", "-noprofile", "-command", "Get-Clipboard"),)


### PR DESCRIPTION
## Summary
- split external launcher platform-specific command candidates into dedicated modules under `src/zivo/adapters/platforms/`
- keep `LocalExternalLaunchAdapter` and internal test-facing helpers available from `src/zivo/adapters/external_launcher.py`
- move shared launch behavior into a common platform base and resolve Linux/WSL/macOS/Windows strategies through a platform resolver

## Testing
- `uv run pytest tests/test_services_external_launcher.py`
- `uv run pytest`
- `uv run ruff check .`

Closes #767
