### PR TITLE
[#768] Refactor filesystem attribute resolution

### DIFF
--- a/src/zivo/adapters/filesystem.py
+++ b/src/zivo/adapters/filesystem.py
@@ -4,11 +4,12 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from functools import lru_cache
 from pathlib import Path
 from typing import Protocol
 
 from zivo.state.models import DirectoryEntryState
+
+from .filesystem_attributes import resolve_owner_group
 
 
 class DirectoryReader(Protocol):
@@ -135,8 +136,7 @@ def _build_directory_entry_details(path: Path) -> DirectoryEntryState | None:
             )
         return None
     kind = "dir" if path.is_dir() else "file"
-    owner = _resolve_user_name(stat_result.st_uid)
-    group = _resolve_group_name(stat_result.st_gid)
+    owner, group = resolve_owner_group(stat_result)
     return DirectoryEntryState(
         path=str(path),
         name=path.name,
@@ -184,27 +184,3 @@ def _calculate_directory_size(
 
 class DirectorySizeCancelled(RuntimeError):
     """Raised internally to abort a recursive size walk."""
-
-
-@lru_cache(maxsize=256)
-def _resolve_user_name(uid: int) -> str | None:
-    try:
-        import pwd
-    except ImportError:
-        return None
-    try:
-        return pwd.getpwuid(uid).pw_name
-    except (KeyError, OSError):
-        return None
-
-
-@lru_cache(maxsize=256)
-def _resolve_group_name(gid: int) -> str | None:
-    try:
-        import grp
-    except ImportError:
-        return None
-    try:
-        return grp.getgrgid(gid).gr_name
-    except (KeyError, OSError):
-        return None

--- a/src/zivo/adapters/filesystem_attributes.py
+++ b/src/zivo/adapters/filesystem_attributes.py
@@ -1,0 +1,100 @@
+"""Internal helpers for OS-aware filesystem attribute resolution."""
+
+from __future__ import annotations
+
+import os
+import platform
+from collections.abc import Callable
+from functools import lru_cache
+from typing import Protocol
+
+from zivo.adapters.platforms.base import is_wsl_environment
+
+EnvironmentVariableReader = Callable[[str], str | None]
+TextFileReader = Callable[[str], str]
+
+
+class FileAttributeResolver(Protocol):
+    """Resolve optional owner/group names for a filesystem stat result."""
+
+    def resolve_owner_group(self, stat_result: os.stat_result) -> tuple[str | None, str | None]: ...
+
+
+class NullFileAttributeResolver:
+    """Return no owner/group details on platforms without supported lookup."""
+
+    def resolve_owner_group(self, stat_result: os.stat_result) -> tuple[str | None, str | None]:
+        return (None, None)
+
+
+class UnixFileAttributeResolver:
+    """Resolve owner/group names with Unix account databases when available."""
+
+    def resolve_owner_group(self, stat_result: os.stat_result) -> tuple[str | None, str | None]:
+        uid = getattr(stat_result, "st_uid", None)
+        gid = getattr(stat_result, "st_gid", None)
+        return (_resolve_user_name(uid), _resolve_group_name(gid))
+
+
+def resolve_owner_group(
+    stat_result: os.stat_result,
+    *,
+    system_name: str | None = None,
+    environment_variable: EnvironmentVariableReader = os.environ.get,
+    text_file_reader: TextFileReader | None = None,
+) -> tuple[str | None, str | None]:
+    """Return best-effort owner/group names for the current environment."""
+
+    return _select_file_attribute_resolver(
+        system_name or platform.system(),
+        environment_variable=environment_variable,
+        text_file_reader=text_file_reader or _read_text_file,
+    ).resolve_owner_group(stat_result)
+
+
+@lru_cache(maxsize=None)
+def _select_file_attribute_resolver(
+    system_name: str,
+    *,
+    environment_variable: EnvironmentVariableReader,
+    text_file_reader: TextFileReader,
+) -> FileAttributeResolver:
+    if system_name == "Windows":
+        return NullFileAttributeResolver()
+    if system_name == "Linux" and is_wsl_environment(environment_variable, text_file_reader):
+        return UnixFileAttributeResolver()
+    if system_name in {"Linux", "Darwin"}:
+        return UnixFileAttributeResolver()
+    return NullFileAttributeResolver()
+
+
+def _read_text_file(path: str) -> str:
+    return open(path, encoding="utf-8").read()
+
+
+@lru_cache(maxsize=256)
+def _resolve_user_name(uid: int | None) -> str | None:
+    if uid is None:
+        return None
+    try:
+        import pwd
+    except ImportError:
+        return None
+    try:
+        return pwd.getpwuid(uid).pw_name
+    except (KeyError, OSError):
+        return None
+
+
+@lru_cache(maxsize=256)
+def _resolve_group_name(gid: int | None) -> str | None:
+    if gid is None:
+        return None
+    try:
+        import grp
+    except ImportError:
+        return None
+    try:
+        return grp.getgrgid(gid).gr_name
+    except (KeyError, OSError):
+        return None

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -1,6 +1,7 @@
 import builtins
 import importlib
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -89,18 +90,50 @@ def test_local_filesystem_adapter_inspect_entry_returns_none_owner_group_when_un
     tmp_path,
     monkeypatch,
 ) -> None:
-    filesystem_module = importlib.import_module("zivo.adapters.filesystem")
+    helper_module = importlib.import_module("zivo.adapters.filesystem_attributes")
     readme = tmp_path / "README.md"
     readme.write_text("plain\n", encoding="utf-8")
     adapter = LocalFilesystemAdapter()
-    monkeypatch.setattr(filesystem_module, "_resolve_user_name", lambda _uid: None)
-    monkeypatch.setattr(filesystem_module, "_resolve_group_name", lambda _gid: None)
+    monkeypatch.setattr(helper_module, "_resolve_user_name", lambda _uid: None)
+    monkeypatch.setattr(helper_module, "_resolve_group_name", lambda _gid: None)
 
     entry = adapter.inspect_entry(str(readme))
 
     assert entry is not None
     assert entry.owner is None
     assert entry.group is None
+
+
+def test_resolve_owner_group_returns_safe_none_on_native_windows() -> None:
+    helper_module = importlib.import_module("zivo.adapters.filesystem_attributes")
+    helper_module._select_file_attribute_resolver.cache_clear()
+    stat_result = SimpleNamespace(st_uid=123, st_gid=456)
+
+    owner, group = helper_module.resolve_owner_group(
+        stat_result,
+        system_name="Windows",
+    )
+
+    assert owner is None
+    assert group is None
+
+
+def test_resolve_owner_group_treats_wsl_as_unix_lookup(monkeypatch) -> None:
+    helper_module = importlib.import_module("zivo.adapters.filesystem_attributes")
+    helper_module._select_file_attribute_resolver.cache_clear()
+    stat_result = SimpleNamespace(st_uid=123, st_gid=456)
+    monkeypatch.setattr(helper_module, "_resolve_user_name", lambda uid: f"user-{uid}")
+    monkeypatch.setattr(helper_module, "_resolve_group_name", lambda gid: f"group-{gid}")
+
+    owner, group = helper_module.resolve_owner_group(
+        stat_result,
+        system_name="Linux",
+        environment_variable=lambda name: "Ubuntu" if name == "WSL_DISTRO_NAME" else None,
+        text_file_reader=lambda _path: "",
+    )
+
+    assert owner == "user-123"
+    assert group == "group-456"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")


### PR DESCRIPTION
## Summary
- extract OS-aware owner/group lookup from `filesystem.py` into an internal helper module
- keep `LocalFilesystemAdapter` public behavior unchanged while adding safe native Windows fallback
- extend filesystem adapter tests for Windows fallback and WSL Unix-style lookup

## Testing
- `uv run pytest`
- `uv run ruff check .`

## Related
- Closes #768
