### PR TITLE
Fix #867: Search workspace grep preview not showing

### DIFF
--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -23,6 +23,7 @@ from .models import (
     SortState,
     select_browser_tabs,
 )
+from .search_workspace_helpers import decode_grep_result_path
 from .selectors_shared import (
     SIDE_PANE_SORT,
     _find_current_cursor_index,
@@ -180,6 +181,11 @@ def select_child_pane_for_cursor(
     elif (
         state.child_pane.mode != "preview"
         or cursor_entry.path != state.child_pane.preview_path
+    ) and not (
+        state.search_workspace is not None
+        and state.search_workspace.kind == "grep"
+        and (decoded := decode_grep_result_path(cursor_entry.path)) is not None
+        and decoded[0] == state.child_pane.preview_path
     ):
         preview_disabled_message = _detect_preview_disabled_message(
             cursor_entry,

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -75,6 +75,7 @@ from zivo.state.actions import (
 )
 from zivo.state.command_palette import CommandPaletteItem
 from zivo.state.reducer_common import directory_size_target_paths
+from zivo.state.search_workspace_helpers import encode_grep_result_path
 from zivo.state.selectors import (
     _has_execute_permission,
     _select_command_palette_window,
@@ -1011,6 +1012,58 @@ def test_select_shell_data_builds_grep_preview_for_palette_selection() -> None:
     assert shell.child_pane.is_preview is True
     assert shell.child_pane.title == "Preview: README.md:5"
     assert shell.child_pane.preview_path == path
+    assert shell.child_pane.preview_start_line == 2
+    assert shell.child_pane.preview_highlight_line == 5
+
+
+def test_select_shell_data_builds_grep_preview_for_search_workspace() -> None:
+    path = "/home/tadashi/develop/zivo/README.md"
+    grep_result = GrepSearchResultState(
+        path=path,
+        display_path="README.md",
+        line_number=5,
+        line_text="TODO: update docs",
+    )
+    encoded_path = encode_grep_result_path(path, 5)
+    state = replace(
+        build_initial_app_state(),
+        search_workspace=SearchWorkspaceState(
+            kind="grep",
+            root_path="/home/tadashi/develop/zivo",
+            query="todo",
+            grep_results=(grep_result,),
+            grep_display_mode="match",
+        ),
+        current_pane=PaneState(
+            directory_path='Search Workspace: grep "todo"',
+            entries=(
+                DirectoryEntryState(
+                    encoded_path,
+                    "README.md:5",
+                    "file",
+                ),
+            ),
+            cursor_path=encoded_path,
+        ),
+        child_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(),
+            mode="preview",
+            preview_path=path,
+            preview_title="Preview: README.md:5",
+            preview_content="line3\nline4\nTODO: update docs\nline6\n",
+            preview_start_line=2,
+            preview_highlight_line=5,
+        ),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.child_pane.is_preview is True
+    assert shell.child_pane.title == "Preview: README.md:5"
+    assert shell.child_pane.preview_path == path
+    assert shell.child_pane.preview_content is not None
+    assert "TODO: update docs" in shell.child_pane.preview_content
     assert shell.child_pane.preview_start_line == 2
     assert shell.child_pane.preview_highlight_line == 5
 

--- a/tests/test_state_selectors_panes.py
+++ b/tests/test_state_selectors_panes.py
@@ -88,6 +88,9 @@ test_select_shell_data_builds_child_preview_message_for_unavailable_file = (
 test_select_shell_data_builds_grep_preview_for_palette_selection = (
     cases.test_select_shell_data_builds_grep_preview_for_palette_selection
 )
+test_select_shell_data_builds_grep_preview_for_search_workspace = (
+    cases.test_select_shell_data_builds_grep_preview_for_search_workspace
+)
 test_select_shell_data_builds_sfg_preview_for_palette_selection = (
     cases.test_select_shell_data_builds_sfg_preview_for_palette_selection
 )


### PR DESCRIPTION
## Summary
- Search workspace の grep 画面でプレビューが動作していなかったバグを修正
- 原因: `select_child_pane_for_cursor()` 内で cursor_entry.path（エンコード済み: real_path + NUL + line_number）と preview_path（実パス）を直接比較していたため常に不一致となり preview が表示されなかった

## Changes
- `src/zivo/state/selectors_panes.py`: preview_path 比較時に grep workspace の場合は `decode_grep_result_path()` でデコードした実パスと比較するよう修正
- `tests/state_selectors_cases.py`: search workspace 経由の grep preview が正しく表示されることを確認するテストケースを追加

## Test results
- 1232 passed, 6 skipped
- ruff check: All checks passed!