### PR TITLE
ヘルプバー整理 (fix #875, fix #869)

### DIFF
--- a/src/zivo/state/input_browsing.py
+++ b/src/zivo/state/input_browsing.py
@@ -235,8 +235,8 @@ def dispatch_search_workspace_input(
     if key == "q":
         return supported(BeginExitCurrentPath())
     return warn(
-        "Search workspace: ↑↓ move | / filter | s sort | m view | "
-        "Space select | a select all | Enter jump | e edit | O GUI | R refresh | C copy paths"
+        "Search workspace: / filter | s sort | m view | "
+        "Space select | a select all | Enter jump | e edit | O GUI"
     )
 
 

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -214,30 +214,26 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             (
                 "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit",
                 "Space select | c copy | x cut | v paste | d delete | r rename",
-                "z undo | . hidden | N new-dir | o new-tab | w close-tab",
-                "b bookmarks | H history | G go-to | : palette",
+                "z undo | . hidden | N new-dir | : palette",
             )
         )
     if state.search_workspace is not None:
         return HelpBarState(
             (
-                "Search workspace | ↑↓ move | Space select | a select all | Enter jump | "
-                "e edit | O GUI | R refresh | C copy paths",
+                "Search workspace | Space select | a select all | Enter jump | "
+                "e edit | O GUI",
             )
         )
     if state.config.help_bar.browsing:
         return HelpBarState(state.config.help_bar.browsing)
     split_terminal_hint = " | t term" if is_split_terminal_supported() else ""
-    browsing_shortcuts = (
-        "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
-    )
     return HelpBarState(
         (
-            "enter open | e edit | O gui editor | i info | space select | "
-            "c copy | x cut | v paste | d delete | r rename | z undo",
-            "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
-            browsing_shortcuts,
+            "enter open | e edit | O gui editor | i info | "
+            "/ filter | s sort | . hidden | [ ] preview",
+            "space select | c copy | x cut | v paste | "
+            "d delete | r rename | z undo",
+            f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette | q quit",
         )
     )
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1432,20 +1432,18 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     split_terminal_hint = " | t term" if os.name == "posix" else ""
 
     assert help_state.lines == (
-        "enter open | e edit | O gui editor | i info | space select | "
-        "c copy | x cut | v paste | d delete | r rename | z undo",
-        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
-        (
-            "n new-file | N new-dir | H history | "
-            f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
-        ),
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] preview",
+        "space select | c copy | x cut | v paste | "
+        "d delete | r rename | z undo",
+        f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette | q quit",
     )
     assert help_state.text == (
-        "enter open | e edit | O gui editor | i info | space select | "
-        "c copy | x cut | v paste | d delete | r rename | z undo\n"
-        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
-        "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] preview\n"
+        "space select | c copy | x cut | v paste | "
+        "d delete | r rename | z undo\n"
+        f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette | q quit"
     )
 
 
@@ -1457,14 +1455,12 @@ def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> Non
     assert help_state.lines == (
         "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit",
         "Space select | c copy | x cut | v paste | d delete | r rename",
-        "z undo | . hidden | N new-dir | o new-tab | w close-tab",
-        "b bookmarks | H history | G go-to | : palette",
+        "z undo | . hidden | N new-dir | : palette",
     )
     assert help_state.text == (
         "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit\n"
         "Space select | c copy | x cut | v paste | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | o new-tab | w close-tab\n"
-        "b bookmarks | H history | G go-to | : palette"
+        "z undo | . hidden | N new-dir | : palette"
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2951,11 +2951,11 @@ async def test_app_displays_browsing_help_bar() -> None:
     app = create_app(snapshot_loader=loader, initial_path=path)
     split_terminal_hint = " | t term" if os.name == "posix" else ""
     expected_help = (
-        "enter open | e edit | O gui editor | i info | space select | "
-        "c copy | x cut | v paste | d delete | r rename | z undo\n"
-        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
-        "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] preview\n"
+        "space select | c copy | x cut | v paste | "
+        "d delete | r rename | z undo\n"
+        f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette | q quit"
     )
 
     async with app.run_test():
@@ -3061,8 +3061,7 @@ async def test_app_displays_transfer_help_bar() -> None:
     expected_help = (
         "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit\n"
         "Space select | c copy | x cut | v paste | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | o new-tab | w close-tab\n"
-        "b bookmarks | H history | G go-to | : palette"
+        "z undo | . hidden | N new-dir | : palette"
     )
 
     async with app.run_test() as pilot:


### PR DESCRIPTION
## Summary

ヘルプバーを整理し、肥大化を解消する。

### #869: Search workspace のヘルプバー簡略化
- `↑↓ move` 削除（カーソル操作は自明）
- `R refresh` 削除（メイン画面にない）
- `C copy paths` 削除（メイン画面にない）

### #875: ブラウズモード ヘルプバー整理
- `H history`, `b bookmarks`, `G go-to`, `~ home`, `p transfer` を削除（すべてコマンドパレットからアクセス可能）
- 残った項目を機能別に再配置（Open/Edit/View, File Operations, Search/Create/Modes の3行）

### Transfer mode ヘルプバー
- `b bookmarks`, `H history`, `G go-to`, `o new-tab`, `w close-tab` を削除
- `: palette` を3行目に統合し、3行に整理

### 変更ファイル
| ファイル | 変更 |
|---|---|
| `src/zivo/state/selectors_ui.py` | 3箇所のヘルプバー定義を更新 |
| `src/zivo/state/input_browsing.py` | search workspace の warn メッセージ同期 |
| `tests/state_selectors_cases.py` | browsing/transfer テスト期待値更新 |
| `tests/test_app.py` | 統合テスト期待値更新 |

### テスト結果
- pytest: 1232 passed, 6 skipped
- ruff: all checks passed