### PR TITLE
#797 Fix replace confirmation ESC crash

### DIFF
--- a/src/zivo/state/reducer_mutations_replace.py
+++ b/src/zivo/state/reducer_mutations_replace.py
@@ -93,6 +93,7 @@ def _handle_confirm_replace_targets(
 def _handle_cancel_replace_confirmation(
     state: AppState,
     action: CancelReplaceConfirmation,
+    reduce_state=None,
 ) -> ReduceResult:
     """Cancel the replace operation and return to the command palette."""
     if state.replace_confirmation is None:


### PR DESCRIPTION
- `_handle_cancel_replace_confirmation` was missing the third `reduce_state` parameter
- `handle_mutation_action` calls all handlers with `handler(state, action, reduce_state)` (3 arguments)
- Other cancel handlers all accept 3 args; only the replace cancel handler accepted 2 args
- This caused `TypeError: takes 2 positional arguments but 3 were given` when pressing ESC

## Fix
Added `reduce_state=None` parameter to `_handle_cancel_replace_confirmation`.

## Test Results
- All 1170 tests passed (5 skipped)
- Ruff lint: All checks passed