### PR TITLE
ヘルプバー整理: browsing/transfer から自明項目を削除し再配置 (fix #891)

### DIFF
--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -213,24 +213,19 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
         return HelpBarState(
             (
                 "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit",
-                "Space select | c copy | x cut | v paste | d delete | r rename",
-                "z undo | . hidden | N new-dir | o new-tab | w close-tab",
-                "b bookmarks | H history | G go-to | : palette",
+                "Space select | c copy | x cut | v paste | d delete | r rename | z undo",
+                ". hidden | N new-dir | : palette",
             )
         )
     if state.config.help_bar.browsing:
         return HelpBarState(state.config.help_bar.browsing)
     split_terminal_hint = " | t term" if is_split_terminal_supported() else ""
-    browsing_shortcuts = (
-        "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
-    )
     return HelpBarState(
         (
-            "enter open | e edit | O gui editor | i info | space select | "
-            "c copy | x cut | v paste | d delete | r rename | z undo",
-            "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
-            browsing_shortcuts,
+            "enter open | e edit | O gui editor | i info | "
+            "/ filter | s sort | . hidden | [ ] preview | q quit",
+            "space select | c copy | x cut | v paste | d delete | r rename | z undo",
+            f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette",
         )
     )
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1272,20 +1272,16 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     split_terminal_hint = " | t term" if os.name == "posix" else ""
 
     assert help_state.lines == (
-        "enter open | e edit | O gui editor | i info | space select | "
-        "c copy | x cut | v paste | d delete | r rename | z undo",
-        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview",
-        (
-            "n new-file | N new-dir | H history | "
-            f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
-        ),
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] preview | q quit",
+        "space select | c copy | x cut | v paste | d delete | r rename | z undo",
+        f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette",
     )
     assert help_state.text == (
-        "enter open | e edit | O gui editor | i info | space select | "
-        "c copy | x cut | v paste | d delete | r rename | z undo\n"
-        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
-        "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] preview | q quit\n"
+        "space select | c copy | x cut | v paste | d delete | r rename | z undo\n"
+        f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette"
     )
 
 
@@ -1296,15 +1292,13 @@ def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> Non
 
     assert help_state.lines == (
         "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit",
-        "Space select | c copy | x cut | v paste | d delete | r rename",
-        "z undo | . hidden | N new-dir | o new-tab | w close-tab",
-        "b bookmarks | H history | G go-to | : palette",
+        "Space select | c copy | x cut | v paste | d delete | r rename | z undo",
+        ". hidden | N new-dir | : palette",
     )
     assert help_state.text == (
         "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit\n"
-        "Space select | c copy | x cut | v paste | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | o new-tab | w close-tab\n"
-        "b bookmarks | H history | G go-to | : palette"
+        "Space select | c copy | x cut | v paste | d delete | r rename | z undo\n"
+        ". hidden | N new-dir | : palette"
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2951,11 +2951,10 @@ async def test_app_displays_browsing_help_bar() -> None:
     app = create_app(snapshot_loader=loader, initial_path=path)
     split_terminal_hint = " | t term" if os.name == "posix" else ""
     expected_help = (
-        "enter open | e edit | O gui editor | i info | space select | "
-        "c copy | x cut | v paste | d delete | r rename | z undo\n"
-        "/ filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview\n"
-        "n new-file | N new-dir | H history | "
-        f"b bookmarks{split_terminal_hint} | p transfer | : palette | q quit"
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] preview | q quit\n"
+        "space select | c copy | x cut | v paste | d delete | r rename | z undo\n"
+        f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette"
     )
 
     async with app.run_test():
@@ -3060,9 +3059,8 @@ async def test_app_displays_transfer_help_bar() -> None:
     app = create_app(snapshot_loader=loader, initial_path=path)
     expected_help = (
         "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit\n"
-        "Space select | c copy | x cut | v paste | d delete | r rename\n"
-        "z undo | . hidden | N new-dir | o new-tab | w close-tab\n"
-        "b bookmarks | H history | G go-to | : palette"
+        "Space select | c copy | x cut | v paste | d delete | r rename | z undo\n"
+        ". hidden | N new-dir | : palette"
     )
 
     async with app.run_test() as pilot:


### PR DESCRIPTION
## Summary

- **Browsing モード**: H/b/G/~/p をヘルプバーから削除（コマンドパレットからアクセス可能）。残りを3行に再編（主要操作 / 選択・ファイル操作 / 作成・モード切替）
- **Transfer モード**: o/w/b/H/G を削除し3行に統合。z undo を2行目（選択・ファイル操作行）に移動
- 両モードで q quit を1行目（主要操作行）に統一し、行構成の整合性を確保
- Search workspace はコードベースに存在しないため対象外

### 変更前後の比較

**Browsing:**
```
(旧) enter open | e edit | O gui editor | i info | space select | c copy | x cut | v paste | d delete | r rename | z undo
     / filter | s sort | . hidden | ~ home | f find | g grep | G go-to | [ ] preview
     n new-file | N new-dir | H history | b bookmarks | t term | p transfer | : palette | q quit

(新) enter open | e edit | O gui editor | i info | / filter | s sort | . hidden | [ ] preview | q quit
     space select | c copy | x cut | v paste | d delete | r rename | z undo
     f find | g grep | n new-file | N new-dir | t term | : palette
```

**Transfer:**
```
(旧) [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit
     Space select | c copy | x cut | v paste | d delete | r rename
     z undo | . hidden | N new-dir | o new-tab | w close-tab
     b bookmarks | H history | G go-to | : palette

(新) [ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit
     Space select | c copy | x cut | v paste | d delete | r rename | z undo
     . hidden | N new-dir | : palette
```

### テスト結果
- pytest: 1203 passed, 6 skipped
- ruff: all checks passed

### 変更ファイル
| ファイル | 変更 |
|---|---|
| `src/zivo/state/selectors_ui.py` | browsing/transfer ヘルプバー更新 |
| `tests/state_selectors_cases.py` | テスト期待値更新 |
| `tests/test_app.py` | 統合テスト期待値更新 |
