### PR TITLE
[#910] refactor: extract terminal response filtering from app.py

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -1,6 +1,5 @@
 """Application assembly for zivo."""
 
-import re
 import threading
 import time
 from collections.abc import Sequence
@@ -12,7 +11,6 @@ from textual.app import App, ComposeResult, ScreenStackError
 from textual.binding import Binding
 from textual.containers import Container, Vertical, VerticalScroll
 from textual.css.query import NoMatches
-from textual.keys import Keys
 from textual.timer import Timer
 from textual.worker import Worker
 
@@ -25,6 +23,10 @@ from zivo.app_runtime import (
 from zivo.app_shell import (
     build_body,
     refresh_shell,
+)
+from zivo.app_terminal_response import (
+    _install_textual_terminal_response_filters,
+    _is_terminal_response_final_byte,
 )
 from zivo.models import (
     AppConfig,
@@ -132,15 +134,6 @@ _REPLACE_PREVIEW_SCROLL_SOURCES = frozenset(
         "grep_replace_selected",
     }
 )
-_TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED = False
-_TERMINAL_DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[(?:\?[\d;]*|[\d;]*)c\Z")
-_TERMINAL_WINDOW_RESPONSE_RE = re.compile(r"\x1b\[(?:4|6|8);[\d;]+t\Z")
-_TERMINAL_COLOR_RESPONSE_RE = re.compile(r"\x1b\]1[01];.*(?:\x07|\x1b\\)\Z", re.DOTALL)
-_ESCAPE = "\x1b"
-_OSC_INTRODUCER = "]"
-_OSC_TERMINATOR = "\\"
-_OSC_BEL = "\x07"
-
 
 def _preview_scroll_delta(state: AppState, key: str) -> int | None:
     """Return scroll delta for preview key bindings, or None if not applicable."""
@@ -877,105 +870,4 @@ def _initial_sort_state(config: AppConfig) -> SortState:
     )
 
 
-def _is_terminal_response_final_byte(key: str) -> bool:
-    if len(key) != 1:
-        return False
-    codepoint = ord(key)
-    return 0x40 <= codepoint <= 0x7E
 
-
-def _install_textual_terminal_response_filters() -> None:
-    global _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED
-    if _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED:
-        return
-
-    import textual._xterm_parser as xterm_parser
-
-    original_feed = xterm_parser.XTermParser.feed
-    original = xterm_parser.XTermParser._sequence_to_key_events
-
-    def _filter_terminal_response_chunk(self, data: str) -> str:
-        pending_escape = getattr(self, "_zivo_pending_escape", False)
-        in_osc = getattr(self, "_zivo_in_osc", False)
-        osc_saw_escape = getattr(self, "_zivo_osc_saw_escape", False)
-
-        if not data:
-            if pending_escape and not in_osc:
-                data = _ESCAPE
-            else:
-                data = ""
-            pending_escape = False
-            in_osc = False
-            osc_saw_escape = False
-            self._zivo_pending_escape = pending_escape
-            self._zivo_in_osc = in_osc
-            self._zivo_osc_saw_escape = osc_saw_escape
-            return data
-
-        filtered: list[str] = []
-        index = 0
-
-        if pending_escape:
-            pending_escape = False
-            if data.startswith(_OSC_INTRODUCER):
-                in_osc = True
-                index = 1
-            else:
-                filtered.append(_ESCAPE)
-
-        while index < len(data):
-            character = data[index]
-            if in_osc:
-                if osc_saw_escape:
-                    osc_saw_escape = False
-                    if character == _OSC_TERMINATOR:
-                        in_osc = False
-                    index += 1
-                    continue
-                if character == _OSC_BEL:
-                    in_osc = False
-                    index += 1
-                    continue
-                if character == _ESCAPE:
-                    osc_saw_escape = True
-                index += 1
-                continue
-
-            if character == _ESCAPE:
-                next_index = index + 1
-                if next_index >= len(data):
-                    pending_escape = True
-                    index += 1
-                    continue
-                if data[next_index] == _OSC_INTRODUCER:
-                    in_osc = True
-                    index += 2
-                    continue
-
-            filtered.append(character)
-            index += 1
-
-        self._zivo_pending_escape = pending_escape
-        self._zivo_in_osc = in_osc
-        self._zivo_osc_saw_escape = osc_saw_escape
-        return "".join(filtered)
-
-    def _wrapped_feed(self, data: str):
-        filtered = _filter_terminal_response_chunk(self, data)
-        if data and not filtered:
-            return ()
-        return original_feed(self, filtered)
-
-    def _wrapped(self, sequence: str):
-        if (
-            _TERMINAL_DEVICE_ATTRIBUTES_RESPONSE_RE.fullmatch(sequence)
-            or _TERMINAL_WINDOW_RESPONSE_RE.fullmatch(sequence)
-            or _TERMINAL_COLOR_RESPONSE_RE.fullmatch(sequence)
-        ):
-            yield events.Key(Keys.Ignore, sequence)
-            return
-        yield from original(self, sequence)
-
-    xterm_parser.XTermParser.feed = _wrapped_feed
-    xterm_parser.XTermParser._sequence_to_key_events = _wrapped
-    _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED = True

--- a/src/zivo/app_terminal_response.py
+++ b/src/zivo/app_terminal_response.py
@@ -1,0 +1,119 @@
+"""XTerm parser monkey-patching to filter terminal response sequences."""
+
+import re
+
+from textual import events
+from textual.keys import Keys
+
+_TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED = False
+_TERMINAL_DEVICE_ATTRIBUTES_RESPONSE_RE = re.compile(r"\x1b\[(?:\?[\d;]*|[\d;]*)c\Z")
+_TERMINAL_WINDOW_RESPONSE_RE = re.compile(r"\x1b\[(?:4|6|8);[\d;]+t\Z")
+_TERMINAL_COLOR_RESPONSE_RE = re.compile(r"\x1b\]1[01];.*(?:\x07|\x1b\\)\Z", re.DOTALL)
+_ESCAPE = "\x1b"
+_OSC_INTRODUCER = "]"
+_OSC_TERMINATOR = "\\"
+_OSC_BEL = "\x07"
+
+
+def _is_terminal_response_final_byte(key: str) -> bool:
+    if len(key) != 1:
+        return False
+    codepoint = ord(key)
+    return 0x40 <= codepoint <= 0x7E
+
+
+def _install_textual_terminal_response_filters() -> None:
+    global _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED
+    if _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED:
+        return
+
+    import textual._xterm_parser as xterm_parser
+
+    original_feed = xterm_parser.XTermParser.feed
+    original = xterm_parser.XTermParser._sequence_to_key_events
+
+    def _filter_terminal_response_chunk(self, data: str) -> str:
+        pending_escape = getattr(self, "_zivo_pending_escape", False)
+        in_osc = getattr(self, "_zivo_in_osc", False)
+        osc_saw_escape = getattr(self, "_zivo_osc_saw_escape", False)
+
+        if not data:
+            if pending_escape and not in_osc:
+                data = _ESCAPE
+            else:
+                data = ""
+            pending_escape = False
+            in_osc = False
+            osc_saw_escape = False
+            self._zivo_pending_escape = pending_escape
+            self._zivo_in_osc = in_osc
+            self._zivo_osc_saw_escape = osc_saw_escape
+            return data
+
+        filtered: list[str] = []
+        index = 0
+
+        if pending_escape:
+            pending_escape = False
+            if data.startswith(_OSC_INTRODUCER):
+                in_osc = True
+                index = 1
+            else:
+                filtered.append(_ESCAPE)
+
+        while index < len(data):
+            character = data[index]
+            if in_osc:
+                if osc_saw_escape:
+                    osc_saw_escape = False
+                    if character == _OSC_TERMINATOR:
+                        in_osc = False
+                    index += 1
+                    continue
+                if character == _OSC_BEL:
+                    in_osc = False
+                    index += 1
+                    continue
+                if character == _ESCAPE:
+                    osc_saw_escape = True
+                index += 1
+                continue
+
+            if character == _ESCAPE:
+                next_index = index + 1
+                if next_index >= len(data):
+                    pending_escape = True
+                    index += 1
+                    continue
+                if data[next_index] == _OSC_INTRODUCER:
+                    in_osc = True
+                    index += 2
+                    continue
+
+            filtered.append(character)
+            index += 1
+
+        self._zivo_pending_escape = pending_escape
+        self._zivo_in_osc = in_osc
+        self._zivo_osc_saw_escape = osc_saw_escape
+        return "".join(filtered)
+
+    def _wrapped_feed(self, data: str):
+        filtered = _filter_terminal_response_chunk(self, data)
+        if data and not filtered:
+            return ()
+        return original_feed(self, filtered)
+
+    def _wrapped(self, sequence: str):
+        if (
+            _TERMINAL_DEVICE_ATTRIBUTES_RESPONSE_RE.fullmatch(sequence)
+            or _TERMINAL_WINDOW_RESPONSE_RE.fullmatch(sequence)
+            or _TERMINAL_COLOR_RESPONSE_RE.fullmatch(sequence)
+        ):
+            yield events.Key(Keys.Ignore, sequence)
+            return
+        yield from original(self, sequence)
+
+    xterm_parser.XTermParser.feed = _wrapped_feed
+    xterm_parser.XTermParser._sequence_to_key_events = _wrapped
+    _TEXTUAL_TERMINAL_RESPONSE_FILTERS_INSTALLED = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1151,7 +1151,7 @@ async def test_app_ignores_terminal_response_sequences_in_browsing_mode() -> Non
 async def test_textual_parser_ignores_terminal_device_attributes_response() -> None:
     from textual._xterm_parser import XTermParser
 
-    from zivo.app import _install_textual_terminal_response_filters
+    from zivo.app_terminal_response import _install_textual_terminal_response_filters
 
     _install_textual_terminal_response_filters()
     parser = XTermParser()
@@ -1165,7 +1165,7 @@ async def test_textual_parser_ignores_terminal_device_attributes_response() -> N
 async def test_textual_parser_ignores_terminal_osc_color_response() -> None:
     from textual._xterm_parser import XTermParser
 
-    from zivo.app import _install_textual_terminal_response_filters
+    from zivo.app_terminal_response import _install_textual_terminal_response_filters
 
     _install_textual_terminal_response_filters()
     parser = XTermParser()
@@ -1180,7 +1180,7 @@ async def test_textual_parser_ignores_terminal_osc_color_response() -> None:
 async def test_textual_parser_ignores_split_terminal_osc_color_response() -> None:
     from textual._xterm_parser import XTermParser
 
-    from zivo.app import _install_textual_terminal_response_filters
+    from zivo.app_terminal_response import _install_textual_terminal_response_filters
 
     _install_textual_terminal_response_filters()
     parser = XTermParser()

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "zivo"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "send2trash" },


### PR DESCRIPTION
Extract XTerm parser monkey-patching logic from `src/zivo/app.py` into a dedicated module `src/zivo/app_terminal_response.py`.

**Changes:**
- `src/zivo/app_terminal_response.py` — **New** (private API, _prefixed)
- `src/zivo/app.py` — Removed ~100 lines, added import
- `tests/test_app.py` — Updated import path (3 occurrences)

**Verification:** ruff check passed, pytest 1206 passed/6 skipped (baseline identical).

Refers to #855.