### PR TITLE
Add grep search workspace with match previews

### DIFF
--- a/src/zivo/state/actions.py
+++ b/src/zivo/state/actions.py
@@ -199,6 +199,7 @@ from .actions_palette import (
     OpenFindResultInGuiEditor,
     OpenGrepResultInEditor,
     OpenGrepResultInGuiEditor,
+    OpenGrepSearchWorkspace,
     SelectedFilesGrepKeywordChanged,
     SetCommandPaletteQuery,
     SetFindReplaceField,
@@ -351,6 +352,7 @@ Action = (
     | MoveCursorAndSelectRange
     | SetCursorPath
     | EnterCursorDirectory
+    | OpenGrepSearchWorkspace
     | EnterSearchWorkspaceResult
     | GoToParentDirectory
     | GoToHomeDirectory

--- a/src/zivo/state/actions_palette.py
+++ b/src/zivo/state/actions_palette.py
@@ -283,3 +283,8 @@ class OpenGrepResultInGuiEditor:
 @dataclass(frozen=True)
 class OpenFindResultInGuiEditor:
     """Open the selected file search result in a GUI editor."""
+
+
+@dataclass(frozen=True)
+class OpenGrepSearchWorkspace:
+    """Open the current grep search results as a search workspace tab."""

--- a/src/zivo/state/input_palette.py
+++ b/src/zivo/state/input_palette.py
@@ -16,6 +16,7 @@ from .actions import (
     OpenFindResultInGuiEditor,
     OpenGrepResultInEditor,
     OpenGrepResultInGuiEditor,
+    OpenGrepSearchWorkspace,
     SelectedFilesGrepKeywordChanged,
     SetCommandPaletteQuery,
     SetFindReplaceField,
@@ -273,6 +274,8 @@ def dispatch_command_palette_input(
     if key == "ctrl+w" and state.command_palette is not None:
         if state.command_palette.source == "file_search":
             return supported(OpenFileSearchWorkspace())
+        if state.command_palette.source == "grep_search":
+            return supported(OpenGrepSearchWorkspace())
 
     if character and character.isprintable():
         if palette_source == "grep_search":

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -63,7 +63,7 @@ DirectorySizeStatus = Literal["pending", "ready", "failed"]
 CurrentPaneProjectionMode = Literal["full", "viewport"]
 LayoutMode = Literal["browser", "transfer"]
 TransferPaneId = Literal["left", "right"]
-SearchWorkspaceKind = Literal["find"]
+SearchWorkspaceKind = Literal["find", "grep"]
 ConfigFieldId = Literal[
     "editor.command",
     "display.show_hidden_files",
@@ -404,11 +404,14 @@ class SearchWorkspaceState:
     root_path: str
     query: str
     file_results: tuple[FileSearchResultState, ...] = ()
+    grep_results: tuple[GrepSearchResultState, ...] = ()
 
     @property
     def title(self) -> str:
         if self.kind == "find":
             return f'Search Workspace: find "{self.query}"'
+        if self.kind == "grep":
+            return f'Search Workspace: grep "{self.query}"'
         return "Search Workspace"
 
 

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -38,6 +38,7 @@ from .actions import (
     OpenFindResultInGuiEditor,
     OpenGrepResultInEditor,
     OpenGrepResultInGuiEditor,
+    OpenGrepSearchWorkspace,
     SelectedFilesGrepKeywordChanged,
     SetCommandPaletteQuery,
     SetFindReplaceField,
@@ -119,7 +120,7 @@ from .reducer_palette_shared import (
     enter_palette,
     restore_browsing_from_palette,
 )
-from .reducer_search_workspace import open_file_search_workspace
+from .reducer_search_workspace import open_file_search_workspace, open_grep_search_workspace
 
 
 def _handle_move_palette_cursor(state: AppState, action: MoveCommandPaletteCursor) -> ReduceResult:
@@ -484,6 +485,7 @@ _PALETTE_HANDLERS: dict[type[Action], _PaletteHandler] = {
     OpenGrepResultInEditor: lambda s, a, r: handle_open_grep_result_in_editor(s, r),
     OpenFindResultInEditor: lambda s, a, r: handle_open_find_result_in_editor(s, r),
     OpenFileSearchWorkspace: lambda s, a, r: open_file_search_workspace(s, r),
+    OpenGrepSearchWorkspace: lambda s, a, r: open_grep_search_workspace(s, r),
     OpenGrepResultInGuiEditor: lambda s, a, r: handle_open_grep_result_in_gui_editor(s, r),
     OpenFindResultInGuiEditor: lambda s, a, r: handle_open_find_result_in_gui_editor(s, r),
 }

--- a/src/zivo/state/reducer_pane_sync.py
+++ b/src/zivo/state/reducer_pane_sync.py
@@ -8,7 +8,12 @@ from zivo.archive_utils import is_supported_archive_path
 from .actions import RequestDirectorySizes
 from .effects import Effect, LoadChildPaneSnapshotEffect, ReduceResult
 from .entry_state_helpers import current_entry_for_path, visible_current_entry_states
-from .models import DirectoryEntryState, DirectorySizeCacheEntry, PaneState
+from .models import (
+    DirectoryEntryState,
+    DirectorySizeCacheEntry,
+    GrepSearchResultState,
+    PaneState,
+)
 from .reducer_requests import ReducerFn
 
 IMAGE_PREVIEW_EXTENSIONS = frozenset(
@@ -111,11 +116,87 @@ def upsert_directory_size_entries(
     return tuple(sorted(cache_by_path.values(), key=lambda entry: entry.path))
 
 
+def _find_grep_result_for_cursor(
+    state,
+    cursor_path: str | None,
+) -> GrepSearchResultState | None:
+    if state.search_workspace is None or state.search_workspace.kind != "grep":
+        return None
+    if cursor_path is None:
+        return None
+    for result in state.search_workspace.grep_results:
+        encoded = _encode_grep_path(result.path, result.line_number)
+        if encoded == cursor_path:
+            return result
+    return None
+
+
+def _encode_grep_path(real_path: str, line_number: int) -> str:
+    return f"{real_path}\x00{line_number}"
+
+
+def _child_pane_matches_grep_result(
+    child_pane: PaneState,
+    result: GrepSearchResultState,
+) -> bool:
+    return (
+        child_pane.mode == "preview"
+        and child_pane.preview_path == result.path
+        and child_pane.preview_highlight_line == result.line_number
+    )
+
+
+def sync_grep_workspace_child_pane(
+    state,
+    cursor_path: str | None,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    grep_result = _find_grep_result_for_cursor(state, cursor_path)
+    if grep_result is None or not state.config.display.enable_text_preview:
+        next_state = replace(
+            state,
+            child_pane=PaneState(directory_path=state.current_path, entries=()),
+            pending_child_pane_request_id=None,
+        )
+        return maybe_request_directory_sizes(next_state, reduce_state)
+
+    if state.pending_child_pane_request_id is None and _child_pane_matches_grep_result(
+        state.child_pane, grep_result
+    ):
+        return maybe_request_directory_sizes(state, reduce_state)
+
+    request_id = state.next_request_id
+    next_state = replace(
+        state,
+        pending_child_pane_request_id=request_id,
+        next_request_id=request_id + 1,
+    )
+    return maybe_request_directory_sizes(
+        next_state,
+        reduce_state,
+        LoadChildPaneSnapshotEffect(
+            request_id=request_id,
+            current_path=state.current_path,
+            cursor_path=grep_result.path,
+            preview_max_bytes=state.config.display.preview_max_kib * 1024,
+            enable_text_preview=state.config.display.enable_text_preview,
+            enable_image_preview=state.config.display.enable_image_preview,
+            enable_pdf_preview=state.config.display.enable_pdf_preview,
+            enable_office_preview=state.config.display.enable_office_preview,
+            grep_result=grep_result,
+            grep_context_lines=state.config.display.grep_preview_context_lines,
+        ),
+    )
+
+
 def sync_child_pane(
     state,
     cursor_path: str | None,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
+    if state.search_workspace is not None and state.search_workspace.kind == "grep":
+        return sync_grep_workspace_child_pane(state, cursor_path, reduce_state)
+
     entry = current_entry_for_path(state, cursor_path)
     if entry is None:
         next_state = replace(

--- a/src/zivo/state/reducer_search_workspace.py
+++ b/src/zivo/state/reducer_search_workspace.py
@@ -11,6 +11,7 @@ from .models import (
     CurrentPaneDeltaState,
     DirectoryEntryState,
     FilterState,
+    GrepSearchResultState,
     HistoryState,
     NotificationState,
     PaneState,
@@ -19,6 +20,28 @@ from .models import (
 )
 from .reducer_common import ReducerFn, finalize, sync_child_pane
 from .reducer_navigation_shared import load_browser_tab_from_tabs
+
+_GREP_PATH_SEP = "\x00"
+
+
+def _encode_grep_path(real_path: str, line_number: int) -> str:
+    return f"{real_path}{_GREP_PATH_SEP}{line_number}"
+
+
+def _decode_grep_path(encoded: str) -> tuple[str, int]:
+    real_path, line_str = encoded.rsplit(_GREP_PATH_SEP, 1)
+    return real_path, int(line_str)
+
+
+def _find_grep_result(state: AppState, cursor_path: str) -> GrepSearchResultState | None:
+    workspace = state.search_workspace
+    if workspace is None or workspace.kind != "grep":
+        return None
+    for result in workspace.grep_results:
+        encoded = _encode_grep_path(result.path, result.line_number)
+        if encoded == cursor_path:
+            return result
+    return None
 
 
 def open_file_search_workspace(
@@ -87,6 +110,73 @@ def open_file_search_workspace(
     return sync_child_pane(next_state, cursor_path, reduce_state)
 
 
+def open_grep_search_workspace(
+    state: AppState,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    """Open grep-search results in a new search workspace tab."""
+
+    palette = state.command_palette
+    if palette is None or palette.source != "grep_search":
+        return finalize(state)
+    if not palette.grep_search_results:
+        message = palette.grep_search_error_message or "No matching lines"
+        return finalize(
+            replace(
+                state,
+                notification=NotificationState(level="warning", message=message),
+            )
+        )
+
+    query = palette.grep_search_keyword.strip()
+    grep_results = palette.grep_search_results
+    workspace = SearchWorkspaceState(
+        kind="grep",
+        root_path=state.current_path,
+        query=query,
+        grep_results=grep_results,
+    )
+    entries = tuple(
+        DirectoryEntryState(
+            path=_encode_grep_path(result.path, result.line_number),
+            name=result.display_label,
+            kind="file",
+        )
+        for result in grep_results
+    )
+    cursor_path = entries[0].path if entries else None
+    tab = BrowserTabState(
+        current_path=workspace.root_path,
+        parent_pane=PaneState(directory_path=workspace.root_path, entries=()),
+        current_pane=PaneState(
+            directory_path=workspace.title,
+            entries=entries,
+            cursor_path=cursor_path,
+        ),
+        child_pane=PaneState(directory_path=workspace.root_path, entries=()),
+        history=HistoryState(visited_all=(workspace.root_path,)),
+        filter=FilterState(),
+        current_pane_delta=CurrentPaneDeltaState(),
+        search_workspace=workspace,
+    )
+    tabs = list(select_browser_tabs(state))
+    insert_index = state.active_tab_index + 1
+    tabs.insert(insert_index, tab)
+    next_state = load_browser_tab_from_tabs(
+        replace(
+            state,
+            command_palette=None,
+            notification=None,
+            ui_mode="BROWSING",
+            pending_file_search_request_id=None,
+            pending_grep_search_request_id=None,
+        ),
+        tuple(tabs),
+        insert_index,
+    )
+    return sync_child_pane(next_state, cursor_path, reduce_state)
+
+
 def handle_enter_search_workspace_result(
     state: AppState,
     action: EnterSearchWorkspaceResult,
@@ -99,6 +189,14 @@ def handle_enter_search_workspace_result(
         return finalize(state)
 
     cursor_path = state.current_pane.cursor_path
+    if state.search_workspace.kind == "grep":
+        real_path, _ = _decode_grep_path(cursor_path)
+        parent_path = str(Path(real_path).parent)
+        next_state = replace(state, search_workspace=None)
+        return reduce_state(
+            next_state,
+            RequestBrowserSnapshot(parent_path, cursor_path=real_path, blocking=True),
+        )
     parent_path = str(Path(cursor_path).parent)
     next_state = replace(state, search_workspace=None)
     return reduce_state(

--- a/src/zivo/state/reducer_terminal_config.py
+++ b/src/zivo/state/reducer_terminal_config.py
@@ -486,12 +486,18 @@ def _handle_open_terminal_at_path(
     )
 
 
+def _decode_target_paths(state: AppState, paths: tuple[str, ...]) -> tuple[str, ...]:
+    if state.search_workspace is not None and state.search_workspace.kind == "grep":
+        return tuple(p.rsplit("\x00", 1)[0] for p in paths)
+    return paths
+
+
 def _handle_copy_paths_to_clipboard(
     state: AppState,
     action: CopyPathsToClipboard,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    target_paths = select_target_paths(state)
+    target_paths = _decode_target_paths(state, select_target_paths(state))
     if not target_paths:
         return finalize(
             replace(

--- a/tests/test_state_reducer_palette_search.py
+++ b/tests/test_state_reducer_palette_search.py
@@ -38,6 +38,7 @@ from zivo.state.actions import (
     OpenFindResultInGuiEditor,
     OpenGrepResultInEditor,
     OpenGrepResultInGuiEditor,
+    OpenGrepSearchWorkspace,
     SelectedFilesGrepKeywordChanged,
     SetCommandPaletteQuery,
     SetGrepSearchField,
@@ -1398,3 +1399,135 @@ def test_grep_filename_filter_with_non_regex_backslash() -> None:
     assert result.state.command_palette.grep_search_error_message is None
     # Non-regex mode should not crash, results may be empty or filtered
     assert isinstance(result.state.command_palette.grep_search_results, tuple)
+
+
+def test_open_grep_search_workspace_creates_new_tab_and_preview_request() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="test",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/main.py",
+                    display_path="src/main.py",
+                    line_number=10,
+                    line_text="def test():",
+                    column_number=1,
+                ),
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/utils.py",
+                    display_path="src/utils.py",
+                    line_number=42,
+                    line_text="answer = 42",
+                    column_number=1,
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, OpenGrepSearchWorkspace())
+
+    assert result.state.ui_mode == "BROWSING"
+    assert result.state.command_palette is None
+    assert result.state.active_tab_index == 1
+    assert result.state.search_workspace is not None
+    assert result.state.search_workspace.query == "test"
+    assert result.state.search_workspace.kind == "grep"
+    assert tuple(entry.name for entry in result.state.current_pane.entries) == (
+        "src/main.py:10: def test():",
+        "src/utils.py:42: answer = 42",
+    )
+    first_encoded = result.state.current_pane.cursor_path
+    assert first_encoded.endswith("\x0010")
+    assert first_encoded.startswith("/home/tadashi/develop/zivo/src/main.py\x00")
+    assert result.effects == (
+        LoadChildPaneSnapshotEffect(
+            request_id=1,
+            current_path="/home/tadashi/develop/zivo",
+            cursor_path="/home/tadashi/develop/zivo/src/main.py",
+            preview_max_bytes=64 * 1024,
+            enable_text_preview=True,
+            enable_image_preview=True,
+            enable_pdf_preview=True,
+            enable_office_preview=True,
+            grep_result=GrepSearchResultState(
+                path="/home/tadashi/develop/zivo/src/main.py",
+                display_path="src/main.py",
+                line_number=10,
+                line_text="def test():",
+                column_number=1,
+            ),
+            grep_context_lines=3,
+        ),
+    )
+
+
+def test_enter_grep_search_workspace_result_jumps_to_normal_browser() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="answer",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/utils.py",
+                    display_path="src/utils.py",
+                    line_number=42,
+                    line_text="answer = 42",
+                ),
+            ),
+        ),
+    )
+    workspace_state = reduce_app_state(state, OpenGrepSearchWorkspace()).state
+
+    result = reduce_app_state(workspace_state, EnterSearchWorkspaceResult())
+
+    assert result.state.search_workspace is None
+    assert result.state.pending_browser_snapshot_request_id == 2
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=2,
+            path="/home/tadashi/develop/zivo/src",
+            cursor_path="/home/tadashi/develop/zivo/src/utils.py",
+            blocking=True,
+            invalidate_paths=(),
+            enable_image_preview=True,
+            enable_pdf_preview=True,
+            enable_office_preview=True,
+        ),
+    )
+
+
+def test_copy_paths_from_grep_workspace_uses_real_paths() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = replace(
+        state,
+        command_palette=replace(
+            state.command_palette,
+            grep_search_keyword="test",
+            grep_search_results=(
+                GrepSearchResultState(
+                    path="/home/tadashi/develop/zivo/src/main.py",
+                    display_path="src/main.py",
+                    line_number=10,
+                    line_text="def test():",
+                ),
+            ),
+        ),
+    )
+    workspace_state = reduce_app_state(state, OpenGrepSearchWorkspace()).state
+
+    result = reduce_app_state(workspace_state, CopyPathsToClipboard())
+
+    assert result.effects == (
+        RunExternalLaunchEffect(
+            request_id=2,
+            request=ExternalLaunchRequest(
+                kind="copy_paths",
+                paths=("/home/tadashi/develop/zivo/src/main.py",),
+            ),
+        ),
+    )


### PR DESCRIPTION
## Summary

- Phase 2 of #819: Grep Search Workspace with match previews
- Adds `OpenGrepSearchWorkspace` action triggered by `ctrl+w` in grep search palette
- Displays grep matches as individual rows in a workspace tab
- Right pane shows context preview with highlight for the selected match
- Match entries use encoded paths (`path\0line`) for unique cursor positioning
- Enter jumps to the real file's directory in normal browser mode
- `C` copies real file paths (decoded) to clipboard
- `Space` toggles selection (match-level)
- All existing cursor movement keys (j/k, up/down, pageup/down, home/end) work

## Files Changed

- `src/zivo/state/models.py` - `SearchWorkspaceKind` extended with "grep"; `SearchWorkspaceState` gains `grep_results`
- `src/zivo/state/actions_palette.py` - New `OpenGrepSearchWorkspace` action
- `src/zivo/state/actions.py` - Action union and `__all__` updated
- `src/zivo/state/reducer_search_workspace.py` - `open_grep_search_workspace()` and grep-aware `handle_enter_search_workspace_result()`
- `src/zivo/state/reducer_pane_sync.py` - `sync_child_pane` detects grep workspace, uses `sync_grep_workspace_child_pane()` with `load_grep_preview`
- `src/zivo/state/reducer_palette.py` - Dispatch table entry
- `src/zivo/state/input_palette.py` - `ctrl+w` binding for grep_search source
- `src/zivo/state/reducer_terminal_config.py` - `CopyPathsToClipboard` decodes grep encoded paths
- `tests/test_state_reducer_palette_search.py` - 3 new test cases

## Test results

```
1213 passed, 5 skipped in 72.85s
```

Lint: all checks passed.

## Follow-up

- Back/forward navigation (`HistoryState`) is not yet wired for workspace tabs
- Replace flow integration (select grep matches and replace) is out of scope per #827
