### PR TITLE
Issue #781: Add numeric tab shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ You can open an external terminal directly from zivo. Press `t` to suspend zivo 
 | `T` | Open terminal at current directory (separate window) |
 | `o` | Open new tab |
 | `w` | Close current tab |
+| `1`-`9`, `0` | Switch to tab 1-9, or tab 10 with `0` |
 | `tab` | Switch to next tab |
 | `shift+tab` | Switch to previous tab |
 | `M` | Open current directory in file manager |
@@ -236,7 +237,7 @@ You can open an external terminal directly from zivo. Press `t` to suspend zivo 
 | `]` | Scroll the right-pane text preview down by a page |
 | `{` | Go back in history |
 | `}` | Go forward in history |
-| `2` | Toggle two-pane transfer mode |
+| `p` | Toggle two-pane transfer mode |
 
 ### Transfer Mode
 
@@ -267,7 +268,9 @@ You can open an external terminal directly from zivo. Press `t` to suspend zivo 
 | `b` | Show bookmarks |
 | `H` | Show history |
 | `:` | Open a transfer-mode command palette with transfer-available commands only |
+| `1`-`9`, `0` | Switch to tab 1-9, or tab 10 with `0` |
 | `Tab` / `Shift+Tab` | Switch browser tabs, same as normal mode |
+| `p` / `Esc` | Return to normal mode |
 
 ### Input Dialogs
 
@@ -355,7 +358,7 @@ The tab strip is only shown when two or more browser tabs are open.
 | `Go to path` | Always | Opens go-to-path input to navigate to a specific path, shows matching directories, and supports `Tab` completion for the selected candidate. On native Windows, drive roots are also offered so you can switch between drives quickly. |
 | `Go to home directory` | Always | Navigates to the home directory. |
 | `Reload directory` | Always | Reloads the current directory. |
-| `Toggle transfer mode` / `Close transfer mode` | Always | Switches between the normal three-pane browser and the two-pane transfer layout. Also available with `q` / `2` while transfer mode is open, and `2` from normal mode. |
+| `Toggle transfer mode` / `Close transfer mode` | Always | Switches between the normal three-pane browser and the two-pane transfer layout. Also available with `p` from normal mode, and `p` / `Esc` while transfer mode is open. |
 | `Undo last file operation` | Undo history is not empty | Reverses the most recent undoable rename, paste, or trash operation. Also available with `z`. |
 | `Select all` | Current directory has at least one visible entry | Selects every currently visible entry in the current directory, respecting hidden-file visibility and any active filter. |
 | `Replace text in selected files` | A file is focused or one or more files are selected in the current directory | Opens a two-field replacement palette for the selected files, or the focused file when nothing is explicitly selected. Matching files appear in the palette, `↑↓` and `Ctrl+n` / `Ctrl+p` move between them, and the right pane shows the selected file's diff before `Enter` applies the replacement. `Shift+↑` / `Shift+↓` scrolls the diff preview. |

--- a/src/zivo/state/actions.py
+++ b/src/zivo/state/actions.py
@@ -115,6 +115,7 @@ __all__ = [
 from .actions_navigation import (
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     AddBookmark,
     ClearTransferSelection,
     CloseCurrentTab,
@@ -314,6 +315,7 @@ Action = (
     | SetFilterQuery
     | PasteIntoPendingInput
     | OpenNewTab
+    | ActivateTabByIndex
     | ActivateNextTab
     | ActivatePreviousTab
     | CloseCurrentTab

--- a/src/zivo/state/actions_navigation.py
+++ b/src/zivo/state/actions_navigation.py
@@ -22,6 +22,13 @@ class ActivatePreviousTab:
 
 
 @dataclass(frozen=True)
+class ActivateTabByIndex:
+    """Activate a browser tab by its zero-based index."""
+
+    index: int
+
+
+@dataclass(frozen=True)
 class CloseCurrentTab:
     """Close the currently active browser tab."""
 

--- a/src/zivo/state/input_browsing.py
+++ b/src/zivo/state/input_browsing.py
@@ -4,6 +4,7 @@ from .actions import (
     Action,
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     AddBookmark,
     BeginBookmarkSearch,
     BeginCommandPalette,
@@ -78,7 +79,7 @@ BROWSING_KEYMAP = {
     "h": "go_to_parent",
     "R": "reload_directory",
     "q": "exit_current_path",
-    "2": "toggle_transfer_mode",
+    "p": "toggle_transfer_mode",
     "r": "begin_rename",
     "!": "begin_shell_command",
     ":": "begin_command_palette",
@@ -146,6 +147,10 @@ def dispatch_browsing_input(
             multi_key_command_dispatch=multi_key_command_dispatch,
         )
 
+    direct_tab_actions = dispatch_direct_tab_input(state, key=key)
+    if direct_tab_actions:
+        return direct_tab_actions
+
     command = BROWSING_KEYMAP.get(key)
     if command is not None:
         handler = BROWSING_COMMAND_DISPATCH.get(command)
@@ -167,6 +172,17 @@ def dispatch_browsing_input(
 
 def noop_browsing_handler(_state: AppState, _ctx: BrowsingCtx) -> DispatchedActions:
     return ()
+
+
+def dispatch_direct_tab_input(state: AppState, *, key: str) -> DispatchedActions:
+    if len(key) != 1 or not key.isdigit():
+        return ()
+
+    tab_number = 10 if key == "0" else int(key)
+    tab_count = len(state.browser_tabs) if state.browser_tabs else 1
+    if tab_number > tab_count:
+        return warn(f"Tab {tab_number} is not open")
+    return supported(ActivateTabByIndex(tab_number - 1))
 
 
 def simple(action_cls: type[Action]) -> BrowsingHandler:

--- a/src/zivo/state/input_transfer.py
+++ b/src/zivo/state/input_transfer.py
@@ -3,6 +3,7 @@
 from .actions import (
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     BeginBookmarkSearch,
     BeginCommandPalette,
     BeginCreateInput,
@@ -73,6 +74,7 @@ TRANSFER_KEYMAP = {
     "tab",
     "shift+tab",
     ":",
+    "p",
 }
 
 
@@ -87,6 +89,10 @@ def dispatch_transfer_input(
     if transfer is None:
         return supported(ToggleTransferMode())
     visible_paths = _visible_paths(state, transfer.pane)
+
+    direct_tab_actions = _dispatch_direct_tab_input(state, key=key)
+    if direct_tab_actions:
+        return direct_tab_actions
 
     if key == "tab":
         return supported(ActivateNextTab())
@@ -157,6 +163,8 @@ def dispatch_transfer_input(
         return supported(BeginBookmarkSearch())
     if key == ":":
         return supported(BeginCommandPalette())
+    if key == "p":
+        return supported(ToggleTransferMode())
 
     if key == "N":
         return supported(BeginCreateInput("dir"))
@@ -221,8 +229,9 @@ def dispatch_transfer_input(
         return supported(PasteClipboardToTransferPane())
 
     return warn(
-        "Use [], space, c copy, x cut, v paste, y copy-to-pane, m move-to-pane, "
-        "d delete, r rename, z undo, b bookmarks, H history, . hidden, or Esc to close"
+        "Use 1-9/0 for tabs, [], space, c copy, x cut, v paste, y copy-to-pane, "
+        "m move-to-pane, d delete, r rename, z undo, b bookmarks, H history, "
+        ". hidden, or p/Esc to close"
     )
 
 
@@ -242,3 +251,14 @@ def _visible_paths(state: AppState, pane: PaneState) -> tuple[str, ...]:
             state.sort,
         )
     )
+
+
+def _dispatch_direct_tab_input(state: AppState, *, key: str) -> DispatchedActions:
+    if len(key) != 1 or not key.isdigit():
+        return ()
+
+    tab_number = 10 if key == "0" else int(key)
+    tab_count = len(state.browser_tabs) if state.browser_tabs else 1
+    if tab_number > tab_count:
+        return warn(f"Tab {tab_number} is not open")
+    return supported(ActivateTabByIndex(tab_number - 1))

--- a/src/zivo/state/reducer_navigation_tabs.py
+++ b/src/zivo/state/reducer_navigation_tabs.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from .actions import (
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     CloseCurrentTab,
     OpenNewTab,
 )
@@ -43,6 +44,17 @@ def _handle_activate_next_tab(
     if len(tabs) <= 1:
         return finalize(state)
     return activate_tab(state, (state.active_tab_index + 1) % len(tabs), reduce_state)
+
+
+def _handle_activate_tab_by_index(
+    state: AppState,
+    action: ActivateTabByIndex,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    tabs = select_browser_tabs(state)
+    if action.index < 0 or action.index >= len(tabs):
+        return finalize(state)
+    return activate_tab(state, action.index, reduce_state)
 
 
 def _handle_activate_previous_tab(
@@ -85,6 +97,7 @@ def _handle_close_current_tab(
 
 TAB_NAVIGATION_HANDLERS = {
     OpenNewTab: _handle_open_new_tab,
+    ActivateTabByIndex: _handle_activate_tab_by_index,
     ActivateNextTab: _handle_activate_next_tab,
     ActivatePreviousTab: _handle_activate_previous_tab,
     CloseCurrentTab: _handle_close_current_tab,

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -199,7 +199,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             return HelpBarState(state.config.help_bar.transfer)
         return HelpBarState(
             (
-                "[ ] focus | y copy-to-pane | m move-to-pane | Esc close",
+                "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close",
                 "Space select | c copy | x cut | v paste | d delete | r rename",
                 "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette",
             )
@@ -209,7 +209,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
     split_terminal_hint = " | t term" if is_split_terminal_supported() else ""
     browsing_shortcuts = (
         "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | : palette | q quit"
+        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
     )
     return HelpBarState(
         (

--- a/tests/input_dispatch_browsing_cases.py
+++ b/tests/input_dispatch_browsing_cases.py
@@ -3,6 +3,11 @@
 import os
 
 from .input_dispatch_helpers import *
+from .state_test_helpers import reduce_state
+
+
+def _reduce_state(state, action):
+    return reduce_state(state, action)
 
 
 def test_browsing_down_dispatches_move_cursor() -> None:
@@ -609,6 +614,42 @@ def test_browsing_shift_tab_activates_previous_tab() -> None:
     actions = dispatch_key_input(state, key="shift+tab")
 
     assert actions == (SetNotification(None), ActivatePreviousTab())
+
+
+def test_browsing_number_activates_direct_tab() -> None:
+    state = _reduce_state(build_initial_app_state(), OpenNewTab())
+
+    actions = dispatch_key_input(state, key="1", character="1")
+
+    assert actions == (SetNotification(None), ActivateTabByIndex(0))
+
+
+def test_browsing_zero_activates_tenth_tab() -> None:
+    state = build_initial_app_state()
+    for _ in range(9):
+        state = _reduce_state(state, OpenNewTab())
+
+    actions = dispatch_key_input(state, key="0", character="0")
+
+    assert actions == (SetNotification(None), ActivateTabByIndex(9))
+
+
+def test_browsing_number_warns_when_target_tab_is_missing() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="2", character="2")
+
+    assert actions == (
+        SetNotification(NotificationState(level="warning", message="Tab 2 is not open")),
+    )
+
+
+def test_browsing_p_toggles_transfer_mode() -> None:
+    state = build_initial_app_state()
+
+    actions = dispatch_key_input(state, key="p", character="p")
+
+    assert actions == (SetNotification(None), ToggleTransferMode())
 
 
 def test_search_palette_j_key_updates_query() -> None:

--- a/tests/input_dispatch_helpers.py
+++ b/tests/input_dispatch_helpers.py
@@ -20,6 +20,7 @@ from zivo.state import (
 from zivo.state.actions import (
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     AddBookmark,
     BeginBookmarkSearch,
     BeginCommandPalette,
@@ -87,6 +88,7 @@ from zivo.state.actions import (
     SubmitPendingInput,
     ToggleHiddenFiles,
     ToggleSelectionAndAdvance,
+    ToggleTransferMode,
     UndoLastOperation,
 )
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1276,7 +1276,7 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
         (
             "n new-file | N new-dir | H history | "
-            f"b bookmarks{split_terminal_hint} | : palette | q quit"
+            f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
         ),
     )
     assert help_state.text == (
@@ -1284,7 +1284,7 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
         "d delete | r rename | z undo\n"
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
         "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | : palette | q quit"
+        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
     )
 
 
@@ -1294,12 +1294,12 @@ def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> Non
     help_state = select_help_bar_state(state)
 
     assert help_state.lines == (
-        "[ ] focus | y copy-to-pane | m move-to-pane | Esc close",
+        "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close",
         "Space select | c copy | x cut | v paste | d delete | r rename",
         "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette",
     )
     assert help_state.text == (
-        "[ ] focus | y copy-to-pane | m move-to-pane | Esc close\n"
+        "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close\n"
         "Space select | c copy | x cut | v paste | d delete | r rename\n"
         "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette"
     )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2671,7 +2671,7 @@ async def test_app_displays_browsing_help_bar() -> None:
         "d delete | r rename | z undo\n"
         "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
         "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | : palette | q quit"
+        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
     )
 
     async with app.run_test():
@@ -2703,7 +2703,7 @@ async def test_app_transfer_mode_refreshes_left_cursor_and_focuses_right_pane() 
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 3)
 
-        await pilot.press("2")
+        await pilot.press("p")
         right_table = await _wait_for_transfer_right_table(app)
         left_table = app.query_one("#current-pane-table", DataTable)
         left_pane = app.query_one("#current-pane", MainPane)
@@ -2744,14 +2744,14 @@ async def test_app_displays_transfer_help_bar() -> None:
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
-        "[ ] focus | y copy-to-pane | m move-to-pane | Esc close\n"
+        "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close\n"
         "Space select | c copy | x cut | v paste | d delete | r rename\n"
         "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette"
     )
 
     async with app.run_test() as pilot:
         await _wait_for_snapshot_loaded(app, path)
-        await pilot.press("2")
+        await pilot.press("p")
         help_bar = await _wait_for_help_bar_text(app, expected_help)
 
         assert str(help_bar.renderable) == expected_help
@@ -2773,7 +2773,7 @@ async def test_app_opens_command_palette_from_transfer_mode_with_colon() -> None
 
     async with app.run_test() as pilot:
         await _wait_for_snapshot_loaded(app, path)
-        await pilot.press("2")
+        await pilot.press("p")
         await pilot.press(":")
         palette = await _wait_for_command_palette(app)
 

--- a/tests/test_input_dispatch_transfer.py
+++ b/tests/test_input_dispatch_transfer.py
@@ -1,8 +1,9 @@
 from tests.test_state_reducer import _reduce_state
-from zivo.state import build_initial_app_state, dispatch_key_input
+from zivo.state import NotificationState, build_initial_app_state, dispatch_key_input
 from zivo.state.actions import (
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     BeginCommandPalette,
     BeginDeleteTargets,
     BeginGoToPath,
@@ -12,6 +13,7 @@ from zivo.state.actions import (
     CopyTargets,
     CutTargets,
     FocusTransferPane,
+    OpenNewTab,
     PasteClipboardToTransferPane,
     SetNotification,
     ToggleHiddenFiles,
@@ -100,6 +102,33 @@ def test_transfer_mode_keeps_tab_keys_for_browser_tabs() -> None:
     assert dispatch_key_input(state, key="shift+tab") == (
         SetNotification(None),
         ActivatePreviousTab(),
+    )
+
+
+def test_transfer_mode_number_activates_direct_tab() -> None:
+    state = _reduce_state(build_initial_app_state(), OpenNewTab())
+    state = _reduce_state(state, ToggleTransferMode())
+
+    assert dispatch_key_input(state, key="1") == (
+        SetNotification(None),
+        ActivateTabByIndex(0),
+    )
+
+
+def test_transfer_mode_number_warns_when_target_tab_is_missing() -> None:
+    state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+    assert dispatch_key_input(state, key="2") == (
+        SetNotification(NotificationState(level="warning", message="Tab 2 is not open")),
+    )
+
+
+def test_transfer_mode_p_toggles_back_to_browser_mode() -> None:
+    state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+    assert dispatch_key_input(state, key="p") == (
+        SetNotification(None),
+        ToggleTransferMode(),
     )
 
 

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -32,6 +32,7 @@ from zivo.state import (
 from zivo.state.actions import (
     ActivateNextTab,
     ActivatePreviousTab,
+    ActivateTabByIndex,
     AddBookmark,
     BeginFilterInput,
     BeginHistorySearch,
@@ -2579,6 +2580,24 @@ def test_activate_tabs_restores_per_tab_filter_state() -> None:
     state = _reduce_state(state, ActivateNextTab())
     assert state.active_tab_index == 1
     assert state.filter.query == "read"
+
+
+def test_activate_tab_by_index_selects_requested_tab() -> None:
+    state = _reduce_state(build_initial_app_state(), OpenNewTab())
+    state = _reduce_state(state, SetFilterQuery("read"))
+
+    state = _reduce_state(state, ActivateTabByIndex(0))
+
+    assert state.active_tab_index == 0
+    assert state.filter.query == ""
+
+
+def test_activate_tab_by_index_ignores_out_of_range_index() -> None:
+    state = _reduce_state(build_initial_app_state(), OpenNewTab())
+
+    next_state = _reduce_state(state, ActivateTabByIndex(9))
+
+    assert next_state == state
 
 def test_close_current_tab_warns_when_only_one_tab_remains() -> None:
     next_state = _reduce_state(build_initial_app_state(), CloseCurrentTab())


### PR DESCRIPTION
## Summary
- add direct browser tab activation for `1`-`9` and `0` (`0` = tab 10)
- move transfer mode toggle from `2` to `p` in browsing and transfer mode
- update help text, README, and tests to match the new shortcuts

## Testing
- `uv run ruff check .`
- `uv run pytest`

## Related
- Closes #781
