### PR TITLE
#851 Search Workspace: Esc should clear filter

### DIFF
--- a/src/zivo/state/input_browsing.py
+++ b/src/zivo/state/input_browsing.py
@@ -201,6 +201,8 @@ def dispatch_search_workspace_input(
     if key == "space":
         return handle_toggle_selection(state, ctx)
     if key == "escape":
+        if ctx.filter_is_active:
+            return supported(CancelFilterInput())
         return supported(ClearSelection())
     if key == "/":
         return supported(BeginFilterInput())

--- a/tests/input_dispatch_browsing_cases.py
+++ b/tests/input_dispatch_browsing_cases.py
@@ -226,6 +226,38 @@ def test_search_workspace_grep_m_toggles_match_and_file_views() -> None:
     assert actions == (SetNotification(None), ToggleSearchWorkspaceGrepDisplayMode())
 
 
+def test_search_workspace_escape_clears_filter_when_active() -> None:
+    base = build_initial_app_state()
+    state = replace(
+        base,
+        search_workspace=SearchWorkspaceState(
+            kind="find",
+            root_path="/home/tadashi/develop/zivo",
+            query="readme",
+        ),
+        filter=replace(base.filter, query="docs", active=True),
+    )
+
+    actions = dispatch_key_input(state, key="escape")
+
+    assert actions == (SetNotification(None), CancelFilterInput())
+
+
+def test_search_workspace_escape_clears_selection_when_no_filter() -> None:
+    state = replace(
+        build_initial_app_state(),
+        search_workspace=SearchWorkspaceState(
+            kind="find",
+            root_path="/home/tadashi/develop/zivo",
+            query="readme",
+        ),
+    )
+
+    actions = dispatch_key_input(state, key="escape")
+
+    assert actions == (SetNotification(None), ClearSelection())
+
+
 def test_browsing_prefix_key_starts_multi_key_sequence(monkeypatch) -> None:
     monkeypatch.setattr(
         input_module,


### PR DESCRIPTION
## Summary

- Search Workspace 内でフィルタがアクティブな状態で `Esc` を押したときにフィルタを解除できるようにする
- `dispatch_search_workspace_input` の Esc 処理に `ctx.filter_is_active` チェックを追加
- フィルタがアクティブなら `CancelFilterInput()`、そうでなければ `ClearSelection()` を返す
- 通常のブラウジングの `handle_clear_selection` と一貫した動作になる

## Changes

- `src/zivo/state/input_browsing.py` - Esc 処理にフィルタ状態チェックを追加
- `tests/input_dispatch_browsing_cases.py` - 2つのテストケースを追加

## Test Results

- All 1222 tests passed, 6 skipped
- ruff check passed

## Related Issue

Closes #851