### PR TITLE
#890 マウス操作の対象を追加 (タブクリック切替・ホバーハイライト)

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -78,6 +78,7 @@ from zivo.state import (
 )
 from zivo.state.actions import (
     Action,
+    ActivateTabByIndex,
     EnterCursorDirectory,
     EnterTransferDirectory,
     ExitCurrentPath,
@@ -101,6 +102,7 @@ from zivo.ui import (
     ShellCommandDialog,
     SidePane,
     StatusBar,
+    TabBar,
 )
 
 
@@ -675,6 +677,11 @@ class zivoApp(App[None]):
 
         await self.dispatch_actions((SetTerminalHeight(height=event.size.height),))
         self._sync_overlay_layout(event.size.width)
+
+    async def on_tab_bar_tab_clicked(self, message: TabBar.TabClicked) -> None:
+        """Handle tab clicks from the TabBar widget."""
+
+        await self.dispatch_actions((ActivateTabByIndex(index=message.tab_index),))
 
     async def on_side_pane_entry_clicked(self, message: SidePane.EntryClicked) -> None:
         """Handle left parent-pane double clicks from the widget message path."""

--- a/src/zivo/app.tcss
+++ b/src/zivo/app.tcss
@@ -90,6 +90,10 @@ Screen {
     color: $text;
 }
 
+#tab-bar:hover {
+    background: $panel;
+}
+
 #help-bar {
     height: auto;
     min-height: 1;

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -62,6 +62,7 @@ class ChildPane(Vertical):
         self._last_render_width = 0
         self._last_render_signature: object | None = None
         self._last_clicked_path: str | None = None
+        self._hovered_path: str | None = None
 
     @property
     def list_view_id(self) -> str | None:
@@ -88,6 +89,7 @@ class ChildPane(Vertical):
                 {},
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             ),
             id=self.list_view_id,
             classes="pane-list",
@@ -137,6 +139,23 @@ class ChildPane(Vertical):
         self._last_clicked_path = path
         event.stop()
         self.post_message(self.EntryClicked(self.id, path, double_click=double_click))
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        if self._state.is_preview:
+            return
+        meta = event.style.meta
+        path = meta.get("entry_path")
+        new_path = str(path) if path is not None else None
+        if new_path != self._hovered_path:
+            self._hovered_path = new_path
+            self._refresh_rendered_content(force=True)
+
+    def on_leave(self, _event: events.Leave) -> None:
+        if self._state.is_preview:
+            return
+        if self._hovered_path is not None:
+            self._hovered_path = None
+            self._refresh_rendered_content(force=True)
 
     async def set_state(self, state: ChildPaneViewState) -> None:
         if state == self._state:
@@ -205,6 +224,7 @@ class ChildPane(Vertical):
                 self._ft_styles,
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             )
         )
         self._last_render_width = render_width

--- a/src/zivo/ui/pane_rendering.py
+++ b/src/zivo/ui/pane_rendering.py
@@ -204,6 +204,7 @@ def _render_file_label(
     *,
     selected_directory_style: str,
     selected_cut_style: str,
+    hovered_path: str | None = None,
 ) -> Text:
     """Render a single file entry label with resolved theme styles."""
 
@@ -217,6 +218,9 @@ def _render_file_label(
         selected_cut_style=selected_cut_style,
     )
     style = _style_without_background(style)
+    if hovered_path is not None and entry.path == hovered_path:
+        base = style or Style()
+        style = Style(reverse=True) + base
     text = Text(label) if style is None else Text(label, style=style)
     if label:
         text.stylize(Style(meta={"entry_path": entry.path}), 0, len(label))
@@ -230,6 +234,7 @@ def _render_file_entries(
     *,
     selected_directory_style: str,
     selected_cut_style: str,
+    hovered_path: str | None = None,
 ) -> Text:
     """Render a sequence of file entries as a single Rich Text block."""
 
@@ -243,6 +248,7 @@ def _render_file_entries(
                 styles,
                 selected_directory_style=selected_directory_style,
                 selected_cut_style=selected_cut_style,
+                hovered_path=hovered_path,
             )
             for entry in entries
         ]

--- a/src/zivo/ui/side_pane.py
+++ b/src/zivo/ui/side_pane.py
@@ -49,6 +49,7 @@ class SidePane(Vertical):
         self._ft_styles: dict[str, Style] = {}
         self._last_render_width = 0
         self._last_clicked_path: str | None = None
+        self._hovered_path: str | None = None
 
     @property
     def list_view_id(self) -> str | None:
@@ -64,6 +65,7 @@ class SidePane(Vertical):
                 {},
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             ),
             id=self.list_view_id,
             classes="pane-list",
@@ -88,6 +90,19 @@ class SidePane(Vertical):
         event.stop()
         self.post_message(self.EntryClicked(self.id, path, double_click=double_click))
 
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        meta = event.style.meta
+        path = meta.get("entry_path")
+        new_path = str(path) if path is not None else None
+        if new_path != self._hovered_path:
+            self._hovered_path = new_path
+            self._refresh_rendered_labels()
+
+    def on_leave(self, _event: events.Leave) -> None:
+        if self._hovered_path is not None:
+            self._hovered_path = None
+            self._refresh_rendered_labels()
+
     async def set_entries(self, entries: Sequence[PaneEntry]) -> None:
         """Replace the rendered entries without remounting the pane."""
 
@@ -104,6 +119,7 @@ class SidePane(Vertical):
                 self._ft_styles,
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             )
         )
         self._entries = next_entries
@@ -124,6 +140,7 @@ class SidePane(Vertical):
                 self._ft_styles,
                 selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
                 selected_cut_style=self.SELECTED_CUT_STYLE,
+                hovered_path=self._hovered_path,
             )
         )
         self._last_render_width = render_width

--- a/src/zivo/ui/side_pane.py
+++ b/src/zivo/ui/side_pane.py
@@ -96,12 +96,12 @@ class SidePane(Vertical):
         new_path = str(path) if path is not None else None
         if new_path != self._hovered_path:
             self._hovered_path = new_path
-            self._refresh_rendered_labels()
+            self._refresh_rendered_labels(force=True)
 
     def on_leave(self, _event: events.Leave) -> None:
         if self._hovered_path is not None:
             self._hovered_path = None
-            self._refresh_rendered_labels()
+            self._refresh_rendered_labels(force=True)
 
     async def set_entries(self, entries: Sequence[PaneEntry]) -> None:
         """Replace the rendered entries without remounting the pane."""
@@ -125,13 +125,13 @@ class SidePane(Vertical):
         self._entries = next_entries
         self._last_render_width = render_width
 
-    def _refresh_rendered_labels(self) -> None:
+    def _refresh_rendered_labels(self, *, force: bool = False) -> None:
         try:
             content = self._content_widget()
         except NoMatches:
             return
         render_width = self._entry_width(content)
-        if render_width <= 0 or render_width == self._last_render_width:
+        if render_width <= 0 or (not force and render_width == self._last_render_width):
             return
         content.update(
             _render_file_entries(

--- a/src/zivo/ui/tab_bar.py
+++ b/src/zivo/ui/tab_bar.py
@@ -1,6 +1,9 @@
 """Tab bar widget shown above the current path bar."""
 
+from rich.style import Style
 from rich.text import Text
+from textual import events
+from textual.message import Message
 from textual.widgets import Static
 
 from zivo.models import TabBarState
@@ -8,6 +11,13 @@ from zivo.models import TabBarState
 
 class TabBar(Static):
     """Compact tab strip for switching between browser workspaces."""
+
+    class TabClicked(Message):
+        """Notify the app that a tab was clicked."""
+
+        def __init__(self, tab_index: int) -> None:
+            super().__init__()
+            self.tab_index = tab_index
 
     def __init__(
         self,
@@ -19,22 +29,53 @@ class TabBar(Static):
         super().__init__(self._render_state(state), id=id, classes=classes)
         self.state = state
         self.display = len(state.tabs) > 1
+        self._hovered_index: int | None = None
 
     def set_state(self, state: TabBarState) -> None:
         """Update the rendered tabs without remounting the widget."""
 
         self.display = len(state.tabs) > 1
+        self._hovered_index = None
         if state == self.state:
             return
         self.state = state
         self.update(self._render_state(state))
 
     @staticmethod
-    def _render_state(state: TabBarState) -> Text:
+    def _render_state(state: TabBarState, hovered_index: int | None = None) -> Text:
         rendered = Text(no_wrap=True, overflow="ellipsis")
         for index, tab in enumerate(state.tabs, start=1):
             if index > 1:
                 rendered.append(" ")
-            style = "reverse bold" if tab.active else "bold"
-            rendered.append(f"[{index}:{tab.label}]", style=style)
+            if tab.active:
+                base_style = Style(reverse=True, bold=True)
+            elif hovered_index == index:
+                base_style = Style(bold=True, underline=True)
+            else:
+                base_style = Style(bold=True)
+            style = Style(meta={"tab_index": index}) + base_style
+            rendered.append(f"[{index}:{tab.label}]", style)
         return rendered
+
+    def on_click(self, event: events.Click) -> None:
+        meta = event.style.meta
+        tab_index = meta.get("tab_index")
+        if tab_index is None:
+            return
+        event.stop()
+        self.post_message(self.TabClicked(tab_index=int(tab_index)))
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        meta = event.style.meta
+        tab_index = meta.get("tab_index")
+        new_hovered = int(tab_index) if tab_index is not None else None
+        if new_hovered != self._hovered_index:
+            self._hovered_index = new_hovered
+            self.update(
+                self._render_state(self.state, hovered_index=self._hovered_index)
+            )
+
+    def on_leave(self, _event: events.Leave) -> None:
+        if self._hovered_index is not None:
+            self._hovered_index = None
+            self.update(self._render_state(self.state))

--- a/src/zivo/ui/tab_bar.py
+++ b/src/zivo/ui/tab_bar.py
@@ -63,7 +63,7 @@ class TabBar(Static):
         if tab_index is None:
             return
         event.stop()
-        self.post_message(self.TabClicked(tab_index=int(tab_index)))
+        self.post_message(self.TabClicked(tab_index=int(tab_index) - 1))
 
     def on_mouse_move(self, event: events.MouseMove) -> None:
         meta = event.style.meta


### PR DESCRIPTION
## Summary

- **タブクリック切替**: タブのクリックで ActivateTabByIndex アクションを発行
- **タブホバーハイライト**: ホバー中のタブに underline スタイル、TabBar 全体に CSS hover 背景色
- **Parent/Child エントリホバー**: SidePane と ChildPane (list モード) のエントリに reverse スタイルでホバー表示

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/zivo/ui/tab_bar.py` | TabClicked メッセージ追加, on_click/on_mouse_move/on_leave, _hovered_index 追跡, _render_state に meta & hovered_index 対応 |
| `src/zivo/ui/pane_rendering.py` | _render_file_label / _render_file_entries に hovered_path パラメータ追加、ホバー時の reverse スタイル適用 |
| `src/zivo/ui/side_pane.py` | on_mouse_move/on_leave, _hovered_path 追跡、レンダリングに hovered_path を伝搬 |
| `src/zivo/ui/child_pane.py` | 同上 (list モードのみ) |
| `src/zivo/app.py` | on_tab_bar_tab_clicked ハンドラ追加、TabBar / ActivateTabByIndex インポート追加 |
| `src/zivo/app.tcss` | #tab-bar:hover 背景色追加 |

## テスト結果

- 1203 passed, 6 skipped
- Ruff lint: all checks passed

## フォローアップ

なし