### PR TITLE
#837 Phase 10: Metadata columns for Search Workspace rows

### DIFF
--- a/src/zivo/services/file_search.py
+++ b/src/zivo/services/file_search.py
@@ -3,6 +3,7 @@
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Literal, Protocol
 
@@ -131,10 +132,20 @@ class LiveFileSearchService:
                     continue
                 if not parsed_query.matches(child.name):
                     continue
+                size_bytes: int | None = None
+                modified_at: datetime | None = None
+                try:
+                    stat_result = child.stat()
+                    size_bytes = stat_result.st_size
+                    modified_at = datetime.fromtimestamp(stat_result.st_mtime)
+                except OSError:
+                    pass
                 results.append(
                     FileSearchResultState(
                         path=str(child),
                         display_path=child.relative_to(root).as_posix(),
+                        size_bytes=size_bytes,
+                        modified_at=modified_at,
                     )
                 )
 

--- a/src/zivo/services/grep_search.py
+++ b/src/zivo/services/grep_search.py
@@ -3,7 +3,8 @@
 import json
 import subprocess
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from datetime import datetime
 from pathlib import Path
 from typing import Protocol
 
@@ -106,7 +107,7 @@ class LiveGrepSearchService:
             if self._is_nonfatal_ripgrep_error(return_code, stderr_text, stripped_query):
                 return tuple(
                     sorted(
-                        self._parse_results(root, stdout_lines),
+                        self._attach_file_metadata(self._parse_results(root, stdout_lines)),
                         key=lambda result: (result.display_path.casefold(), result.line_number),
                     )
                 )
@@ -114,7 +115,7 @@ class LiveGrepSearchService:
                 raise InvalidGrepSearchQueryError(message)
             raise OSError(message)
 
-        results = self._parse_results(root, stdout_lines)
+        results = self._attach_file_metadata(self._parse_results(root, stdout_lines))
         return tuple(
             sorted(
                 results,
@@ -188,6 +189,25 @@ class LiveGrepSearchService:
                 )
             )
         return results
+
+    @staticmethod
+    def _attach_file_metadata(
+        results: list[GrepSearchResultState],
+    ) -> list[GrepSearchResultState]:
+        cache: dict[str, tuple[int | None, datetime | None]] = {}
+        for path in {r.path for r in results}:
+            try:
+                stat_result = Path(path).stat()
+                cache[path] = (
+                    stat_result.st_size,
+                    datetime.fromtimestamp(stat_result.st_mtime),
+                )
+            except OSError:
+                cache[path] = (None, None)
+        return [
+            replace(r, size_bytes=cache[r.path][0], modified_at=cache[r.path][1])
+            for r in results
+        ]
 
     @staticmethod
     def _relative_display_path(root: Path, path: Path) -> str:

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -361,6 +361,8 @@ class FileSearchResultState:
 
     path: str
     display_path: str
+    size_bytes: int | None = None
+    modified_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -372,6 +374,8 @@ class GrepSearchResultState:
     line_number: int
     line_text: str
     column_number: int = 1
+    size_bytes: int | None = None
+    modified_at: datetime | None = None
 
     @property
     def display_label(self) -> str:

--- a/src/zivo/state/reducer_search_workspace.py
+++ b/src/zivo/state/reducer_search_workspace.py
@@ -54,6 +54,8 @@ def open_file_search_workspace(
             path=result.path,
             name=result.display_path,
             kind="file",
+            size_bytes=result.size_bytes,
+            modified_at=result.modified_at,
         )
         for result in workspace.file_results
     )
@@ -121,6 +123,8 @@ def open_grep_search_workspace(
             path=encode_grep_result_path(result.path, result.line_number),
             name=result.display_label,
             kind="file",
+            size_bytes=result.size_bytes,
+            modified_at=result.modified_at,
         )
         for result in grep_results
     )

--- a/src/zivo/state/search_workspace_helpers.py
+++ b/src/zivo/state/search_workspace_helpers.py
@@ -42,6 +42,8 @@ def build_grep_file_entries(
             path=result.path,
             name=result.display_path,
             kind="file",
+            size_bytes=result.size_bytes,
+            modified_at=result.modified_at,
         )
     return tuple(file_entries.values())
 

--- a/tests/test_services_file_search.py
+++ b/tests/test_services_file_search.py
@@ -20,6 +20,47 @@ def test_live_file_search_service_matches_files_recursively(tmp_path) -> None:
     assert [result.display_path for result in results] == ["docs/README.md"]
 
 
+def test_live_file_search_service_populates_file_metadata(tmp_path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "data.txt").write_text("hello\n", encoding="utf-8")
+
+    service = LiveFileSearchService()
+
+    results = service.search(str(root), "data", show_hidden=False)
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.display_path == "data.txt"
+    assert result.size_bytes == 6
+    assert result.modified_at is not None
+
+
+def test_live_file_search_service_handles_stat_failure(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    target = root / "data.txt"
+    target.write_text("hello\n", encoding="utf-8")
+
+    original_stat = Path.stat
+
+    def broken_stat(self: Path, *args, **kwargs):
+        if self.name == "data.txt":
+            raise PermissionError("denied")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", broken_stat)
+
+    service = LiveFileSearchService()
+
+    results = service.search(str(root), "data", show_hidden=False)
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.size_bytes is None
+    assert result.modified_at is None
+
+
 def test_live_file_search_service_skips_hidden_paths_when_disabled(tmp_path) -> None:
     root = tmp_path / "project"
     root.mkdir()

--- a/tests/test_services_file_search.py
+++ b/tests/test_services_file_search.py
@@ -23,7 +23,9 @@ def test_live_file_search_service_matches_files_recursively(tmp_path) -> None:
 def test_live_file_search_service_populates_file_metadata(tmp_path) -> None:
     root = tmp_path / "project"
     root.mkdir()
-    (root / "data.txt").write_text("hello\n", encoding="utf-8")
+    target = root / "data.txt"
+    target.write_text("hello\n", encoding="utf-8")
+    expected_size = target.stat().st_size
 
     service = LiveFileSearchService()
 
@@ -32,7 +34,7 @@ def test_live_file_search_service_populates_file_metadata(tmp_path) -> None:
     assert len(results) == 1
     result = results[0]
     assert result.display_path == "data.txt"
-    assert result.size_bytes == 6
+    assert result.size_bytes == expected_size
     assert result.modified_at is not None
 
 

--- a/tests/test_services_grep_search.py
+++ b/tests/test_services_grep_search.py
@@ -33,6 +33,23 @@ def test_live_grep_search_service_matches_file_contents_recursively(tmp_path) ->
 
 
 @skip_if_no_rg
+def test_live_grep_search_service_populates_file_metadata(tmp_path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "data.txt").write_text("TODO: item\n", encoding="utf-8")
+
+    service = LiveGrepSearchService()
+
+    results = service.search(str(root), "todo", show_hidden=False)
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.display_path == "data.txt"
+    assert result.size_bytes == 11
+    assert result.modified_at is not None
+
+
+@skip_if_no_rg
 def test_live_grep_search_service_records_first_match_column(tmp_path) -> None:
     root = tmp_path / "project"
     root.mkdir()

--- a/tests/test_services_grep_search.py
+++ b/tests/test_services_grep_search.py
@@ -36,7 +36,9 @@ def test_live_grep_search_service_matches_file_contents_recursively(tmp_path) ->
 def test_live_grep_search_service_populates_file_metadata(tmp_path) -> None:
     root = tmp_path / "project"
     root.mkdir()
-    (root / "data.txt").write_text("TODO: item\n", encoding="utf-8")
+    target = root / "data.txt"
+    target.write_text("TODO: item\n", encoding="utf-8")
+    expected_size = target.stat().st_size
 
     service = LiveGrepSearchService()
 
@@ -45,7 +47,7 @@ def test_live_grep_search_service_populates_file_metadata(tmp_path) -> None:
     assert len(results) == 1
     result = results[0]
     assert result.display_path == "data.txt"
-    assert result.size_bytes == 11
+    assert result.size_bytes == expected_size
     assert result.modified_at is not None
 
 


### PR DESCRIPTION
## Summary

- Add `size_bytes` and `modified_at` optional fields to `FileSearchResultState` and `GrepSearchResultState`
- Populate metadata via `os.stat()` in `LiveFileSearchService` (during file tree walk) and `LiveGrepSearchService` (after ripgrep parsing)
- Pass metadata through to `DirectoryEntryState` in:
  - `open_file_search_workspace()` — file search workspace
  - `open_grep_search_workspace()` — grep match-mode workspace
  - `build_grep_file_entries()` — grep file-mode workspace
- Handle stat failures gracefully: `OSError`/`PermissionError` → `None` fallback → UI displays `"-"`
- Add tests for metadata population and stat failure handling

## Test Results

All 1225 tests passed (6 skipped).