### PR TITLE
#777 Fix go to path root candidates

### DIFF
--- a/src/zivo/state/reducer_path_helpers.py
+++ b/src/zivo/state/reducer_path_helpers.py
@@ -315,6 +315,8 @@ def _uses_windows_path_rules(base_path: str, query: str) -> bool:
     normalized_query = query.strip().replace("/", "\\")
     if not normalized_query:
         return False
+    if query.strip().startswith("/"):
+        return False
     if normalized_query.startswith("\\"):
         return True
     return bool(ntpath.splitdrive(normalized_query)[0])

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -442,10 +442,19 @@ def test_set_command_palette_query_shows_root_directory_candidates_for_slash() -
     )
 
     next_state = _reduce_state(state, SetCommandPaletteQuery("/"))
+    expected_candidates = tuple(
+        sorted(
+            (
+                str(child.resolve())
+                for child in Path("/").iterdir()
+                if child.is_dir()
+            ),
+            key=lambda path: (Path(path).name.casefold(), path),
+        )
+    )
 
     assert next_state.command_palette is not None
-    assert "/home" in next_state.command_palette.go_to_path_candidates
-    assert "/usr" in next_state.command_palette.go_to_path_candidates
+    assert next_state.command_palette.go_to_path_candidates == expected_candidates
 
 def test_submit_go_to_path_palette_requests_snapshot(tmp_path) -> None:
     state = _reduce_state(

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -435,6 +435,18 @@ def test_set_command_palette_query_resolves_relative_go_to_path_candidates(tmp_p
         str(tmp_path / "projects" / "zivo"),
     )
 
+def test_set_command_palette_query_shows_root_directory_candidates_for_slash() -> None:
+    state = _reduce_state(
+        replace(build_initial_app_state(), current_path="/tmp"),
+        BeginGoToPath(),
+    )
+
+    next_state = _reduce_state(state, SetCommandPaletteQuery("/"))
+
+    assert next_state.command_palette is not None
+    assert "/home" in next_state.command_palette.go_to_path_candidates
+    assert "/usr" in next_state.command_palette.go_to_path_candidates
+
 def test_submit_go_to_path_palette_requests_snapshot(tmp_path) -> None:
     state = _reduce_state(
         replace(build_initial_app_state(), current_path=str(tmp_path)),


### PR DESCRIPTION
## Summary
- fix Unix path handling so `go to path` treats `/` and `/...` as absolute POSIX paths instead of Windows-style paths
- restore root-level directory suggestions when `/` is entered in the command palette
- add a reducer regression test covering `/` completion

## Test Results
- `uv run pytest -q tests/test_state_reducer_palette_commands.py -k go_to_path`
- `uv run pytest -q tests/test_app.py -k go_to_path`
- `uv run ruff check .`
- `uv run pytest -q`

## Follow-up
- none

Closes #777
