### PR TITLE
Fix #846: Add Ctrl+w workspace to grep search palette help bar

### DIFF
--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -157,8 +157,8 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
                 return HelpBarState(state.config.help_bar.palette_grep_search)
             return HelpBarState(
                 (
-                    "type text / tab fields / ↑↓ or Ctrl+n/p select | "
-                    "enter jump | Ctrl+e edit | Ctrl+o GUI | esc cancel",
+                    "type text / ↑↓ or Ctrl+n/p select | "
+                    "enter open | Ctrl+w workspace | Ctrl+e edit | Ctrl+o GUI | esc cancel",
                 )
             )
         if (

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1621,8 +1621,8 @@ def test_select_help_bar_state_for_grep_search_palette() -> None:
     help_bar = select_help_bar_state(state)
 
     assert help_bar.lines == (
-        "type text / tab fields / ↑↓ or Ctrl+n/p select | "
-        "enter jump | Ctrl+e edit | Ctrl+o GUI | esc cancel",
+        "type text / ↑↓ or Ctrl+n/p select | "
+        "enter open | Ctrl+w workspace | Ctrl+e edit | Ctrl+o GUI | esc cancel",
     )
 
 


### PR DESCRIPTION
## Summary

- grep search パレットのデフォルトヘルプバーに `Ctrl+w workspace` を追加
- `enter jump` → `enter open` に変更（grep search はファイルを開く動作のため）
- `tab fields /` を削除（タブ操作の表示は不要）

## Changes

| Before | After |
|--------|-------|
| `type text / tab fields / ↑↓ or Ctrl+n/p select \| enter jump \| Ctrl+e edit \| Ctrl+o GUI \| esc cancel` | `type text / ↑↓ or Ctrl+n/p select \| enter open \| Ctrl+w workspace \| Ctrl+e edit \| Ctrl+o GUI \| esc cancel` |

## Files changed

- `src/zivo/state/selectors_ui.py` — デフォルトヘルプバーテキスト
- `tests/state_selectors_cases.py` — テスト期待値

## Test results

- ✅ 1225 passed, 6 skipped (pytest)
- ✅ All checks passed (ruff)