### PR TITLE
Issue #789: 転送モードでのタブのオープンとクローズサポート

### DIFF
--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -467,6 +467,7 @@ def _build_transfer_command_palette_items(state: AppState) -> tuple[CommandPalet
     has_single_target = _transfer_single_target_entry(state) is not None
     has_visible_entries = bool(_transfer_visible_entries(state))
     can_paste = state.clipboard.mode != "none" and bool(state.clipboard.paths)
+    tab_count = len(state.browser_tabs) or 1
 
     return (
         CommandPaletteItem(
@@ -510,6 +511,30 @@ def _build_transfer_command_palette_items(state: AppState) -> tuple[CommandPalet
             label="Undo last file operation",
             shortcut="z",
             enabled=bool(state.undo_stack),
+        ),
+        CommandPaletteItem(
+            id="new_tab",
+            label="New tab",
+            shortcut="o",
+            enabled=True,
+        ),
+        CommandPaletteItem(
+            id="next_tab",
+            label="Next tab",
+            shortcut="tab",
+            enabled=tab_count > 1,
+        ),
+        CommandPaletteItem(
+            id="previous_tab",
+            label="Previous tab",
+            shortcut="shift+tab",
+            enabled=tab_count > 1,
+        ),
+        CommandPaletteItem(
+            id="close_current_tab",
+            label="Close current tab",
+            shortcut="w",
+            enabled=tab_count > 1,
         ),
         CommandPaletteItem(
             id="copy_targets",

--- a/src/zivo/state/input_transfer.py
+++ b/src/zivo/state/input_transfer.py
@@ -12,6 +12,7 @@ from .actions import (
     BeginHistorySearch,
     BeginRenameInput,
     ClearTransferSelection,
+    CloseCurrentTab,
     CopyTargets,
     CutTargets,
     EnterTransferDirectory,
@@ -22,6 +23,7 @@ from .actions import (
     MoveTransferCursor,
     MoveTransferCursorAndSelectRange,
     MoveTransferCursorByPage,
+    OpenNewTab,
     PasteClipboardToTransferPane,
     SelectAllVisibleTransferEntries,
     ToggleHiddenFiles,
@@ -41,8 +43,10 @@ TRANSFER_KEYMAP = {
     "N",
     "c",
     "d",
+    "o",
     "r",
     "v",
+    "w",
     "x",
     "~",
     "[",
@@ -166,6 +170,11 @@ def dispatch_transfer_input(
     if key == "p":
         return supported(ToggleTransferMode())
 
+    if key == "o":
+        return supported(OpenNewTab())
+    if key == "w":
+        return supported(CloseCurrentTab())
+
     if key == "N":
         return supported(BeginCreateInput("dir"))
 
@@ -229,9 +238,9 @@ def dispatch_transfer_input(
         return supported(PasteClipboardToTransferPane())
 
     return warn(
-        "Use 1-9/0 for tabs, [], space, c copy, x cut, v paste, y copy-to-pane, "
+        "Use [], space, c copy, x cut, v paste, y copy-to-pane, "
         "m move-to-pane, d delete, r rename, z undo, b bookmarks, H history, "
-        ". hidden, or p/Esc to close"
+        ". hidden, o new-tab, w close-tab, or p/Esc to close"
     )
 
 

--- a/src/zivo/state/reducer_navigation_shared.py
+++ b/src/zivo/state/reducer_navigation_shared.py
@@ -82,6 +82,47 @@ def activate_tab(
 
 def build_new_tab_state(state: AppState) -> BrowserTabState:
     active_tab = browser_tab_from_app_state(state)
+    
+    # If in transfer mode, copy the transfer state to the new tab
+    if active_tab.layout_mode == "transfer":
+        return replace(
+            active_tab,
+            current_pane=replace(
+                active_tab.current_pane,
+                selected_paths=frozenset(),
+                selection_anchor_path=None,
+            ),
+            filter=FilterState(),
+            history=HistoryState(visited_all=(active_tab.current_path,)),
+            current_pane_delta=CurrentPaneDeltaState(),
+            pending_browser_snapshot_request_id=None,
+            pending_child_pane_request_id=None,
+            # Preserve transfer mode state
+            layout_mode="transfer",
+            active_transfer_pane=active_tab.active_transfer_pane,
+            transfer_left=replace(
+                active_tab.transfer_left,
+                pane=replace(
+                    active_tab.transfer_left.pane,
+                    selected_paths=frozenset(),
+                    selection_anchor_path=None,
+                ),
+                current_pane_delta=CurrentPaneDeltaState(),
+                pending_snapshot_request_id=None,
+            ) if active_tab.transfer_left else None,
+            transfer_right=replace(
+                active_tab.transfer_right,
+                pane=replace(
+                    active_tab.transfer_right.pane,
+                    selected_paths=frozenset(),
+                    selection_anchor_path=None,
+                ),
+                current_pane_delta=CurrentPaneDeltaState(),
+                pending_snapshot_request_id=None,
+            ) if active_tab.transfer_right else None,
+        )
+    
+    # Browser mode: create a new tab in browser mode
     return replace(
         active_tab,
         current_pane=replace(

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -199,9 +199,10 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             return HelpBarState(state.config.help_bar.transfer)
         return HelpBarState(
             (
-                "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close",
+                "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close",
                 "Space select | c copy | x cut | v paste | d delete | r rename",
-                "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette",
+                "z undo | . hidden | N new-dir | o new-tab | w close-tab",
+                "b bookmarks | H history | G go-to | : palette",
             )
         )
     if state.config.help_bar.browsing:

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1294,14 +1294,16 @@ def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> Non
     help_state = select_help_bar_state(state)
 
     assert help_state.lines == (
-        "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close",
+        "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close",
         "Space select | c copy | x cut | v paste | d delete | r rename",
-        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette",
+        "z undo | . hidden | N new-dir | o new-tab | w close-tab",
+        "b bookmarks | H history | G go-to | : palette",
     )
     assert help_state.text == (
-        "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close\n"
+        "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close\n"
         "Space select | c copy | x cut | v paste | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette"
+        "z undo | . hidden | N new-dir | o new-tab | w close-tab\n"
+        "b bookmarks | H history | G go-to | : palette"
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2744,9 +2744,10 @@ async def test_app_displays_transfer_help_bar() -> None:
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
-        "1-9/0 tabs | [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close\n"
+        "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close\n"
         "Space select | c copy | x cut | v paste | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | b bookmarks | H history | G go-to | : palette"
+        "z undo | . hidden | N new-dir | o new-tab | w close-tab\n"
+        "b bookmarks | H history | G go-to | : palette"
     )
 
     async with app.run_test() as pilot:

--- a/tests/test_input_dispatch_transfer.py
+++ b/tests/test_input_dispatch_transfer.py
@@ -10,6 +10,7 @@ from zivo.state.actions import (
     BeginHistorySearch,
     BeginRenameInput,
     ClearTransferSelection,
+    CloseCurrentTab,
     CopyTargets,
     CutTargets,
     FocusTransferPane,
@@ -142,6 +143,24 @@ def test_transfer_mode_uses_non_function_keys_for_copy_and_move() -> None:
     assert dispatch_key_input(state, key="m") == (
         SetNotification(None),
         TransferMoveToOppositePane(),
+    )
+
+
+def test_transfer_mode_opens_new_tab_with_o() -> None:
+    state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+    assert dispatch_key_input(state, key="o") == (
+        SetNotification(None),
+        OpenNewTab(),
+    )
+
+
+def test_transfer_mode_closes_current_tab_with_w() -> None:
+    state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+    assert dispatch_key_input(state, key="w") == (
+        SetNotification(None),
+        CloseCurrentTab(),
     )
 
 

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -38,6 +38,7 @@ from zivo.state.actions import (
     CancelCommandPalette,
     DismissAttributeDialog,
     MoveCommandPaletteCursor,
+    OpenNewTab,
     SetCommandPaletteQuery,
     SetCursorPath,
     ShowAttributes,
@@ -312,6 +313,71 @@ def test_submit_history_palette_in_transfer_mode_navigates_active_pane() -> None
         and e.path == "/tmp/c"
         for e in result.effects
     )
+
+
+def test_submit_command_palette_opens_new_tab_in_transfer_mode() -> None:
+    state = build_initial_app_state()
+    state = replace(
+        state,
+        layout_mode="transfer",
+        active_transfer_pane="left",
+        transfer_left=TransferPaneState(
+            pane=PaneState(directory_path="/tmp/a", entries=(), cursor_path="/tmp/a"),
+            current_path="/tmp/a",
+        ),
+        transfer_right=TransferPaneState(
+            pane=PaneState(directory_path="/tmp/b", entries=(), cursor_path="/tmp/b"),
+            current_path="/tmp/b",
+        ),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="commands",
+            query="",
+            cursor_index=7,  # new_tab
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert len(result.state.browser_tabs) == 2
+    assert result.state.active_tab_index == 1
+    # New tab should preserve transfer mode state
+    assert result.state.layout_mode == "transfer"
+    assert result.state.transfer_left is not None
+    assert result.state.transfer_right is not None
+
+
+def test_submit_command_palette_closes_current_tab_in_transfer_mode() -> None:
+    state = build_initial_app_state()
+    # Create a second tab first
+    state = reduce_app_state(state, OpenNewTab()).state
+    initial_tab_count = len(state.browser_tabs)
+
+    state = replace(
+        state,
+        layout_mode="transfer",
+        active_transfer_pane="left",
+        transfer_left=TransferPaneState(
+            pane=PaneState(directory_path="/tmp/a", entries=(), cursor_path="/tmp/a"),
+            current_path="/tmp/a",
+        ),
+        transfer_right=TransferPaneState(
+            pane=PaneState(directory_path="/tmp/b", entries=(), cursor_path="/tmp/b"),
+            current_path="/tmp/b",
+        ),
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="commands",
+            query="",
+            cursor_index=10,  # close_current_tab
+        ),
+    )
+
+    result = reduce_app_state(state, SubmitCommandPalette())
+
+    assert result.state.command_palette is None
+    assert len(result.state.browser_tabs) == initial_tab_count - 1
 
 
 def test_submit_command_palette_select_all_in_transfer_mode() -> None:

--- a/tests/test_state_reducer_transfer.py
+++ b/tests/test_state_reducer_transfer.py
@@ -222,9 +222,10 @@ def test_transfer_mode_is_scoped_to_browser_tab() -> None:
     new_tab_state = _reduce_state(state, OpenNewTab())
 
     assert new_tab_state.active_tab_index == 1
-    assert new_tab_state.layout_mode == "browser"
-    assert new_tab_state.transfer_left is None
-    assert new_tab_state.transfer_right is None
+    # New tab preserves transfer mode state
+    assert new_tab_state.layout_mode == "transfer"
+    assert new_tab_state.transfer_left is not None
+    assert new_tab_state.transfer_right is not None
 
     previous_tab_state = _reduce_state(new_tab_state, ActivatePreviousTab())
 


### PR DESCRIPTION
## 概要
転送モードでのタブのオープンとクローズをサポートします。

## 変更内容

### キーバインドの追加
- `o` キーで新しいタブを開く（現在の転送モードの状態を保持）
- `w` キーで現在のタブを閉じる

### コマンドパレットの拡張
転送モードのコマンドパレットに以下を追加:
- New tab (`o` キー)
- Next tab (`Tab` キー - 既に実装済み)
- Previous tab (`Shift+Tab` キー - 既に実装済み)
- Close current tab (`w` キー)

### ヘルプバーの修正
転送モードのヘルプバーから `1-9/0 tabs` を削除し、`o new-tab` と `w close-tab` を追加

### エラーメッセージの更新
転送モードで未サポートキーが押された場合の警告メッセージから `1-9/0 for tabs` を削除し、`o new-tab | w close-tab` を追加

### 新しいタブの状態保持
転送モードで新しいタブを開く場合、現在の転送モードの状態（`layout_mode`, `transfer_left`, `transfer_right`）を新しいタブにコピーするように `build_new_tab_state` を修正

## テスト
- 転送モードで `o` キーが新しいタブを開くことを確認
- 転送モードで `w` キーが現在のタブを閉じることを確認
- 転送モードのコマンドパレットにタブ操作が表示されることを確認
- 転送モードのヘルプバーが正しく表示されることを確認
- 最後のタブを閉じようとすると適切にエラーになることを確認

すべてのテストが成功しています。

## 関連 Issue
Closes #789