### PR TITLE
Fix preview not working in grep in selected files (sfg)

### DIFF
--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -358,6 +358,7 @@ def _handle_cancel_command_palette(
         "replace_in_found_files",
         "replace_in_grep_files",
         "grep_replace_selected",
+        "selected_files_grep",
     }:
         return sync_child_pane(next_state, next_state.current_pane.cursor_path, reduce_state)
     return finalize(next_state)

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -244,6 +244,8 @@ def _select_command_palette_preview_pane(
         return _select_file_search_preview_pane(state, syntax_theme)
     if state.command_palette.source == "grep_search":
         return _select_grep_preview_pane(state, syntax_theme)
+    if state.command_palette.source == "selected_files_grep":
+        return _select_sfg_preview_pane(state, syntax_theme)
     if state.command_palette.source in {
         "replace_text",
         "replace_in_found_files",
@@ -302,6 +304,40 @@ def _select_grep_preview_pane(
         return _build_child_entries_view((), syntax_theme)
 
     results = state.command_palette.grep_search_results
+    if not results:
+        return _build_child_entries_view((), syntax_theme)
+
+    selected_result = results[
+        normalize_command_palette_cursor(state, state.command_palette.cursor_index)
+    ]
+    if (
+        state.child_pane.mode != "preview"
+        or state.child_pane.preview_path != selected_result.path
+        or state.child_pane.preview_highlight_line != selected_result.line_number
+    ):
+        return _build_child_entries_view((), syntax_theme)
+
+    return _build_child_preview_view(
+        state.child_pane.preview_title,
+        state.child_pane.preview_path or selected_result.path,
+        state.child_pane.preview_content,
+        state.child_pane.preview_kind,
+        state.child_pane.preview_message,
+        state.child_pane.preview_truncated,
+        state.child_pane.preview_start_line,
+        state.child_pane.preview_highlight_line,
+        syntax_theme,
+    )
+
+
+def _select_sfg_preview_pane(
+    state: AppState,
+    syntax_theme: str,
+) -> ChildPaneViewState:
+    if not state.config.display.enable_text_preview:
+        return _build_child_entries_view((), syntax_theme)
+
+    results = state.command_palette.sfg_results
     if not results:
         return _build_child_entries_view((), syntax_theme)
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -2908,6 +2908,93 @@ def test_detect_preview_disabled_message_returns_none_for_directory() -> None:
     assert message is None
 
 
+def test_select_shell_data_builds_sfg_preview_for_palette_selection() -> None:
+    initial_state = build_initial_app_state()
+    path = "/home/tadashi/develop/zivo/README.md"
+    grep_result = GrepSearchResultState(
+        path=path,
+        display_path="README.md",
+        line_number=5,
+        line_text="TODO: update docs",
+    )
+    state = replace(
+        initial_state,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="selected_files_grep",
+            query="todo",
+            sfg_target_paths=(path,),
+            sfg_results=(grep_result,),
+        ),
+        child_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(),
+            mode="preview",
+            preview_path=path,
+            preview_title="Preview: README.md:5",
+            preview_content="line3\nline4\nTODO: update docs\nline6\n",
+            preview_start_line=2,
+            preview_highlight_line=5,
+        ),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is True
+    assert shell.child_pane.title == "Preview: README.md:5"
+    assert shell.child_pane.preview_path == path
+    assert shell.child_pane.preview_start_line == 2
+    assert shell.child_pane.preview_highlight_line == 5
+
+
+def test_select_shell_data_builds_sfg_preview_falls_back_to_empty_for_no_results() -> None:
+    initial_state = build_initial_app_state()
+    state = replace(
+        initial_state,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="selected_files_grep",
+            query="todo",
+            sfg_results=(),
+        ),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is False
+    assert shell.child_pane.title == "Child Directory"
+
+
+def test_select_shell_data_builds_sfg_preview_falls_back_to_empty_when_preview_disabled() -> None:
+    initial_state = build_initial_app_state()
+    config = replace(
+        initial_state.config,
+        display=replace(initial_state.config.display, enable_text_preview=False),
+    )
+    path = "/home/tadashi/develop/zivo/README.md"
+    grep_result = GrepSearchResultState(
+        path=path,
+        display_path="README.md",
+        line_number=5,
+        line_text="TODO: update docs",
+    )
+    state = replace(
+        initial_state,
+        config=config,
+        ui_mode="PALETTE",
+        command_palette=CommandPaletteState(
+            source="selected_files_grep",
+            query="todo",
+            sfg_results=(grep_result,),
+        ),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is False
+    assert shell.child_pane.title == "Child Directory"
+
+
 def test_detect_preview_disabled_message_returns_none_for_null_cursor() -> None:
     """Test that preview disabled message is None for null cursor."""
     from zivo.state.selectors_panes import _detect_preview_disabled_message

--- a/tests/test_state_selectors_panes.py
+++ b/tests/test_state_selectors_panes.py
@@ -88,6 +88,15 @@ test_select_shell_data_builds_child_preview_message_for_unavailable_file = (
 test_select_shell_data_builds_grep_preview_for_palette_selection = (
     cases.test_select_shell_data_builds_grep_preview_for_palette_selection
 )
+test_select_shell_data_builds_sfg_preview_for_palette_selection = (
+    cases.test_select_shell_data_builds_sfg_preview_for_palette_selection
+)
+test_select_shell_data_builds_sfg_preview_falls_back_to_empty_for_no_results = (
+    cases.test_select_shell_data_builds_sfg_preview_falls_back_to_empty_for_no_results
+)
+test_select_shell_data_builds_sfg_preview_falls_back_to_empty_when_preview_disabled = (
+    cases.test_select_shell_data_builds_sfg_preview_falls_back_to_empty_when_preview_disabled
+)
 test_select_shell_data_emits_row_delta_updates_for_cut_changes = (
     cases.test_select_shell_data_emits_row_delta_updates_for_cut_changes
 )


### PR DESCRIPTION
## Summary

- Fixes #796: preview (context preview) did not work in "Grep in selected files" mode
- Two bugs found and fixed:

### Bug 1: `_select_command_palette_preview_pane` missing `selected_files_grep` branch

`selectors_panes.py:_select_command_palette_preview_pane()` only handled `file_search`, `grep_search`, and replace sources. `selected_files_grep` returned `None`, causing the carefully loaded grep context preview in `state.child_pane` to be ignored by the UI selector. Added `_select_sfg_preview_pane()` (modeled on `_select_grep_preview_pane()`) and wired it in.

### Bug 2: Cancel handler missing `selected_files_grep` from source set

`reducer_palette.py:_handle_cancel_command_palette()` didn't include `"selected_files_grep"` in the set of sources that trigger `sync_child_pane` on Esc. Added it so the child pane correctly restores directory listing when leaving this mode.

## Test Results

- Added 3 new test cases for sfg preview selector
- 1175 passed, 5 skipped (3 new tests + 1172 existing)
- Lint: all checks passed