### PR TITLE
#901 preview画面の折返し表示切り替えサポート

### DIFF
--- a/src/zivo/models/config.py
+++ b/src/zivo/models/config.py
@@ -57,6 +57,7 @@ class DisplayConfig:
     default_sort_descending: bool = False
     directories_first: bool = True
     grep_preview_context_lines: int = 3
+    preview_word_wrap: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/zivo/models/shell_data.py
+++ b/src/zivo/models/shell_data.py
@@ -106,6 +106,7 @@ class ChildPaneViewState:
     preview_highlight_line: int | None = None
     syntax_theme: str = "monokai"
     permissions_label: str = ""
+    preview_word_wrap: bool = False
 
     @property
     def is_preview(self) -> bool:

--- a/src/zivo/services/config/loader.py
+++ b/src/zivo/services/config/loader.py
@@ -194,6 +194,13 @@ def load_display_config(section: object, warnings: list[str]) -> DisplayConfig:
             warnings=warnings,
             section_name="display",
         ),
+        preview_word_wrap=read_bool(
+            validated,
+            key="preview_word_wrap",
+            default=config.preview_word_wrap,
+            warnings=warnings,
+            section_name="display",
+        ),
     )
     return replace(
         config,

--- a/src/zivo/services/config/render.py
+++ b/src/zivo/services/config/render.py
@@ -95,7 +95,8 @@ def render_display_section(config: AppConfig) -> str:
         f'default_sort_field = "{config.display.default_sort_field}"\n'
         f"default_sort_descending = {render_bool(config.display.default_sort_descending)}\n"
         f"directories_first = {render_bool(config.display.directories_first)}\n"
-        f"grep_preview_context_lines = {config.display.grep_preview_context_lines}"
+        f"grep_preview_context_lines = {config.display.grep_preview_context_lines}\n"
+        f"preview_word_wrap = {render_bool(config.display.preview_word_wrap)}"
     )
 
 

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -228,6 +228,14 @@ def cycle_config_editor_value(config: AppConfig, cursor_index: int, delta: int) 
                 ),
             ),
         )
+    if field_id == "display.preview_word_wrap":
+        return replace(
+            config,
+            display=replace(
+                config.display,
+                preview_word_wrap=not config.display.preview_word_wrap,
+            ),
+        )
     if field_id == "behavior.confirm_delete":
         return replace(
             config,
@@ -329,6 +337,7 @@ def config_editor_field_ids() -> tuple[str, ...]:
         "behavior.paste_conflict_action",
         "logging.level",
         "file_search.max_results",
+        "display.preview_word_wrap",
     )
 
 
@@ -355,6 +364,7 @@ def config_editor_labels() -> tuple[str, ...]:
         "Paste conflict action",
         "Log level",
         "File search max results",
+        "Preview word wrap",
     )
 
 
@@ -481,6 +491,12 @@ def config_editor_field_description(field_index: int, config: AppConfig) -> tupl
             "Increase this to show more context in grep preview results.",
             f"Current behavior: {config.display.grep_preview_context_lines} context lines.",
         )
+    if field_id == "display.preview_word_wrap":
+        return (
+            "Controls whether long lines in the preview pane wrap to fit the available width.",
+            "Current behavior: word wrap is "
+            f"{'enabled' if config.display.preview_word_wrap else 'disabled'} on startup.",
+        )
     if field_id == "behavior.confirm_delete":
         return (
             "Controls whether delete and move-to-trash actions ask for confirmation first.",
@@ -522,7 +538,7 @@ def config_editor_field_description(field_index: int, config: AppConfig) -> tupl
 CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
     ("External", (0, 1)),
     ("Theme", (3, 9)),
-    ("Preview", (5, 6, 7, 8, 10, 15)),
+    ("Preview", (5, 6, 7, 8, 10, 15, 21)),
     ("Display", (2, 4, 11, 16)),
     ("File Search", (20,)),
     ("Sorting", (12, 13, 14)),
@@ -604,6 +620,8 @@ def format_config_field_value(field_index: int, config: AppConfig) -> str:
         return _format_bool(config.display.directories_first)
     if field_id == "display.grep_preview_context_lines":
         return str(config.display.grep_preview_context_lines)
+    if field_id == "display.preview_word_wrap":
+        return _format_bool(config.display.preview_word_wrap)
     if field_id == "behavior.confirm_delete":
         return _format_bool(config.behavior.confirm_delete)
     if field_id == "behavior.confirm_exit":

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -204,6 +204,7 @@ def select_child_pane_for_cursor(
             state.child_pane.preview_highlight_line,
             syntax_theme,
             permissions_label,
+            state.config.display.preview_word_wrap,
         )
     if state.child_pane.mode == "preview" and state.child_pane.preview_message is not None:
         preview_path = state.child_pane.preview_path or cursor_entry.path
@@ -218,6 +219,7 @@ def select_child_pane_for_cursor(
             state.child_pane.preview_highlight_line,
             syntax_theme,
             permissions_label,
+            state.config.display.preview_word_wrap,
         )
 
     visible_entries = _select_side_pane_entry_states(state.child_pane.entries, state.show_hidden)
@@ -316,6 +318,7 @@ def _select_file_search_preview_pane(
         state.child_pane.preview_start_line,
         state.child_pane.preview_highlight_line,
         syntax_theme,
+        preview_word_wrap=state.config.display.preview_word_wrap,
     )
 
 
@@ -350,6 +353,7 @@ def _select_grep_preview_pane(
         state.child_pane.preview_start_line,
         state.child_pane.preview_highlight_line,
         syntax_theme,
+        preview_word_wrap=state.config.display.preview_word_wrap,
     )
 
 
@@ -384,6 +388,7 @@ def _select_sfg_preview_pane(
         state.child_pane.preview_start_line,
         state.child_pane.preview_highlight_line,
         syntax_theme,
+        preview_word_wrap=state.config.display.preview_word_wrap,
     )
 
 
@@ -422,6 +427,7 @@ def _select_replace_preview_pane(
         state.child_pane.preview_start_line,
         state.child_pane.preview_highlight_line,
         syntax_theme,
+        preview_word_wrap=state.config.display.preview_word_wrap,
     )
 
 
@@ -631,6 +637,7 @@ def _build_child_preview_view(
     preview_highlight_line: int | None,
     syntax_theme: str,
     permissions_label: str = "",
+    preview_word_wrap: bool = False,
 ) -> ChildPaneViewState:
     return ChildPaneViewState(
         title=preview_title or _format_child_preview_title(preview_path, preview_truncated),
@@ -644,6 +651,7 @@ def _build_child_preview_view(
         preview_highlight_line=preview_highlight_line,
         syntax_theme=syntax_theme,
         permissions_label=permissions_label,
+        preview_word_wrap=preview_word_wrap,
     )
 
 

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -271,7 +271,7 @@ class ChildPane(Vertical):
             state.preview_content,
             lexer=lexer,
             theme=state.syntax_theme,
-            word_wrap=False,
+            word_wrap=state.preview_word_wrap,
             line_numbers=state.preview_start_line is not None,
             start_line=state.preview_start_line or 1,
             highlight_lines=(


### PR DESCRIPTION
## Summary

- preview画面（右ペイン）でテキストのワードラップ有無を設定画面から切り替え可能にする
- 設定エディタの Preview カテゴリに "Preview word wrap" 項目を追加
- config.toml の `[display]` セクションに `preview_word_wrap` 設定を追加（デフォルト: false）
- false の場合、従来通り折り返さない（既存挙動を維持）

## Changes

| File | Change |
|------|--------|
| `src/zivo/models/config.py` | DisplayConfig に `preview_word_wrap: bool = False` を追加 |
| `src/zivo/models/shell_data.py` | ChildPaneViewState に `preview_word_wrap: bool = False` を追加 |
| `src/zivo/services/config/loader.py` | load_display_config() に read_bool 呼び出しを追加 |
| `src/zivo/services/config/render.py` | render_display_section() に TOML 出力行を追加 |
| `src/zivo/state/reducer_config.py` | field_ids/labels/cycle/format/description/categories に項目を追加 |
| `src/zivo/state/selectors_panes.py` | _build_child_preview_view と全呼び出し元に preview_word_wrap を追加 |
| `src/zivo/ui/child_pane.py` | Syntax(word_wrap=...) を state.preview_word_wrap に変更 |

## Test Results

- ruff check: All checks passed
- pytest: 1206 passed, 6 skipped (全成功)

Closes #901