### PR TITLE
Add mouse interaction: tab click switching and hover highlights (fixes #870)

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -78,6 +78,7 @@ from zivo.state import (
 )
 from zivo.state.actions import (
     Action,
+    ActivateTabByIndex,
     EnterCursorDirectory,
     EnterTransferDirectory,
     ExitCurrentPath,
@@ -101,6 +102,7 @@ from zivo.ui import (
     ShellCommandDialog,
     SidePane,
     StatusBar,
+    TabBar,
 )
 
 
@@ -691,6 +693,11 @@ class zivoApp(App[None]):
             await self.dispatch_actions((RequestBrowserSnapshot(message.path, blocking=True),))
             return
         await self.dispatch_actions((OpenPathWithDefaultApp(message.path),))
+
+    async def on_tab_bar_tab_clicked(self, message: TabBar.TabClicked) -> None:
+        """Handle tab clicks from the widget message path."""
+
+        await self.dispatch_actions((ActivateTabByIndex(message.index),))
 
     async def on_child_pane_entry_clicked(self, message: ChildPane.EntryClicked) -> None:
         """Handle right child-pane double clicks from the widget message path."""

--- a/src/zivo/app.tcss
+++ b/src/zivo/app.tcss
@@ -90,6 +90,10 @@ Screen {
     color: $text;
 }
 
+#tab-bar:hover {
+    background: $panel;
+}
+
 #help-bar {
     height: auto;
     min-height: 1;

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -62,6 +62,7 @@ class ChildPane(Vertical):
         self._last_render_width = 0
         self._last_render_signature: object | None = None
         self._last_clicked_path: str | None = None
+        self._hovered_path: str | None = None
 
     @property
     def list_view_id(self) -> str | None:
@@ -138,9 +139,50 @@ class ChildPane(Vertical):
         event.stop()
         self.post_message(self.EntryClicked(self.id, path, double_click=double_click))
 
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        if self._state.is_preview:
+            return
+        meta = event.style.meta
+        if "entry_path" not in meta:
+            if self._hovered_path is not None:
+                self._hovered_path = None
+                self._refresh_list_hover()
+            return
+        path = str(meta["entry_path"])
+        if path != self._hovered_path:
+            self._hovered_path = path
+            self._refresh_list_hover()
+
+    def on_leave(self, _event: events.Leave) -> None:
+        if self._state.is_preview:
+            return
+        if self._hovered_path is not None:
+            self._hovered_path = None
+            self._refresh_list_hover()
+
+    def _refresh_list_hover(self) -> None:
+        try:
+            widget = self._list_widget()
+        except NoMatches:
+            return
+        render_width = self._last_render_width
+        if render_width <= 0:
+            return
+        widget.update(
+            _render_file_entries(
+                self._state.entries,
+                render_width,
+                self._ft_styles,
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
+            )
+        )
+
     async def set_state(self, state: ChildPaneViewState) -> None:
         if state == self._state:
             return
+        self._hovered_path = None
 
         previous_state = self._state
         preview_identity_changed = self._preview_identity(state) != self._preview_identity(
@@ -205,6 +247,7 @@ class ChildPane(Vertical):
                 self._ft_styles,
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             )
         )
         self._last_render_width = render_width

--- a/src/zivo/ui/pane_rendering.py
+++ b/src/zivo/ui/pane_rendering.py
@@ -204,6 +204,7 @@ def _render_file_label(
     *,
     selected_directory_style: str,
     selected_cut_style: str,
+    hovered_path: str | None = None,
 ) -> Text:
     """Render a single file entry label with resolved theme styles."""
 
@@ -217,6 +218,8 @@ def _render_file_label(
         selected_cut_style=selected_cut_style,
     )
     style = _style_without_background(style)
+    if hovered_path is not None and entry.path == hovered_path:
+        style = (style or Style()) + Style(reverse=True)
     text = Text(label) if style is None else Text(label, style=style)
     if label:
         text.stylize(Style(meta={"entry_path": entry.path}), 0, len(label))
@@ -230,6 +233,7 @@ def _render_file_entries(
     *,
     selected_directory_style: str,
     selected_cut_style: str,
+    hovered_path: str | None = None,
 ) -> Text:
     """Render a sequence of file entries as a single Rich Text block."""
 
@@ -243,6 +247,7 @@ def _render_file_entries(
                 styles,
                 selected_directory_style=selected_directory_style,
                 selected_cut_style=selected_cut_style,
+                hovered_path=hovered_path,
             )
             for entry in entries
         ]

--- a/src/zivo/ui/side_pane.py
+++ b/src/zivo/ui/side_pane.py
@@ -49,6 +49,7 @@ class SidePane(Vertical):
         self._ft_styles: dict[str, Style] = {}
         self._last_render_width = 0
         self._last_clicked_path: str | None = None
+        self._hovered_path: str | None = None
 
     @property
     def list_view_id(self) -> str | None:
@@ -88,6 +89,42 @@ class SidePane(Vertical):
         event.stop()
         self.post_message(self.EntryClicked(self.id, path, double_click=double_click))
 
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        meta = event.style.meta
+        if "entry_path" not in meta:
+            if self._hovered_path is not None:
+                self._hovered_path = None
+                self._refresh_hover()
+            return
+        path = str(meta["entry_path"])
+        if path != self._hovered_path:
+            self._hovered_path = path
+            self._refresh_hover()
+
+    def on_leave(self, _event: events.Leave) -> None:
+        if self._hovered_path is not None:
+            self._hovered_path = None
+            self._refresh_hover()
+
+    def _refresh_hover(self) -> None:
+        try:
+            content = self._content_widget()
+        except NoMatches:
+            return
+        render_width = self._last_render_width
+        if render_width <= 0:
+            return
+        content.update(
+            _render_file_entries(
+                self._entries,
+                render_width,
+                self._ft_styles,
+                selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+                selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
+            )
+        )
+
     async def set_entries(self, entries: Sequence[PaneEntry]) -> None:
         """Replace the rendered entries without remounting the pane."""
 
@@ -95,6 +132,7 @@ class SidePane(Vertical):
         if next_entries == self._entries:
             return
 
+        self._hovered_path = None
         content = self._content_widget()
         render_width = self._entry_width(content)
         content.update(
@@ -124,6 +162,7 @@ class SidePane(Vertical):
                 self._ft_styles,
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             )
         )
         self._last_render_width = render_width

--- a/src/zivo/ui/tab_bar.py
+++ b/src/zivo/ui/tab_bar.py
@@ -1,6 +1,9 @@
 """Tab bar widget shown above the current path bar."""
 
+from rich.style import Style
 from rich.text import Text
+from textual import events
+from textual.message import Message
 from textual.widgets import Static
 
 from zivo.models import TabBarState
@@ -8,6 +11,13 @@ from zivo.models import TabBarState
 
 class TabBar(Static):
     """Compact tab strip for switching between browser workspaces."""
+
+    class TabClicked(Message):
+        """Notify the app that a tab was clicked."""
+
+        def __init__(self, index: int) -> None:
+            super().__init__()
+            self.index = index
 
     def __init__(
         self,
@@ -18,7 +28,11 @@ class TabBar(Static):
     ) -> None:
         super().__init__(self._render_state(state), id=id, classes=classes)
         self.state = state
+        self._hovered_index: int | None = None
         self.display = len(state.tabs) > 1
+
+    def on_mount(self) -> None:
+        self.can_focus = True
 
     def set_state(self, state: TabBarState) -> None:
         """Update the rendered tabs without remounting the widget."""
@@ -27,14 +41,44 @@ class TabBar(Static):
         if state == self.state:
             return
         self.state = state
+        self._hovered_index = None
         self.update(self._render_state(state))
 
+    def on_click(self, event: events.Click) -> None:
+        meta = event.style.meta
+        if "tab_index" not in meta:
+            return
+        tab_index = int(meta["tab_index"])
+        event.stop()
+        self.post_message(self.TabClicked(tab_index))
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        meta = event.style.meta
+        if "tab_index" not in meta:
+            if self._hovered_index is not None:
+                self._hovered_index = None
+                self.update(self._render_state(self.state))
+            return
+        tab_index = int(meta["tab_index"])
+        if tab_index != self._hovered_index:
+            self._hovered_index = tab_index
+            self.update(self._render_state(self.state, hovered_index=tab_index))
+
+    def on_leave(self, _event: events.Leave) -> None:
+        if self._hovered_index is not None:
+            self._hovered_index = None
+            self.update(self._render_state(self.state))
+
     @staticmethod
-    def _render_state(state: TabBarState) -> Text:
+    def _render_state(state: TabBarState, *, hovered_index: int | None = None) -> Text:
         rendered = Text(no_wrap=True, overflow="ellipsis")
         for index, tab in enumerate(state.tabs, start=1):
             if index > 1:
                 rendered.append(" ")
             style = "reverse bold" if tab.active else "bold"
-            rendered.append(f"[{index}:{tab.label}]", style=style)
+            if hovered_index is not None and (index - 1) == hovered_index and not tab.active:
+                style = "reverse bold underline"
+            segment = Text(f"[{index}:{tab.label}]", style=style)
+            segment.stylize(Style(meta={"tab_index": index - 1}))
+            rendered.append(segment)
         return rendered


### PR DESCRIPTION
## Summary

- Tab click switching: Single/double-click on a tab activates it via ActivateTabByIndex
- Tab hover highlight: Inactive tabs get underline added on hover, with tab bar background change via CSS
- Directory entry hover highlight: Entries in SidePane and ChildPane (list mode) show reverse style on hover
- Double-click on tabs behaves same as single-click (tab activation)

## Changes

| File | Change |
|------|--------|
| src/zivo/ui/tab_bar.py | _render_state() supports hovered_index; added on_click/on_mouse_move/on_leave; TabClicked message |
| src/zivo/ui/pane_rendering.py | New hovered_path parameter on rendering functions |
| src/zivo/ui/side_pane.py | on_mouse_move/on_leave/_refresh_hover hover tracking |
| src/zivo/ui/child_pane.py | Same hover support in list mode |
| src/zivo/app.tcss | tab-bar:hover background |
| src/zivo/app.py | on_tab_bar_tab_clicked handler |

## Test Results

- 1232 passed, 6 skipped
- Ruff lint: all checks passed