### PR TITLE
#904 findでdirectoryにフォーカスを当てたときにDirectoryの内容を右ペインに表示する

### DIFF
--- a/src/zivo/state/reducer_palette_search.py
+++ b/src/zivo/state/reducer_palette_search.py
@@ -681,18 +681,26 @@ def sync_file_search_preview(state: AppState) -> ReduceResult:
     selected_result = selected_file_search_result(state)
     if selected_result is None:
         return finalize(replace(state, pending_child_pane_request_id=None))
-    if not (
-        state.config.display.enable_text_preview
-        or state.config.display.enable_pdf_preview
-        or state.config.display.enable_office_preview
-    ):
-        return finalize(replace(state, pending_child_pane_request_id=None))
 
-    if state.pending_child_pane_request_id is None and matches_file_search_preview(
-        state,
-        selected_result,
-    ):
-        return finalize(state)
+    if selected_result.entry_type == "directory":
+        if state.pending_child_pane_request_id is None and (
+            state.child_pane.mode == "entries"
+            and state.child_pane.directory_path == selected_result.path
+        ):
+            return finalize(state)
+    else:
+        if not (
+            state.config.display.enable_text_preview
+            or state.config.display.enable_pdf_preview
+            or state.config.display.enable_office_preview
+        ):
+            return finalize(replace(state, pending_child_pane_request_id=None))
+
+        if state.pending_child_pane_request_id is None and matches_file_search_preview(
+            state,
+            selected_result,
+        ):
+            return finalize(state)
 
     request_id = state.next_request_id
     return finalize(

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -260,13 +260,6 @@ def _select_file_search_preview_pane(
     state: AppState,
     syntax_theme: str,
 ) -> ChildPaneViewState:
-    if not (
-        state.config.display.enable_text_preview
-        or state.config.display.enable_pdf_preview
-        or state.config.display.enable_office_preview
-    ):
-        return _build_child_entries_view((), syntax_theme)
-
     results = state.command_palette.file_search_results
     if not results:
         return _build_child_entries_view((), syntax_theme)
@@ -274,6 +267,36 @@ def _select_file_search_preview_pane(
     selected_result = results[
         normalize_command_palette_cursor(state, state.command_palette.cursor_index)
     ]
+
+    if selected_result.entry_type == "directory":
+        if (
+            state.child_pane.mode == "entries"
+            and state.child_pane.directory_path == selected_result.path
+        ):
+            visible_entries = _select_side_pane_entry_states(
+                state.child_pane.entries, state.show_hidden
+            )
+            return _build_child_entries_view(
+                _select_side_pane_entries(
+                    visible_entries,
+                    state.directory_size_cache,
+                    display_directory_sizes=False,
+                    selected_path=None,
+                    cut_paths=_select_visible_cut_paths(
+                        visible_entries, _select_cut_paths(state)
+                    ),
+                ),
+                syntax_theme,
+            )
+        return _build_child_entries_view((), syntax_theme)
+
+    if not (
+        state.config.display.enable_text_preview
+        or state.config.display.enable_pdf_preview
+        or state.config.display.enable_office_preview
+    ):
+        return _build_child_entries_view((), syntax_theme)
+
     if (
         state.child_pane.mode != "preview"
         or state.child_pane.preview_path != selected_result.path


### PR DESCRIPTION
## Summary
- find コマンドパレットの検索結果でディレクトリにフォーカスしたとき、右ペインにディレクトリの中身（ファイル一覧）を表示するよう修正
- 従来はファイルのテキストプレビューのみ対応しており、ディレクトリには何も表示されなかった

## Changes
1. **`src/zivo/state/selectors_panes.py`** - `_select_file_search_preview_pane()`
   - 選択結果が `entry_type == "directory"` の場合の分岐を追加
   - `state.child_pane.mode == "entries"` で子エントリがロード済みなら一覧表示
   - 未ロードなら空エントリビュー（プレースホルダ）

2. **`src/zivo/state/reducer_palette_search.py`** - `sync_file_search_preview()`
   - プレビュー無効設定チェックをディレクトリの場合はバイパス
   - ディレクトリ用のキャッシュヒット判定（`mode == "entries"` + `directory_path`一致）を追加

## Test Results
- 1206 passed, 6 skipped (no regression)
- Ruff lint: all checks passed

## Follow-up
None