### PR TITLE
Fix terminal editor integration (fix #916)

### DIFF
--- a/src/zivo/app_runtime_execution.py
+++ b/src/zivo/app_runtime_execution.py
@@ -473,6 +473,9 @@ def report_zip_compress_progress(
 
 
 def schedule_external_launch_effect(app: Any, effect: RunExternalLaunchEffect) -> None:
+    if effect.request.kind == "open_editor":
+        app.call_next(run_foreground_external_launch, app, effect)
+        return
     if (
         effect.request.kind == "open_terminal"
         and effect.request.terminal_launch_mode == "foreground"


### PR DESCRIPTION
## Summary
- Fix terminal editor integration broken after exit confirmation refactoring
- `open_editor` requests were falling through to `schedule_external_launch` (worker thread, no `app.suspend()`), causing TUI/editor terminal contention
- Restored the `open_editor` foreground branch in `schedule_external_launch_effect` so editor launches via `app.suspend()`

## Changes
- `src/zivo/app_runtime_execution.py`: Added explicit `open_editor` → `run_foreground_external_launch` dispatch in `schedule_external_launch_effect`

## Test Results
- All 1206 tests passed, 6 skipped
- Lint passed