### PR TITLE
#895 transferモードでマウスクリックでペインフォーカスを切り替え

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -542,6 +542,13 @@ class zivoApp(App[None]):
             double_click=message.double_click,
         )
 
+    async def on_main_pane_pane_clicked(self, message: MainPane.PaneClicked) -> None:
+        """Handle clicks on a transfer pane area (not on a specific row)."""
+
+        pane = "right" if message.pane_id == "transfer-right-pane" else "left"
+        if self._app_state.active_transfer_pane != pane:
+            await self.dispatch_actions((FocusTransferPane(pane),))
+
     async def action_dispatch_bound_key(self, key: str) -> None:
         """Handle priority key bindings through the central dispatcher."""
 

--- a/src/zivo/ui/main_pane.py
+++ b/src/zivo/ui/main_pane.py
@@ -44,6 +44,7 @@ class _MainPaneDataTable(DataTable):
             return
         if row_index < 0 or column_index < 0:
             return
+        event.stop()
         handler = getattr(self.parent, "handle_table_row_clicked", None)
         if handler is None:
             return
@@ -77,6 +78,13 @@ class MainPane(Vertical):
             self.pane_id = pane_id
             self.path = path
             self.double_click = double_click
+
+    class PaneClicked(Message):
+        """Notify the app that a transfer pane was clicked (not on a specific row)."""
+
+        def __init__(self, pane_id: str | None) -> None:
+            super().__init__()
+            self.pane_id = pane_id
 
     def __init__(
         self,
@@ -150,6 +158,16 @@ class MainPane(Vertical):
         if handler is None:
             return
         await handler(self.EntryClicked(self.id, path, double_click=double_click))
+
+    async def on_click(self, event: events.Click) -> None:
+        """In transfer mode, clicking on the pane switches focus to it."""
+
+        if "transfer-pane" not in self.classes:
+            return
+        handler = getattr(self.app, "on_main_pane_pane_clicked", None)
+        if handler is None:
+            return
+        await handler(self.PaneClicked(self.id))
 
     def set_entries(
         self,


### PR DESCRIPTION
## Summary

- transfer モードでペインの行以外の領域（タイトルバーや空スペースなど）をマウスクリックした際にも、クリックされたペインにフォーカスを切り替えられるようにした
- 行クリック時は従来通り _handle_main_pane_click でフォーカス + カーソル移動を処理し、非行クリック時は新設の PaneClicked メッセージ経由で FocusTransferPane のみ dispatch する
- 行クリックと非行クリックの二重処理を防ぐため、_MainPaneDataTable._on_click 内で有効な行を処理した後に event.stop() を追加

## Changes

- `src/zivo/ui/main_pane.py`:
  - `MainPane.PaneClicked` メッセージを追加
  - `MainPane.on_click` 追加 — transfer モード時のみ PaneClicked を post
  - `_MainPaneDataTable._on_click` に行クリック処理後の `event.stop()` を追加
- `src/zivo/app.py`:
  - `on_main_pane_pane_clicked` ハンドラ追加 — FocusTransferPane を dispatch

## Test Results

```
1203 passed, 6 skipped in 73.33s
```

## Follow-up

- なし
