### PR TITLE
Fix #800 macOS image preview terminal response handling

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -1,6 +1,8 @@
 """Application assembly for zivo."""
 
+import re
 import threading
+import time
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
@@ -10,6 +12,7 @@ from textual.app import App, ComposeResult, ScreenStackError
 from textual.binding import Binding
 from textual.containers import Container, Vertical
 from textual.css.query import NoMatches
+from textual.keys import Keys
 from textual.timer import Timer
 from textual.worker import Worker
 
@@ -118,6 +121,14 @@ _REPLACE_PREVIEW_SCROLL_SOURCES = frozenset(
         "grep_replace_selected",
     }
 )
+_TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED = False
+_TERMINAL_DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[(?:\?[\d;]*|[\d;]*)c\Z")
+_TERMINAL_WINDOW_RESPONSE_RE = re.compile(r"\x1b\[(?:4|6|8);[\d;]+t\Z")
+_TERMINAL_COLOR_RESPONSE_RE = re.compile(r"\x1b\]1[01];.*(?:\x07|\x1b\\)\Z", re.DOTALL)
+_ESCAPE = "\x1b"
+_OSC_INTRODUCER = "]"
+_OSC_TERMINATOR = "\\"
+_OSC_BEL = "\x07"
 
 
 def _preview_scroll_delta(state: AppState, key: str) -> int | None:
@@ -140,6 +151,7 @@ class zivoApp(App[None]):
 
     TITLE = "zivo"
     SUB_TITLE = "Three-pane shell"
+    TERMINAL_RESPONSE_ESCAPE_TIMEOUT_SECONDS = 0.05
     BINDINGS = [
         Binding("ctrl+p", "dispatch_bound_key('ctrl+p')", show=False, priority=True),
         Binding("ctrl+n", "dispatch_bound_key('ctrl+n')", show=False, priority=True),
@@ -173,6 +185,7 @@ class zivoApp(App[None]):
         current_pane_projection_mode: Literal["full", "viewport"] = "viewport",
     ) -> None:
         super().__init__()
+        _install_textual_terminal_response_filters()
         self._app_config = app_config or AppConfig()
         self.theme = self._app_config.display.theme
         self._initial_path = resolve_parent_directory_path(str(initial_path or Path.cwd()))[0]
@@ -219,6 +232,9 @@ class zivoApp(App[None]):
         self._active_grep_search_request_id: int | None = None
         self._active_directory_size_cancel_event: threading.Event | None = None
         self._active_directory_size_request_id: int | None = None
+        self._pending_terminal_response_escape = False
+        self._swallowing_terminal_response = False
+        self._terminal_response_escape_deadline = 0.0
 
     @property
     def app_state(self) -> AppState:
@@ -476,6 +492,8 @@ class zivoApp(App[None]):
         *,
         character: str | None = None,
     ) -> bool:
+        if self._should_swallow_terminal_response_key(key):
+            return True
         actions = dispatch_key_input(
             self._app_state,
             key=key,
@@ -485,6 +503,40 @@ class zivoApp(App[None]):
             return False
         await self.dispatch_actions(actions)
         return True
+
+    def _should_swallow_terminal_response_key(self, key: str) -> bool:
+        now = time.monotonic()
+        if (
+            self._pending_terminal_response_escape
+            and now > self._terminal_response_escape_deadline
+        ):
+            self._pending_terminal_response_escape = False
+            self._swallowing_terminal_response = False
+
+        if self._swallowing_terminal_response:
+            if len(key) == 1:
+                if _is_terminal_response_final_byte(key):
+                    self._swallowing_terminal_response = False
+                    self._pending_terminal_response_escape = False
+                return True
+            self._swallowing_terminal_response = False
+            self._pending_terminal_response_escape = False
+            return False
+
+        if self._pending_terminal_response_escape:
+            if len(key) == 1 and key in {"[", "]", "O", "P", "^", "_", "X"}:
+                self._swallowing_terminal_response = True
+                return True
+            self._pending_terminal_response_escape = False
+
+        if key == "escape":
+            self._pending_terminal_response_escape = True
+            self._terminal_response_escape_deadline = (
+                now + self.TERMINAL_RESPONSE_ESCAPE_TIMEOUT_SECONDS
+            )
+            self._swallowing_terminal_response = False
+
+        return False
 
     async def dispatch_actions(self, actions: Sequence[Action]) -> None:
         """Apply reducer actions, refresh the UI, and schedule any effects."""
@@ -628,3 +680,107 @@ def _initial_sort_state(config: AppConfig) -> SortState:
         descending=config.display.default_sort_descending,
         directories_first=config.display.directories_first,
     )
+
+
+def _is_terminal_response_final_byte(key: str) -> bool:
+    if len(key) != 1:
+        return False
+    codepoint = ord(key)
+    return 0x40 <= codepoint <= 0x7E
+
+
+def _install_textual_terminal_response_filters() -> None:
+    global _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED
+    if _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED:
+        return
+
+    import textual._xterm_parser as xterm_parser
+
+    original_feed = xterm_parser.XTermParser.feed
+    original = xterm_parser.XTermParser._sequence_to_key_events
+
+    def _filter_terminal_response_chunk(self, data: str) -> str:
+        pending_escape = getattr(self, "_zivo_pending_escape", False)
+        in_osc = getattr(self, "_zivo_in_osc", False)
+        osc_saw_escape = getattr(self, "_zivo_osc_saw_escape", False)
+
+        if not data:
+            if pending_escape and not in_osc:
+                data = _ESCAPE
+            else:
+                data = ""
+            pending_escape = False
+            in_osc = False
+            osc_saw_escape = False
+            self._zivo_pending_escape = pending_escape
+            self._zivo_in_osc = in_osc
+            self._zivo_osc_saw_escape = osc_saw_escape
+            return data
+
+        filtered: list[str] = []
+        index = 0
+
+        if pending_escape:
+            pending_escape = False
+            if data.startswith(_OSC_INTRODUCER):
+                in_osc = True
+                index = 1
+            else:
+                filtered.append(_ESCAPE)
+
+        while index < len(data):
+            character = data[index]
+            if in_osc:
+                if osc_saw_escape:
+                    osc_saw_escape = False
+                    if character == _OSC_TERMINATOR:
+                        in_osc = False
+                    index += 1
+                    continue
+                if character == _OSC_BEL:
+                    in_osc = False
+                    index += 1
+                    continue
+                if character == _ESCAPE:
+                    osc_saw_escape = True
+                index += 1
+                continue
+
+            if character == _ESCAPE:
+                next_index = index + 1
+                if next_index >= len(data):
+                    pending_escape = True
+                    index += 1
+                    continue
+                if data[next_index] == _OSC_INTRODUCER:
+                    in_osc = True
+                    index += 2
+                    continue
+
+            filtered.append(character)
+            index += 1
+
+        self._zivo_pending_escape = pending_escape
+        self._zivo_in_osc = in_osc
+        self._zivo_osc_saw_escape = osc_saw_escape
+        return "".join(filtered)
+
+    def _wrapped_feed(self, data: str):
+        filtered = _filter_terminal_response_chunk(self, data)
+        if data and not filtered:
+            return ()
+        return original_feed(self, filtered)
+
+    def _wrapped(self, sequence: str):
+        if (
+            _TERMINAL_DEVICE_ATTRIBUTES_RESPONSE_RE.fullmatch(sequence)
+            or _TERMINAL_WINDOW_RESPONSE_RE.fullmatch(sequence)
+            or _TERMINAL_COLOR_RESPONSE_RE.fullmatch(sequence)
+        ):
+            yield events.Key(Keys.Ignore, sequence)
+            return
+        yield from original(self, sequence)
+
+    xterm_parser.XTermParser.feed = _wrapped_feed
+    xterm_parser.XTermParser._sequence_to_key_events = _wrapped
+    _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED = True

--- a/src/zivo/services/previews/core.py
+++ b/src/zivo/services/previews/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -181,10 +182,19 @@ IMAGE_PREVIEW_DEPENDENCY_MESSAGE = "Preview unavailable: install `chafa` for ima
 GREP_PREVIEW_ERROR_MESSAGE = "Preview unavailable: failed to load context"
 
 GrepContextCacheKey = tuple[str, int, int, int, int, int]
+_ANSI_CONTROL_SEQUENCE_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 
 
 def _normalize_preview_newlines(text: str) -> str:
     return text.replace("\r\n", "\n")
+
+
+def _strip_non_sgr_ansi(text: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        sequence = match.group(0)
+        return sequence if sequence.endswith("m") else ""
+
+    return _ANSI_CONTROL_SEQUENCE_RE.sub(_replace, text)
 
 
 @dataclass(frozen=True)
@@ -369,6 +379,7 @@ class ChafaImagePreviewLoader:
             content = _normalize_preview_newlines(
                 result.stdout.decode("utf-8", errors="ignore")
             )
+        content = _strip_non_sgr_ansi(content)
         if not content.strip():
             return None
         return FilePreviewState.with_content(content, False, content_kind="image")
@@ -489,6 +500,13 @@ def _load_text_preview(
         return FilePreviewState.error()
 
     if b"\x00" in chunk[:preview_limit]:
+        if _has_image_signature(path, header=chunk[:32]):
+            if not enable_image_preview:
+                return FilePreviewState.unavailable()
+            loader = image_preview_loader or ChafaImagePreviewLoader()
+            preview = loader.load_preview(path, preview_columns=max(1, preview_columns))
+            if preview is not None:
+                return preview
         return FilePreviewState.unsupported()
 
     truncated = len(chunk) > preview_limit
@@ -496,6 +514,13 @@ def _load_text_preview(
     try:
         preview_text = _normalize_preview_newlines(preview_bytes.decode("utf-8"))
     except UnicodeDecodeError:
+        if _has_image_signature(path, header=chunk[:32]):
+            if not enable_image_preview:
+                return FilePreviewState.unavailable()
+            loader = image_preview_loader or ChafaImagePreviewLoader()
+            preview = loader.load_preview(path, preview_columns=max(1, preview_columns))
+            if preview is not None:
+                return preview
         return FilePreviewState.unsupported()
 
     return FilePreviewState.with_content(preview_text, truncated)
@@ -633,6 +658,31 @@ def _is_pdf_preview_candidate(path: Path) -> bool:
 
 def _is_image_preview_candidate(path: Path) -> bool:
     return path.suffix.casefold() in IMAGE_PREVIEW_EXTENSIONS
+
+
+def _has_image_signature(path: Path, *, header: bytes | None = None) -> bool:
+    if header is None:
+        try:
+            with path.open("rb") as handle:
+                header = handle.read(32)
+        except OSError:
+            return False
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return True
+    if header.startswith((b"\xff\xd8\xff", b"GIF87a", b"GIF89a", b"BM")):
+        return True
+    if header.startswith((b"II*\x00", b"MM\x00*")):
+        return True
+    if header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return True
+    if len(header) >= 12 and header[4:12] in {
+        b"ftypavif",
+        b"ftypavis",
+        b"ftypmif1",
+        b"ftypmsf1",
+    }:
+        return True
+    return False
 
 
 def _is_office_preview_candidate(path: Path) -> bool:

--- a/src/zivo/services/previews/core.py
+++ b/src/zivo/services/previews/core.py
@@ -183,6 +183,9 @@ GREP_PREVIEW_ERROR_MESSAGE = "Preview unavailable: failed to load context"
 
 GrepContextCacheKey = tuple[str, int, int, int, int, int]
 _ANSI_CONTROL_SEQUENCE_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_ANSI_OSC_SEQUENCE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+_ANSI_STRING_SEQUENCE_RE = re.compile(r"\x1b[P^_X].*?(?:\x1b\\)", re.DOTALL)
+_ANSI_ESCAPE_SEQUENCE_RE = re.compile(r"\x1b(?:[@-Z\\-_])")
 
 
 def _normalize_preview_newlines(text: str) -> str:
@@ -190,11 +193,15 @@ def _normalize_preview_newlines(text: str) -> str:
 
 
 def _strip_non_sgr_ansi(text: str) -> str:
+    text = _ANSI_OSC_SEQUENCE_RE.sub("", text)
+    text = _ANSI_STRING_SEQUENCE_RE.sub("", text)
+
     def _replace(match: re.Match[str]) -> str:
         sequence = match.group(0)
         return sequence if sequence.endswith("m") else ""
 
-    return _ANSI_CONTROL_SEQUENCE_RE.sub(_replace, text)
+    text = _ANSI_CONTROL_SEQUENCE_RE.sub(_replace, text)
+    return _ANSI_ESCAPE_SEQUENCE_RE.sub("", text)
 
 
 @dataclass(frozen=True)

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -1,5 +1,8 @@
 """Child pane widget that toggles between list and preview modes."""
 
+import re
+
+from rich.color import Color
 from rich.style import Style
 from rich.syntax import Syntax
 from rich.text import Text
@@ -18,6 +21,8 @@ from .pane_rendering import (
     _resolve_component_styles,
 )
 from .side_pane import SidePane
+
+_SGR_SEQUENCE_RE = re.compile(r"\x1b\[([0-9;]*)m")
 
 
 class ChildPane(Vertical):
@@ -205,12 +210,7 @@ class ChildPane(Vertical):
             return Text()
 
         if state.preview_kind == "image":
-            return Text.from_ansi(
-                state.preview_content,
-                no_wrap=True,
-                overflow="ignore",
-                end="",
-            )
+            return _render_image_preview_text(state.preview_content)
 
         lexer = "text"
         if state.preview_path is not None:
@@ -278,3 +278,57 @@ class ChildPane(Vertical):
                 state.syntax_theme,
             )
         return ("list", state.entries)
+
+
+def _render_image_preview_text(content: str) -> Text:
+    text = Text(no_wrap=True, overflow="ignore", end="")
+    current_style = Style()
+    position = 0
+
+    for match in _SGR_SEQUENCE_RE.finditer(content):
+        if match.start() > position:
+            text.append(content[position : match.start()], style=current_style)
+        current_style = _apply_sgr_codes(current_style, match.group(1))
+        position = match.end()
+
+    if position < len(content):
+        text.append(content[position:], style=current_style)
+
+    return text
+
+
+def _apply_sgr_codes(style: Style, raw_codes: str) -> Style:
+    if not raw_codes:
+        return Style()
+
+    color = style.color
+    bgcolor = style.bgcolor
+    codes = [int(code) if code else 0 for code in raw_codes.split(";")]
+    index = 0
+
+    while index < len(codes):
+        code = codes[index]
+        if code == 0:
+            color = None
+            bgcolor = None
+            index += 1
+            continue
+        if code == 39:
+            color = None
+            index += 1
+            continue
+        if code == 49:
+            bgcolor = None
+            index += 1
+            continue
+        if code == 38 and index + 4 < len(codes) and codes[index + 1] == 2:
+            color = Color.from_rgb(codes[index + 2], codes[index + 3], codes[index + 4])
+            index += 5
+            continue
+        if code == 48 and index + 4 < len(codes) and codes[index + 1] == 2:
+            bgcolor = Color.from_rgb(codes[index + 2], codes[index + 3], codes[index + 4])
+            index += 5
+            continue
+        index += 1
+
+    return Style(color=color, bgcolor=bgcolor)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1056,6 +1056,51 @@ async def test_app_renders_text_preview_in_child_pane_for_file_cursor() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_renders_image_preview_in_child_pane_for_file_cursor() -> None:
+    path = str(Path("/tmp/zivo-image-preview").resolve())
+    image = f"{path}/preview.png"
+    preview_content = (
+        "\x1b[31m@@\x1b[0m\n"
+        "\x1b[32m##\x1b[0m\n"
+        "\x1b[34m..\x1b[0m\n"
+    ) * 40
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(
+                        DirectoryEntryState(path, "zivo-image-preview", "dir"),
+                        DirectoryEntryState("/tmp/sibling", "sibling", "dir"),
+                    ),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(DirectoryEntryState(image, "preview.png", "file"),),
+                    cursor_path=image,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=image,
+                    preview_content=preview_content,
+                    preview_kind="image",
+                ),
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 1)
+        await _wait_for_child_preview(app, "Preview: preview.png", "@@")
+
+
+@pytest.mark.asyncio
 async def test_app_browsing_preview_scrolls_with_brackets() -> None:
     path = str(Path("/tmp/zivo-preview-scroll").resolve())
     readme = f"{path}/README.md"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1101,6 +1101,95 @@ async def test_app_renders_image_preview_in_child_pane_for_file_cursor() -> None
 
 
 @pytest.mark.asyncio
+async def test_app_ignores_terminal_response_sequences_in_browsing_mode() -> None:
+    path = str(Path("/tmp/zivo-terminal-response").resolve())
+    readme = f"{path}/README.md"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(
+                        DirectoryEntryState(path, "zivo-terminal-response", "dir"),
+                        DirectoryEntryState("/tmp/sibling", "sibling", "dir"),
+                    ),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(DirectoryEntryState(readme, "README.md", "file"),),
+                    cursor_path=readme,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=readme,
+                    preview_content="# Title\npreview body\n",
+                ),
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test():
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_row_count(app, 1)
+        await app._dispatch_key_press("escape")
+        await app._dispatch_key_press("[")
+        await app._dispatch_key_press("0")
+        await app._dispatch_key_press("c")
+
+        notification = app.app_state.notification
+        assert notification is None or "Copied" not in notification.message
+
+
+@pytest.mark.asyncio
+async def test_textual_parser_ignores_terminal_device_attributes_response() -> None:
+    from textual._xterm_parser import XTermParser
+
+    from zivo.app import _install_textual_terminal_response_filters
+
+    _install_textual_terminal_response_filters()
+    parser = XTermParser()
+
+    events = list(parser.feed("\x1b[0c"))
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_textual_parser_ignores_terminal_osc_color_response() -> None:
+    from textual._xterm_parser import XTermParser
+
+    from zivo.app import _install_textual_terminal_response_filters
+
+    _install_textual_terminal_response_filters()
+    parser = XTermParser()
+
+    events = list(parser.feed("\x1b]10;rgb:0000/0000/0000\x1b\\"))
+
+    assert events == []
+    assert list(parser.feed("")) == []
+
+
+@pytest.mark.asyncio
+async def test_textual_parser_ignores_split_terminal_osc_color_response() -> None:
+    from textual._xterm_parser import XTermParser
+
+    from zivo.app import _install_textual_terminal_response_filters
+
+    _install_textual_terminal_response_filters()
+    parser = XTermParser()
+
+    assert list(parser.feed("\x1b]10;rgb:0000")) == []
+    assert list(parser.feed("/0000/0000\x1b")) == []
+    assert list(parser.feed("\\")) == []
+    assert list(parser.feed("")) == []
+
+
+@pytest.mark.asyncio
 async def test_app_browsing_preview_scrolls_with_brackets() -> None:
     path = str(Path("/tmp/zivo-preview-scroll").resolve())
     readme = f"{path}/README.md"

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -346,6 +346,63 @@ def test_pandoc_document_preview_loader_uses_pandoc_command(tmp_path, monkeypatc
     assert preview == FilePreviewState.with_content("# Slide 1\n", False)
 
 
+def test_chafa_image_preview_loader_strips_non_sgr_control_sequences(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from zivo.services.browser_snapshot import ChafaImagePreviewLoader
+
+    image = tmp_path / "preview.png"
+    image.write_bytes(b"png")
+    loader = ChafaImagePreviewLoader()
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.shutil.which",
+        lambda name: "/usr/bin/chafa",
+    )
+
+    class _CompletedProcess:
+        stdout = b"\x1b[?25l\x1b[31m@@\x1b[0m\n\x1b[?25h"
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.subprocess.run",
+        lambda *args, **kwargs: _CompletedProcess(),
+    )
+
+    preview = loader.load_preview(image, preview_columns=40)
+
+    assert preview == FilePreviewState.with_content(
+        "\x1b[31m@@\x1b[0m\n",
+        False,
+        content_kind="image",
+    )
+
+
+def test_live_browser_snapshot_loader_detects_png_signature_without_extension(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    image = project / "preview.bin"
+    image.write_bytes(b"\x89PNG\r\n\x1a\nrest")
+    preview_loader = StubImagePreviewLoader(
+        previews_by_path={
+            str(image): FilePreviewState.with_content(
+                "\x1b[31m@@\x1b[0m\n",
+                False,
+                content_kind="image",
+            ),
+        }
+    )
+    loader = LiveBrowserSnapshotLoader(image_preview_loader=preview_loader)
+
+    snapshot = loader.load_browser_snapshot(str(project), cursor_path=str(image))
+
+    assert snapshot.child_pane.mode == "preview"
+    assert snapshot.child_pane.preview_path == str(image)
+    assert snapshot.child_pane.preview_content == "\x1b[31m@@\x1b[0m\n"
+    assert snapshot.child_pane.preview_kind == "image"
+    assert preview_loader.calls == [f"{image}:80"]
+
+
 def test_live_browser_snapshot_loader_uses_pdftotext_for_pdf_preview(
     tmp_path,
     monkeypatch,

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -378,6 +378,42 @@ def test_chafa_image_preview_loader_strips_non_sgr_control_sequences(
     )
 
 
+def test_chafa_image_preview_loader_strips_osc_sequences(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from zivo.services.browser_snapshot import ChafaImagePreviewLoader
+
+    image = tmp_path / "preview.png"
+    image.write_bytes(b"png")
+    loader = ChafaImagePreviewLoader()
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.shutil.which",
+        lambda name: "/usr/bin/chafa",
+    )
+
+    class _CompletedProcess:
+        stdout = (
+            b"\x1b]7;file:///tmp/zivo\x1b\\"
+            b"\x1b[31m@@\x1b[0m\n"
+            b"\x1b]1337;RemoteHost=test\x07"
+        )
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.subprocess.run",
+        lambda *args, **kwargs: _CompletedProcess(),
+    )
+
+    preview = loader.load_preview(image, preview_columns=40)
+
+    assert preview == FilePreviewState.with_content(
+        "\x1b[31m@@\x1b[0m\n",
+        False,
+        content_kind="image",
+    )
+
+
 def test_live_browser_snapshot_loader_detects_png_signature_without_extension(tmp_path) -> None:
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -414,6 +414,47 @@ def test_chafa_image_preview_loader_strips_osc_sequences(
     )
 
 
+def test_chafa_image_preview_loader_uses_full_color_mode(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from zivo.services.browser_snapshot import ChafaImagePreviewLoader
+
+    image = tmp_path / "preview.png"
+    image.write_bytes(b"png")
+    loader = ChafaImagePreviewLoader()
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.shutil.which",
+        lambda name: "/usr/bin/chafa",
+    )
+
+    class _CompletedProcess:
+        stdout = b"@@\n"
+
+    captured_args: list[str] = []
+
+    def _run(args, **kwargs):
+        captured_args.extend(args)
+        return _CompletedProcess()
+
+    monkeypatch.setattr("zivo.services.previews.core.subprocess.run", _run)
+
+    preview = loader.load_preview(image, preview_columns=40)
+
+    assert preview == FilePreviewState.with_content("@@\n", False, content_kind="image")
+    assert captured_args[:8] == [
+        "/usr/bin/chafa",
+        "--format",
+        "symbols",
+        "--colors",
+        "full",
+        "--animate",
+        "off",
+        "--fit-width",
+    ]
+
+
 def test_live_browser_snapshot_loader_detects_png_signature_without_extension(tmp_path) -> None:
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -92,7 +92,7 @@ def test_child_pane_renders_image_preview_as_ansi() -> None:
     )
 
     assert isinstance(renderable, Text)
-    assert renderable.plain == "@@"
+    assert renderable.plain == "@@\n"
     assert renderable.no_wrap is True
 
 


### PR DESCRIPTION
## Summary
- filter terminal response sequences that macOS can emit during image preview before they are interpreted as key input
- keep color image preview rendering while avoiding Rich/Textual ANSI parsing paths that can destabilize the preview pane
- add regression tests for `OSC 10/11`, `CSI ... c`, and image preview rendering behavior

## Testing
- `uv run pytest`
- `uv run ruff check .`

## Related
- Closes #800
- Related to #798
