### PR TITLE
#889 フィルタ操作の挙動改善

### DIFF
--- a/src/zivo/state/reducer_navigation_browsing.py
+++ b/src/zivo/state/reducer_navigation_browsing.py
@@ -74,17 +74,29 @@ def _handle_confirm_filter_input(
     action: ConfirmFilterInput,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    return finalize(
-        replace(
-            state,
-            ui_mode="BROWSING",
-            current_pane=replace(
-                state.current_pane,
-                selection_anchor_path=None,
-            ),
-            notification=None,
-        )
+    next_state = replace(
+        state,
+        ui_mode="BROWSING",
+        notification=None,
     )
+    visible_entries = select_visible_current_entry_states(next_state)
+    visible_paths = tuple(entry.path for entry in visible_entries)
+    cursor_path = normalize_cursor_path(
+        visible_entries,
+        state.current_pane.cursor_path,
+    )
+    next_state = replace(
+        next_state,
+        current_pane=replace(
+            next_state.current_pane,
+            cursor_path=cursor_path,
+            selection_anchor_path=normalize_selection_anchor_path(
+                state.current_pane.selection_anchor_path,
+                visible_paths,
+            ),
+        ),
+    )
+    return sync_child_pane(next_state, cursor_path, reduce_state)
 
 
 def _handle_cancel_filter_input(

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1407,6 +1407,16 @@ def test_confirm_filter_input_returns_to_browsing() -> None:
 
     assert next_state.ui_mode == "BROWSING"
 
+def test_confirm_filter_input_normalizes_cursor_path() -> None:
+    state = build_initial_app_state()
+    state = _reduce_state(state, SetUiMode("FILTER"))
+    state = _reduce_state(state, SetFilterQuery("src"))
+
+    next_state = _reduce_state(state, ConfirmFilterInput())
+
+    assert next_state.ui_mode == "BROWSING"
+    assert next_state.current_pane.cursor_path == "/home/tadashi/develop/zivo/src"
+
 def test_cancel_filter_input_clears_query() -> None:
     state = build_initial_app_state()
     state = _reduce_state(state, SetUiMode("FILTER"))


### PR DESCRIPTION
## Summary

フィルタ入力後に Enter を押したとき、カーソルが可視エントリの先頭に正規化されず、preview や child directory が表示されない問題を修正しました。

## Changes

- **`src/zivo/state/reducer_navigation_browsing.py`**: `_handle_confirm_filter_input` でフィルタ確定時に `normalize_cursor_path` を使って `cursor_path` を先頭の可視エントリに正規化し、`sync_child_pane` を呼び出して子ペインを更新するように修正
- **`tests/test_state_reducer.py`**: フィルタ確定後のカーソル位置正規化を確認するテストを追加

## Related Issue

Closes #889

## Test Results

```
1203 passed, 6 skipped
ruff check . -> All checks passed!
```
