### PR TITLE
[#911] refactor: extract overlay geometry logic from app.py

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -15,6 +15,7 @@ from textual.timer import Timer
 from textual.worker import Worker
 
 from zivo.adapters import LocalExternalLaunchAdapter
+from zivo.app_overlay_layout import sync_overlay_layout
 from zivo.app_runtime import (
     handle_worker_state_changed,
     schedule_effects,
@@ -287,139 +288,6 @@ class zivoApp(App[None]):
         yield HelpBar(shell.help, id="help-bar")
         yield StatusBar(shell.status, id="status-bar")
 
-    _PANE_VISIBILITY_NARROW_THRESHOLD = 66
-    _PANE_VISIBILITY_MEDIUM_THRESHOLD = 100
-
-    def _update_pane_visibility(self, width: int) -> None:
-        """Show or hide side panes based on terminal width."""
-        try:
-            parent_pane = self.query_one("#parent-pane")
-            child_pane = self.query_one("#child-pane")
-        except NoMatches:
-            return
-
-        if self._app_state.layout_mode == "transfer":
-            parent_pane.display = False
-            child_pane.display = False
-            return
-
-        if width >= self._PANE_VISIBILITY_MEDIUM_THRESHOLD:
-            parent_pane.display = True
-        elif width >= self._PANE_VISIBILITY_NARROW_THRESHOLD:
-            parent_pane.display = False
-        else:
-            parent_pane.display = False
-
-        if width >= self._PANE_VISIBILITY_NARROW_THRESHOLD:
-            child_pane.display = True
-        else:
-            child_pane.display = False
-
-    def _get_target_overlay_pane(self) -> MainPane | None:
-        """
-        Get the target pane for overlay positioning based on current mode.
-
-        In transfer mode, overlays the opposite pane to keep the active pane visible.
-        In browser mode, overlays the current pane.
-
-        Returns:
-            MainPane instance if found, None otherwise
-        """
-        # Transfer mode with active left pane -> overlay on right pane
-        if (
-            self._app_state.layout_mode == "transfer"
-            and self._app_state.active_transfer_pane == "left"
-        ):
-            try:
-                return self.query_one("#transfer-right-pane", MainPane)
-            except NoMatches:
-                # Fallback to current pane if right pane doesn't exist
-                pass
-
-        # Default: current pane (browser mode or transfer mode with active right pane)
-        try:
-            return self.query_one("#current-pane", MainPane)
-        except NoMatches:
-            return None
-
-    def _update_command_palette_geometry(self) -> None:
-        """Constrain the command palette overlay to the appropriate pane."""
-
-        try:
-            command_palette_layer = self.query_one("#command-palette-layer", Container)
-            browser_row = self.query_one("#browser-row")
-        except NoMatches:
-            return
-
-        # Determine target pane based on mode and active pane
-        target_pane = self._get_target_overlay_pane()
-        if target_pane is None:
-            return
-
-        pane_region = target_pane.region
-        row_region = browser_row.region
-        if pane_region.width <= 0 or pane_region.height <= 0:
-            return
-
-        command_palette_layer.styles.width = pane_region.width
-        command_palette_layer.styles.height = pane_region.height
-        command_palette_layer.styles.offset = (
-            pane_region.x,
-            row_region.y,
-        )
-
-    def _update_config_dialog_geometry(self) -> None:
-        """Constrain the config dialog overlay to the appropriate pane."""
-
-        try:
-            config_dialog_layer = self.query_one("#config-dialog-layer", Container)
-            browser_row = self.query_one("#browser-row")
-        except NoMatches:
-            return
-
-        # Determine target pane based on mode and active pane
-        target_pane = self._get_target_overlay_pane()
-        if target_pane is None:
-            return
-
-        pane_region = target_pane.region
-        row_region = browser_row.region
-        if pane_region.width <= 0 or pane_region.height <= 0:
-            return
-
-        config_dialog_layer.styles.width = pane_region.width
-        config_dialog_layer.styles.height = pane_region.height
-        config_dialog_layer.styles.offset = (
-            pane_region.x,
-            row_region.y,
-        )
-
-    def _update_input_dialog_geometry(self) -> None:
-        """Constrain the input dialog overlay to the appropriate pane."""
-
-        try:
-            input_dialog_layer = self.query_one("#input-dialog-layer", Container)
-            browser_row = self.query_one("#browser-row")
-        except NoMatches:
-            return
-
-        # Determine target pane based on mode and active pane
-        target_pane = self._get_target_overlay_pane()
-        if target_pane is None:
-            return
-
-        pane_region = target_pane.region
-        row_region = browser_row.region
-        if pane_region.width <= 0 or pane_region.height <= 0:
-            return
-
-        input_dialog_layer.styles.width = pane_region.width
-        input_dialog_layer.styles.height = pane_region.height
-        input_dialog_layer.styles.offset = (
-            pane_region.x,
-            row_region.y,
-        )
-
     async def on_mount(self) -> None:
         """Load the initial directory snapshot after the UI mounts."""
 
@@ -427,7 +295,7 @@ class zivoApp(App[None]):
             SetTerminalHeight(height=self.size.height),
             RequestBrowserSnapshot(self._initial_path, blocking=True),
         ))
-        self.call_after_refresh(self._sync_overlay_layout)
+        self.call_after_refresh(lambda: sync_overlay_layout(self))
 
     async def on_key(self, event: events.Key) -> None:
         """Normalize keyboard input into reducer actions."""
@@ -676,7 +544,7 @@ class zivoApp(App[None]):
         """Update the terminal height on resize."""
 
         await self.dispatch_actions((SetTerminalHeight(height=event.size.height),))
-        self._sync_overlay_layout(event.size.width)
+        sync_overlay_layout(self, event.size.width)
 
     async def on_tab_bar_tab_clicked(self, message: TabBar.TabClicked) -> None:
         """Handle tab clicks from the TabBar widget."""
@@ -723,17 +591,9 @@ class zivoApp(App[None]):
                 select_shell_data(self._app_state),
                 theme_changed=theme_changed,
             )
-            self.call_after_refresh(self._sync_overlay_layout)
+            self.call_after_refresh(lambda: sync_overlay_layout(self))
         except ScreenStackError:
             return
-
-    def _sync_overlay_layout(self, width: int | None = None) -> None:
-        """Refresh side-pane visibility and overlay geometry together."""
-
-        self._update_pane_visibility(self.size.width if width is None else width)
-        self._update_command_palette_geometry()
-        self._update_config_dialog_geometry()
-        self._update_input_dialog_geometry()
 
     async def _handle_main_pane_click(
         self,

--- a/src/zivo/app_overlay_layout.py
+++ b/src/zivo/app_overlay_layout.py
@@ -1,0 +1,137 @@
+"""Overlay geometry and pane visibility helpers."""
+
+from typing import Any
+
+from textual.containers import Container
+from textual.css.query import NoMatches
+
+from zivo.ui import MainPane
+
+_PANE_VISIBILITY_NARROW_THRESHOLD = 66
+_PANE_VISIBILITY_MEDIUM_THRESHOLD = 100
+
+
+def update_pane_visibility(app: Any, width: int) -> None:
+    """Show or hide side panes based on terminal width."""
+    try:
+        parent_pane = app.query_one("#parent-pane")
+        child_pane = app.query_one("#child-pane")
+    except NoMatches:
+        return
+
+    if app._app_state.layout_mode == "transfer":
+        parent_pane.display = False
+        child_pane.display = False
+        return
+
+    if width >= _PANE_VISIBILITY_MEDIUM_THRESHOLD:
+        parent_pane.display = True
+    elif width >= _PANE_VISIBILITY_NARROW_THRESHOLD:
+        parent_pane.display = False
+    else:
+        parent_pane.display = False
+
+    if width >= _PANE_VISIBILITY_NARROW_THRESHOLD:
+        child_pane.display = True
+    else:
+        child_pane.display = False
+
+
+def get_target_overlay_pane(app: Any) -> MainPane | None:
+    """Get the target pane for overlay positioning based on current mode."""
+    if (
+        app._app_state.layout_mode == "transfer"
+        and app._app_state.active_transfer_pane == "left"
+    ):
+        try:
+            return app.query_one("#transfer-right-pane", MainPane)
+        except NoMatches:
+            pass
+
+    try:
+        return app.query_one("#current-pane", MainPane)
+    except NoMatches:
+        return None
+
+
+def update_command_palette_geometry(app: Any) -> None:
+    """Constrain the command palette overlay to the appropriate pane."""
+    try:
+        command_palette_layer = app.query_one("#command-palette-layer", Container)
+        browser_row = app.query_one("#browser-row")
+    except NoMatches:
+        return
+
+    target_pane = get_target_overlay_pane(app)
+    if target_pane is None:
+        return
+
+    pane_region = target_pane.region
+    row_region = browser_row.region
+    if pane_region.width <= 0 or pane_region.height <= 0:
+        return
+
+    command_palette_layer.styles.width = pane_region.width
+    command_palette_layer.styles.height = pane_region.height
+    command_palette_layer.styles.offset = (
+        pane_region.x,
+        row_region.y,
+    )
+
+
+def update_config_dialog_geometry(app: Any) -> None:
+    """Constrain the config dialog overlay to the appropriate pane."""
+    try:
+        config_dialog_layer = app.query_one("#config-dialog-layer", Container)
+        browser_row = app.query_one("#browser-row")
+    except NoMatches:
+        return
+
+    target_pane = get_target_overlay_pane(app)
+    if target_pane is None:
+        return
+
+    pane_region = target_pane.region
+    row_region = browser_row.region
+    if pane_region.width <= 0 or pane_region.height <= 0:
+        return
+
+    config_dialog_layer.styles.width = pane_region.width
+    config_dialog_layer.styles.height = pane_region.height
+    config_dialog_layer.styles.offset = (
+        pane_region.x,
+        row_region.y,
+    )
+
+
+def update_input_dialog_geometry(app: Any) -> None:
+    """Constrain the input dialog overlay to the appropriate pane."""
+    try:
+        input_dialog_layer = app.query_one("#input-dialog-layer", Container)
+        browser_row = app.query_one("#browser-row")
+    except NoMatches:
+        return
+
+    target_pane = get_target_overlay_pane(app)
+    if target_pane is None:
+        return
+
+    pane_region = target_pane.region
+    row_region = browser_row.region
+    if pane_region.width <= 0 or pane_region.height <= 0:
+        return
+
+    input_dialog_layer.styles.width = pane_region.width
+    input_dialog_layer.styles.height = pane_region.height
+    input_dialog_layer.styles.offset = (
+        pane_region.x,
+        row_region.y,
+    )
+
+
+def sync_overlay_layout(app: Any, width: int | None = None) -> None:
+    """Refresh side-pane visibility and overlay geometry together."""
+    update_pane_visibility(app, app.size.width if width is None else width)
+    update_command_palette_geometry(app)
+    update_config_dialog_geometry(app)
+    update_input_dialog_geometry(app)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ from textual.widgets import DataTable, Label, Static
 
 from zivo import create_app
 from zivo.app import _preview_scroll_delta
+from zivo.app_overlay_layout import update_pane_visibility
 from zivo.models import (
     AppConfig,
     BehaviorConfig,
@@ -6176,15 +6177,15 @@ async def test_app_toggles_pane_visibility_on_resize() -> None:
         assert parent.display
         assert child.display
 
-        app._update_pane_visibility(60)
+        update_pane_visibility(app, 60)
         assert not parent.display
         assert not child.display
 
-        app._update_pane_visibility(80)
+        update_pane_visibility(app, 80)
         assert not parent.display
         assert child.display
 
-        app._update_pane_visibility(120)
+        update_pane_visibility(app, 120)
         assert parent.display
         assert child.display
 


### PR DESCRIPTION
Extract pane visibility and overlay positioning methods from `src/zivo/app.py` into a dedicated module `src/zivo/app_overlay_layout.py`.

**Changes:**
- `src/zivo/app_overlay_layout.py` — **New** (6 functions: `update_pane_visibility`, `get_target_overlay_pane`, `update_command_palette_geometry`, `update_config_dialog_geometry`, `update_input_dialog_geometry`, `sync_overlay_layout`)
- `src/zivo/app.py` — Removed ~134 lines (2 class constants + 6 methods), added import, updated 3 callers
- `tests/test_app.py` — Updated 3 calls to `update_pane_visibility(app, width)`

**Verification:** ruff check passed, pytest 1206 passed/6 skipped (baseline identical).

Refers to #855.