### PR TITLE
#798 Fix older chafa compatibility on WSL

### DIFF
--- a/src/zivo/services/previews/core.py
+++ b/src/zivo/services/previews/core.py
@@ -349,6 +349,7 @@ class PandocDocumentPreviewLoader:
 class ChafaImagePreviewLoader:
     chafa_path: str | None = field(default=None, init=False, repr=False)
     chafa_missing: bool = field(default=False, init=False, repr=False)
+    supports_animate_option: bool | None = field(default=None, init=False, repr=False)
 
     def load_preview(
         self,
@@ -359,26 +360,29 @@ class ChafaImagePreviewLoader:
         chafa = self._resolve_chafa()
         if chafa is None:
             return None
+        args = self._build_chafa_command(
+            chafa,
+            path,
+            preview_columns=preview_columns,
+        )
         try:
-            result = subprocess.run(
-                [
-                    chafa,
-                    "--format",
-                    "symbols",
-                    "--colors",
-                    "full",
-                    "--animate",
-                    "off",
-                    "--fit-width",
-                    "--size",
-                    f"{max(1, preview_columns)}x",
-                    str(path),
-                ],
-                check=True,
-                capture_output=True,
+            result = subprocess.run(args, check=True, capture_output=True)
+            self.supports_animate_option = "--animate" in args
+        except subprocess.CalledProcessError as error:
+            if not self._should_retry_without_animate(error, args):
+                return FilePreviewState.error()
+            self.supports_animate_option = False
+            fallback_args = self._build_chafa_command(
+                chafa,
+                path,
+                preview_columns=preview_columns,
             )
+            try:
+                result = subprocess.run(fallback_args, check=True, capture_output=True)
+            except (OSError, subprocess.SubprocessError, ValueError):
+                return FilePreviewState.error()
         except (OSError, subprocess.SubprocessError, ValueError):
-            return None
+            return FilePreviewState.error()
 
         try:
             content = _normalize_preview_newlines(result.stdout.decode("utf-8"))
@@ -388,8 +392,45 @@ class ChafaImagePreviewLoader:
             )
         content = _strip_non_sgr_ansi(content)
         if not content.strip():
-            return None
+            return FilePreviewState.error()
         return FilePreviewState.with_content(content, False, content_kind="image")
+
+    def _build_chafa_command(
+        self,
+        chafa: str,
+        path: Path,
+        *,
+        preview_columns: int,
+    ) -> list[str]:
+        args = [
+            chafa,
+            "--format",
+            "symbols",
+            "--colors",
+            "full",
+        ]
+        if self.supports_animate_option is False:
+            args.extend(["--duration", "0"])
+        else:
+            args.extend(["--animate", "off"])
+        args.extend(
+            [
+                "--size",
+                f"{max(1, preview_columns)}x",
+                str(path),
+            ]
+        )
+        return args
+
+    def _should_retry_without_animate(
+        self,
+        error: subprocess.CalledProcessError,
+        args: list[str],
+    ) -> bool:
+        if "--animate" not in args:
+            return False
+        stderr = error.stderr or b""
+        return b"Unknown option --animate" in stderr
 
     def _resolve_chafa(self) -> str | None:
         if self.chafa_missing:

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -1,3 +1,4 @@
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -443,7 +444,7 @@ def test_chafa_image_preview_loader_uses_full_color_mode(
     preview = loader.load_preview(image, preview_columns=40)
 
     assert preview == FilePreviewState.with_content("@@\n", False, content_kind="image")
-    assert captured_args[:8] == [
+    assert captured_args[:7] == [
         "/usr/bin/chafa",
         "--format",
         "symbols",
@@ -451,8 +452,95 @@ def test_chafa_image_preview_loader_uses_full_color_mode(
         "full",
         "--animate",
         "off",
-        "--fit-width",
     ]
+
+
+def test_chafa_image_preview_loader_falls_back_for_older_chafa(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from zivo.services.browser_snapshot import ChafaImagePreviewLoader
+
+    image = tmp_path / "preview.png"
+    image.write_bytes(b"png")
+    loader = ChafaImagePreviewLoader()
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.shutil.which",
+        lambda name: "/usr/bin/chafa",
+    )
+
+    class _CompletedProcess:
+        stdout = b"@@\n"
+
+    captured_calls: list[list[str]] = []
+
+    def _run(args, **kwargs):
+        captured_calls.append(list(args))
+        if "--animate" in args:
+            raise subprocess.CalledProcessError(
+                1,
+                args,
+                stderr=b"chafa: Unknown option --animate\n",
+            )
+        return _CompletedProcess()
+
+    monkeypatch.setattr("zivo.services.previews.core.subprocess.run", _run)
+
+    preview = loader.load_preview(image, preview_columns=40)
+
+    assert preview == FilePreviewState.with_content("@@\n", False, content_kind="image")
+    assert captured_calls == [
+        [
+            "/usr/bin/chafa",
+            "--format",
+            "symbols",
+            "--colors",
+            "full",
+            "--animate",
+            "off",
+            "--size",
+            "40x",
+            str(image),
+        ],
+        [
+            "/usr/bin/chafa",
+            "--format",
+            "symbols",
+            "--colors",
+            "full",
+            "--duration",
+            "0",
+            "--size",
+            "40x",
+            str(image),
+        ],
+    ]
+
+
+def test_chafa_image_preview_loader_returns_error_when_command_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from zivo.services.browser_snapshot import ChafaImagePreviewLoader
+
+    image = tmp_path / "preview.png"
+    image.write_bytes(b"png")
+    loader = ChafaImagePreviewLoader()
+
+    monkeypatch.setattr(
+        "zivo.services.previews.core.shutil.which",
+        lambda name: "/usr/bin/chafa",
+    )
+
+    def _run(args, **kwargs):
+        raise subprocess.CalledProcessError(1, args, stderr=b"decoder failed\n")
+
+    monkeypatch.setattr("zivo.services.previews.core.subprocess.run", _run)
+
+    preview = loader.load_preview(image, preview_columns=40)
+
+    assert preview == FilePreviewState.error()
 
 
 def test_live_browser_snapshot_loader_detects_png_signature_without_extension(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add compatibility fallback for older `chafa` builds used on WSL
- stop reporting image preview command failures as missing `chafa` installs
- add regression coverage for the fallback and error handling

## Test
- `uv run ruff check .`
- `uv run pytest tests/test_services_browser_snapshot.py`
- `uv run pytest` *(fails on current WSL environment in pre-existing `tests/test_services_external_launcher.py` cases; reproduced on clean `origin/develop` as well)*

Closes #798