### PR TITLE
[refactor] Extract GrfPaletteState from CommandPaletteState (ref #925)

### DIFF
--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -118,7 +118,7 @@ def get_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, ...]
                 enabled=True,
                 path=result.path,
             )
-            for index, result in enumerate(state.command_palette.grf_preview_results)
+            for index, result in enumerate(state.command_palette.grf.preview_results)
         )
 
     if state.command_palette.source == "grep_replace_selected":
@@ -161,7 +161,7 @@ def normalize_command_palette_cursor(state: AppState, cursor_index: int) -> int:
     elif state.command_palette.source == "replace_in_found_files":
         item_count = len(state.command_palette.rff.preview_results)
     elif state.command_palette.source == "replace_in_grep_files":
-        item_count = len(state.command_palette.grf_preview_results)
+        item_count = len(state.command_palette.grf.preview_results)
     elif state.command_palette.source == "grep_replace_selected":
         item_count = len(state.command_palette.grs.preview_results)
     elif state.command_palette.source == "history":

--- a/src/zivo/state/input_palette.py
+++ b/src/zivo/state/input_palette.py
@@ -76,16 +76,16 @@ def active_find_replace_field_value(state: AppState) -> str:
 def active_grep_replace_field_value(state: AppState) -> str:
     if state.command_palette is None:
         return ""
-    field = state.command_palette.grf_active_field
+    field = state.command_palette.grf.active_field
     if field == "keyword":
-        return state.command_palette.grf_keyword or state.command_palette.query
+        return state.command_palette.grf.keyword or state.command_palette.query
     if field == "replace":
-        return state.command_palette.grf_replacement_text
+        return state.command_palette.grf.replacement_text
     if field == "filename":
-        return state.command_palette.grf_filename_filter
+        return state.command_palette.grf.filename_filter
     if field == "include":
-        return state.command_palette.grf_include_extensions
-    return state.command_palette.grf_exclude_extensions
+        return state.command_palette.grf.include_extensions
+    return state.command_palette.grf.exclude_extensions
 
 
 def active_grep_replace_selected_field_value(state: AppState) -> str:
@@ -266,7 +266,7 @@ def dispatch_command_palette_input(
         if palette_source == "replace_in_grep_files":
             return supported(
                 SetGrepReplaceField(
-                    field=state.command_palette.grf_active_field,
+                    field=state.command_palette.grf.active_field,
                     value=active_grep_replace_field_value(state)[:-1],
                 )
             )
@@ -332,7 +332,7 @@ def dispatch_command_palette_input(
                 )
             )
         if palette_source == "replace_in_grep_files":
-            active_field_grf: GrepReplaceFieldId = state.command_palette.grf_active_field
+            active_field_grf: GrepReplaceFieldId = state.command_palette.grf.active_field
             return supported(
                 SetGrepReplaceField(
                     field=active_field_grf,

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -485,6 +485,22 @@ class GrsPaletteState:
 
 
 @dataclass(frozen=True)
+class GrfPaletteState:
+    keyword: str = ""
+    include_extensions: str = ""
+    exclude_extensions: str = ""
+    active_field: GrepReplaceFieldId = "keyword"
+    grep_results: tuple[GrepSearchResultState, ...] = ()
+    grep_error_message: str | None = None
+    filename_filter: str = ""
+    replacement_text: str = ""
+    preview_results: tuple[ReplacePreviewResultState, ...] = ()
+    error_message: str | None = None
+    status_message: str | None = None
+    total_match_count: int = 0
+
+
+@dataclass(frozen=True)
 class CommandPaletteState:
     """Transient palette search and cursor state."""
 
@@ -501,18 +517,7 @@ class CommandPaletteState:
     )
     rff: RffPaletteState = field(default_factory=RffPaletteState)
     grs: GrsPaletteState = field(default_factory=GrsPaletteState)
-    grf_keyword: str = ""
-    grf_include_extensions: str = ""
-    grf_exclude_extensions: str = ""
-    grf_active_field: GrepReplaceFieldId = "keyword"
-    grf_grep_results: tuple[GrepSearchResultState, ...] = ()
-    grf_grep_error_message: str | None = None
-    grf_filename_filter: str = ""
-    grf_replacement_text: str = ""
-    grf_preview_results: tuple[ReplacePreviewResultState, ...] = ()
-    grf_error_message: str | None = None
-    grf_status_message: str | None = None
-    grf_total_match_count: int = 0
+    grf: GrfPaletteState = field(default_factory=GrfPaletteState)
     sfg: SfgPaletteState = field(default_factory=SfgPaletteState)
 
 

--- a/src/zivo/state/reducer_palette_replace.py
+++ b/src/zivo/state/reducer_palette_replace.py
@@ -260,14 +260,17 @@ def handle_cycle_grep_replace_field(
 ) -> ReduceResult:
     if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
         return finalize(state)
-    current_index = GREP_REPLACE_FIELDS.index(state.command_palette.grf_active_field)
+    current_index = GREP_REPLACE_FIELDS.index(state.command_palette.grf.active_field)
     next_index = (current_index + action.delta) % len(GREP_REPLACE_FIELDS)
     return finalize(
         replace(
             state,
             command_palette=replace(
                 state.command_palette,
-                grf_active_field=GREP_REPLACE_FIELDS[next_index],
+                grf=replace(
+                    state.command_palette.grf,
+                    active_field=GREP_REPLACE_FIELDS[next_index],
+                ),
             ),
         )
     )
@@ -307,11 +310,11 @@ def handle_set_grep_replace_field(state: AppState, field, value: str) -> ReduceR
 
 def validate_grf_filters(palette) -> tuple[tuple[str, ...], tuple[str, ...]]:
     include_globs = normalize_grep_extension_filters(
-        palette.grf_include_extensions,
+        palette.grf.include_extensions,
         label="include",
     )
     exclude_globs = normalize_grep_extension_filters(
-        palette.grf_exclude_extensions,
+        palette.grf.exclude_extensions,
         label="exclude",
     )
     conflicts = tuple(sorted(set(include_globs) & set(exclude_globs)))
@@ -325,18 +328,25 @@ def validate_grf_filters(palette) -> tuple[tuple[str, ...], tuple[str, ...]]:
 
 def handle_set_grf_keyword(state: AppState, field, value: str) -> ReduceResult:
     next_palette = replace_grf_field(state.command_palette, field=field, value=value)
-    next_palette = replace(next_palette, grf_grep_error_message=None, cursor_index=0)
-    keyword = next_palette.grf_keyword.strip()
+    next_palette = replace(
+        next_palette,
+        grf=replace(next_palette.grf, grep_error_message=None),
+        cursor_index=0,
+    )
+    keyword = next_palette.grf.keyword.strip()
     if not keyword:
         return sync_grep_replace_preview(
             replace(
                 state,
                 command_palette=replace(
                     next_palette,
-                    grf_grep_results=(),
-                    grf_grep_error_message=None,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
+                    grf=replace(
+                        next_palette.grf,
+                        grep_results=(),
+                        grep_error_message=None,
+                        preview_results=(),
+                        total_match_count=0,
+                    ),
                 ),
                 pending_grep_search_request_id=None,
             )
@@ -349,10 +359,13 @@ def handle_set_grf_keyword(state: AppState, field, value: str) -> ReduceResult:
                 state,
                 command_palette=replace(
                     next_palette,
-                    grf_grep_results=(),
-                    grf_grep_error_message=str(error),
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
+                    grf=replace(
+                        next_palette.grf,
+                        grep_results=(),
+                        grep_error_message=str(error),
+                        preview_results=(),
+                        total_match_count=0,
+                    ),
                 ),
                 pending_grep_search_request_id=None,
             )
@@ -380,9 +393,12 @@ def handle_set_grf_keyword(state: AppState, field, value: str) -> ReduceResult:
 def handle_set_grf_replace(state: AppState, value: str) -> ReduceResult:
     next_palette = replace(
         state.command_palette,
-        grf_replacement_text=value,
-        grf_error_message=None,
-        grf_status_message=None,
+        grf=replace(
+            state.command_palette.grf,
+            replacement_text=value,
+            error_message=None,
+            status_message=None,
+        ),
         cursor_index=0,
     )
     return trigger_grf_preview(state, next_palette)
@@ -394,11 +410,14 @@ def handle_set_grf_filename(state: AppState, value: str) -> ReduceResult:
     if validation_error:
         next_palette = replace(
             state.command_palette,
-            grf_filename_filter=value,
-            grf_error_message=validation_error,
-            grf_status_message=None,
-            grf_preview_results=(),
-            grf_total_match_count=0,
+            grf=replace(
+                state.command_palette.grf,
+                filename_filter=value,
+                error_message=validation_error,
+                status_message=None,
+                preview_results=(),
+                total_match_count=0,
+            ),
             cursor_index=0,
         )
         return sync_grep_replace_preview(
@@ -412,9 +431,12 @@ def handle_set_grf_filename(state: AppState, value: str) -> ReduceResult:
 
     next_palette = replace(
         state.command_palette,
-        grf_filename_filter=value,
-        grf_error_message=None,
-        grf_status_message=None,
+        grf=replace(
+            state.command_palette.grf,
+            filename_filter=value,
+            error_message=None,
+            status_message=None,
+        ),
         cursor_index=0,
     )
     return trigger_grf_preview(state, next_palette)
@@ -425,10 +447,10 @@ def grf_unique_file_paths(grep_results: tuple[GrepSearchResultState, ...]) -> tu
 
 
 def trigger_grf_preview(state: AppState, next_palette) -> ReduceResult:
-    keyword = next_palette.grf_keyword.strip()
+    keyword = next_palette.grf.keyword.strip()
     filtered_results = filter_grep_results_by_filename(
-        next_palette.grf_grep_results,
-        next_palette.grf_filename_filter,
+        next_palette.grf.grep_results,
+        next_palette.grf.filename_filter,
     )
     file_paths = grf_unique_file_paths(filtered_results)
     if not keyword or not file_paths:
@@ -437,8 +459,11 @@ def trigger_grf_preview(state: AppState, next_palette) -> ReduceResult:
                 state,
                 command_palette=replace(
                     next_palette,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
+                    grf=replace(
+                        next_palette.grf,
+                        preview_results=(),
+                        total_match_count=0,
+                    ),
                 ),
                 child_pane=PaneState(directory_path=state.current_path, entries=()),
                 pending_replace_preview_request_id=None,
@@ -448,7 +473,7 @@ def trigger_grf_preview(state: AppState, next_palette) -> ReduceResult:
     request = TextReplaceRequest(
         paths=file_paths,
         find_text=keyword,
-        replace_text=next_palette.grf_replacement_text,
+        replace_text=next_palette.grf.replacement_text,
     )
     return finalize(
         replace(
@@ -627,27 +652,27 @@ def handle_submit_grep_replace_palette(state: AppState) -> ReduceResult:
         return notify(state, level="warning", message="Grep search is still running")
     if state.command_palette is None:
         return finalize(state)
-    if not state.command_palette.grf_keyword.strip():
+    if not state.command_palette.grf.keyword.strip():
         return notify(state, level="warning", message="Keyword is required")
-    if state.command_palette.grf_error_message is not None:
-        return notify(state, level="warning", message=state.command_palette.grf_error_message)
-    if not state.command_palette.grf_preview_results:
-        message = state.command_palette.grf_status_message or "No matching files"
+    if state.command_palette.grf.error_message is not None:
+        return notify(state, level="warning", message=state.command_palette.grf.error_message)
+    if not state.command_palette.grf.preview_results:
+        message = state.command_palette.grf.status_message or "No matching files"
         return notify(state, level="warning", message=message)
 
     # Show confirmation dialog instead of directly applying replacement
     filtered_results = filter_grep_results_by_filename(
-        state.command_palette.grf_grep_results,
-        state.command_palette.grf_filename_filter,
+        state.command_palette.grf.grep_results,
+        state.command_palette.grf.filename_filter,
     )
     file_paths = grf_unique_file_paths(filtered_results)
     return _handle_begin_replace_confirmation(
         state,
         mode="replace_in_grep_files",
-        find_text=state.command_palette.grf_keyword,
-        replacement_text=state.command_palette.grf_replacement_text,
+        find_text=state.command_palette.grf.keyword,
+        replacement_text=state.command_palette.grf.replacement_text,
         target_paths=file_paths,
-        total_match_count=state.command_palette.grf_total_match_count,
+        total_match_count=state.command_palette.grf.total_match_count,
     )
 
 
@@ -731,27 +756,33 @@ def handle_grf_grep_search_completed(state: AppState, action: GrepSearchComplete
         state,
         command_palette=replace(
             state.command_palette,
-            grf_grep_results=action.results,
-            grf_grep_error_message=None,
+            grf=replace(
+                state.command_palette.grf,
+                grep_results=action.results,
+                grep_error_message=None,
+            ),
             cursor_index=0,
         ),
         pending_grep_search_request_id=None,
     )
-    keyword = next_state.command_palette.grf_keyword.strip()
+    keyword = next_state.command_palette.grf.keyword.strip()
     if not keyword or not action.results:
         return sync_grep_replace_preview(
             replace(
                 next_state,
                 command_palette=replace(
                     next_state.command_palette,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
+                    grf=replace(
+                        next_state.command_palette.grf,
+                        preview_results=(),
+                        total_match_count=0,
+                    ),
                 ),
             )
         )
     filtered_results = filter_grep_results_by_filename(
         action.results,
-        next_state.command_palette.grf_filename_filter,
+        next_state.command_palette.grf.filename_filter,
     )
     file_paths = grf_unique_file_paths(filtered_results)
     if not file_paths:
@@ -760,8 +791,11 @@ def handle_grf_grep_search_completed(state: AppState, action: GrepSearchComplete
                 next_state,
                 command_palette=replace(
                     next_state.command_palette,
-                    grf_preview_results=(),
-                    grf_total_match_count=0,
+                    grf=replace(
+                        next_state.command_palette.grf,
+                        preview_results=(),
+                        total_match_count=0,
+                    ),
                 ),
             )
         )
@@ -769,7 +803,7 @@ def handle_grf_grep_search_completed(state: AppState, action: GrepSearchComplete
     request = TextReplaceRequest(
         paths=file_paths,
         find_text=keyword,
-        replace_text=next_state.command_palette.grf_replacement_text,
+        replace_text=next_state.command_palette.grf.replacement_text,
     )
     return finalize(
         replace(
@@ -906,10 +940,13 @@ def handle_grf_preview_completed(
         state,
         command_palette=replace(
             state.command_palette,
-            grf_preview_results=preview_results,
-            grf_error_message=None,
-            grf_status_message=status_message,
-            grf_total_match_count=action.result.total_match_count,
+            grf=replace(
+                state.command_palette.grf,
+                preview_results=preview_results,
+                error_message=None,
+                status_message=status_message,
+                total_match_count=action.result.total_match_count,
+            ),
             cursor_index=0,
         ),
         pending_replace_preview_request_id=None,
@@ -989,10 +1026,13 @@ def handle_text_replace_preview_failed(
                     state,
                     command_palette=replace(
                         state.command_palette,
-                        grf_preview_results=(),
-                        grf_error_message=action.message,
-                        grf_status_message=None,
-                        grf_total_match_count=0,
+                        grf=replace(
+                            state.command_palette.grf,
+                            preview_results=(),
+                            error_message=action.message,
+                            status_message=None,
+                            total_match_count=0,
+                        ),
                         cursor_index=0,
                     ),
                     child_pane=PaneState(directory_path=state.current_path, entries=()),
@@ -1217,7 +1257,7 @@ def sync_find_replace_preview(state: AppState) -> ReduceResult:
 def selected_grep_replace_preview_result(state: AppState) -> ReplacePreviewResultState | None:
     if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
         return None
-    results = state.command_palette.grf_preview_results
+    results = state.command_palette.grf.preview_results
     if not results:
         return None
     return results[normalize_command_palette_cursor(state, state.command_palette.cursor_index)]
@@ -1231,7 +1271,7 @@ def sync_grep_replace_preview(state: AppState) -> ReduceResult:
             state.command_palette is not None
             and state.command_palette.source == "replace_in_grep_files"
         ):
-            preview_message = state.command_palette.grf_status_message or preview_message
+            preview_message = state.command_palette.grf.status_message or preview_message
         return finalize(
             replace(
                 state,
@@ -1259,7 +1299,7 @@ def sync_grep_replace_preview(state: AppState) -> ReduceResult:
                 preview_title="Replace Preview",
                 preview_content=selected_result.diff_text,
                 preview_message=(
-                    state.command_palette.grf_status_message
+                    state.command_palette.grf.status_message
                     if state.command_palette is not None
                     else None
                 ),

--- a/src/zivo/state/reducer_palette_shared.py
+++ b/src/zivo/state/reducer_palette_shared.py
@@ -110,14 +110,14 @@ def grf_field_value(
     field: GrepReplaceFieldId,
 ) -> str:
     if field == "keyword":
-        return palette.grf_keyword
+        return palette.grf.keyword
     if field == "replace":
-        return palette.grf_replacement_text
+        return palette.grf.replacement_text
     if field == "filename":
-        return palette.grf_filename_filter
+        return palette.grf.filename_filter
     if field == "include":
-        return palette.grf_include_extensions
-    return palette.grf_exclude_extensions
+        return palette.grf.include_extensions
+    return palette.grf.exclude_extensions
 
 
 def replace_grf_field(
@@ -127,14 +127,14 @@ def replace_grf_field(
     value: str,
 ) -> CommandPaletteState:
     if field == "keyword":
-        return replace(palette, query=value, grf_keyword=value)
+        return replace(palette, query=value, grf=replace(palette.grf, keyword=value))
     if field == "replace":
-        return replace(palette, grf_replacement_text=value)
+        return replace(palette, grf=replace(palette.grf, replacement_text=value))
     if field == "filename":
-        return replace(palette, grf_filename_filter=value)
+        return replace(palette, grf=replace(palette.grf, filename_filter=value))
     if field == "include":
-        return replace(palette, grf_include_extensions=value)
-    return replace(palette, grf_exclude_extensions=value)
+        return replace(palette, grf=replace(palette.grf, include_extensions=value))
+    return replace(palette, grf=replace(palette.grf, exclude_extensions=value))
 
 
 def grs_field_value(

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -401,7 +401,7 @@ def _select_replace_preview_pane(
     if state.command_palette.source == "replace_in_found_files":
         results = state.command_palette.rff.preview_results
     elif state.command_palette.source == "replace_in_grep_files":
-        results = state.command_palette.grf_preview_results
+        results = state.command_palette.grf.preview_results
     elif state.command_palette.source == "grep_replace_selected":
         results = state.command_palette.grs.preview_results
     else:

--- a/src/zivo/state/selectors_shared.py
+++ b/src/zivo/state/selectors_shared.py
@@ -500,33 +500,33 @@ def _build_grep_replace_input_fields(
     return (
         CommandPaletteInputFieldViewState(
             label="Keyword",
-            value=palette.grf_keyword or palette.query,
+            value=palette.grf.keyword or palette.query,
             placeholder="search text",
-            active=palette.grf_active_field == "keyword",
+            active=palette.grf.active_field == "keyword",
         ),
         CommandPaletteInputFieldViewState(
             label="Replace",
-            value=palette.grf_replacement_text,
+            value=palette.grf.replacement_text,
             placeholder="replacement text",
-            active=palette.grf_active_field == "replace",
+            active=palette.grf.active_field == "replace",
         ),
         CommandPaletteInputFieldViewState(
             label="Filter: Filename",
-            value=palette.grf_filename_filter,
+            value=palette.grf.filename_filter,
             placeholder="pattern or re:pattern",
-            active=palette.grf_active_field == "filename",
+            active=palette.grf.active_field == "filename",
         ),
         CommandPaletteInputFieldViewState(
             label="Include extensions",
-            value=palette.grf_include_extensions,
+            value=palette.grf.include_extensions,
             placeholder="e.g. py, js",
-            active=palette.grf_active_field == "include",
+            active=palette.grf.active_field == "include",
         ),
         CommandPaletteInputFieldViewState(
             label="Exclude extensions",
-            value=palette.grf_exclude_extensions,
+            value=palette.grf.exclude_extensions,
             placeholder="e.g. log, tmp",
-            active=palette.grf_active_field == "exclude",
+            active=palette.grf.active_field == "exclude",
         ),
     )
 

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -401,12 +401,12 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
     if state.command_palette.source == "replace_in_grep_files":
         visible_results, title = _select_find_replace_preview_window(
             state,
-            state.command_palette.grf_preview_results,
+            state.command_palette.grf.preview_results,
             cursor_index,
         )
         return CommandPaletteViewState(
             title=title,
-            query=state.command_palette.grf_keyword,
+            query=state.command_palette.grf.keyword,
             items=tuple(
                 CommandPaletteItemViewState(
                     label=result.display_label,
@@ -419,7 +419,7 @@ def select_command_palette_state(state: AppState) -> CommandPaletteViewState | N
             empty_message=_grep_replace_empty_message(state),
             input_fields=_build_grep_replace_input_fields(state.command_palette),
             has_more_items=(
-                len(state.command_palette.grf_preview_results) > len(visible_results)
+                len(state.command_palette.grf.preview_results) > len(visible_results)
             ),
         )
     if state.command_palette.source == "grep_replace_selected":
@@ -868,22 +868,22 @@ def _grep_replace_empty_message(state: AppState) -> str:
         return "Searching..."
     if state.command_palette is None or state.command_palette.source != "replace_in_grep_files":
         return ""
-    if state.command_palette.grf_grep_error_message is not None:
-        return state.command_palette.grf_grep_error_message
-    if not state.command_palette.grf_keyword.strip():
+    if state.command_palette.grf.grep_error_message is not None:
+        return state.command_palette.grf.grep_error_message
+    if not state.command_palette.grf.keyword.strip():
         return "Type a search keyword"
-    if not state.command_palette.grf_replacement_text.strip():
-        file_count = len(state.command_palette.grf_grep_results)
+    if not state.command_palette.grf.replacement_text.strip():
+        file_count = len(state.command_palette.grf.grep_results)
         if file_count == 0:
             return "No matching lines"
         return f"{file_count} result(s) found. Tab to Replace field."
     if state.pending_replace_preview_request_id is not None:
         return "Previewing diff in right pane..."
-    if state.command_palette.grf_error_message is not None:
-        return state.command_palette.grf_error_message
-    if state.command_palette.grf_status_message is not None:
-        return state.command_palette.grf_status_message
-    if state.command_palette.grf_total_match_count > 0:
+    if state.command_palette.grf.error_message is not None:
+        return state.command_palette.grf.error_message
+    if state.command_palette.grf.status_message is not None:
+        return state.command_palette.grf.status_message
+    if state.command_palette.grf.total_match_count > 0:
         return "Preview shown in right pane. Press Enter to apply."
     return "No matching files"
 

--- a/tests/test_state_reducer_palette_replace.py
+++ b/tests/test_state_reducer_palette_replace.py
@@ -660,14 +660,14 @@ def test_begin_grep_replace_enters_grf_mode() -> None:
     assert state.ui_mode == "PALETTE"
     assert state.command_palette is not None
     assert state.command_palette.source == "replace_in_grep_files"
-    assert state.command_palette.grf_active_field == "keyword"
+    assert state.command_palette.grf.active_field == "keyword"
 
 def test_set_grf_keyword_field_starts_grep_search() -> None:
     state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
     result = reduce_app_state(state, SetGrepReplaceField(field="keyword", value="todo"))
 
     assert result.state.pending_grep_search_request_id is not None
-    assert result.state.command_palette.grf_keyword == "todo"
+    assert result.state.command_palette.grf.keyword == "todo"
     effects = [e for e in result.effects if isinstance(e, RunGrepSearchEffect)]
     assert len(effects) == 1
     assert effects[0].query == "todo"
@@ -678,7 +678,7 @@ def test_set_grf_keyword_clear_triggers_no_search() -> None:
     result = reduce_app_state(state, SetGrepReplaceField(field="keyword", value=""))
 
     assert result.state.pending_grep_search_request_id is None
-    assert result.state.command_palette.grf_grep_results == ()
+    assert result.state.command_palette.grf.grep_results == ()
 
 def test_set_grf_replace_field_with_grep_results_starts_preview() -> None:
     state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
@@ -686,13 +686,16 @@ def test_set_grf_replace_field_with_grep_results_starts_preview() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                grep_results=(
+                    GrepSearchResultState(
+                        path="/home/tadashi/develop/zivo/README.md",
+                        display_path="README.md",
+                        line_number=1,
+                        line_text="todo item",
+                    ),
                 ),
             ),
         ),
@@ -710,13 +713,16 @@ def test_set_grf_replace_field_without_grep_results_no_preview() -> None:
     result = reduce_app_state(state, SetGrepReplaceField(field="replace", value="done"))
 
     assert result.state.pending_replace_preview_request_id is None
-    assert result.state.command_palette.grf_preview_results == ()
+    assert result.state.command_palette.grf.preview_results == ()
 
 def test_grf_grep_search_completed_stores_results() -> None:
     state = _reduce_state(build_initial_app_state(), BeginGrepReplace())
     state = replace(
         state,
-        command_palette=replace(state.command_palette, grf_keyword="todo"),
+        command_palette=replace(
+            state.command_palette,
+            grf=replace(state.command_palette.grf, keyword="todo"),
+        ),
         pending_grep_search_request_id=10,
         next_request_id=11,
     )
@@ -732,7 +738,7 @@ def test_grf_grep_search_completed_stores_results() -> None:
         state, GrepSearchCompleted(request_id=10, query="todo", results=results)
     )
 
-    assert result.state.command_palette.grf_grep_results == results
+    assert result.state.command_palette.grf.grep_results == results
     assert result.state.pending_grep_search_request_id is None
 
 def test_grf_grep_search_completed_auto_triggers_preview_when_replace_text_present() -> None:
@@ -741,8 +747,11 @@ def test_grf_grep_search_completed_auto_triggers_preview_when_replace_text_prese
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                replacement_text="done",
+            ),
         ),
         pending_grep_search_request_id=10,
         next_request_id=11,
@@ -759,7 +768,7 @@ def test_grf_grep_search_completed_auto_triggers_preview_when_replace_text_prese
         state, GrepSearchCompleted(request_id=10, query="todo", results=results)
     )
 
-    assert result.state.command_palette.grf_grep_results == results
+    assert result.state.command_palette.grf.grep_results == results
     assert result.state.pending_replace_preview_request_id is not None
     effects = [e for e in result.effects if isinstance(e, RunTextReplacePreviewEffect)]
     assert len(effects) == 1
@@ -770,14 +779,17 @@ def test_grf_preview_completed_stores_results() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                replacement_text="done",
+                grep_results=(
+                    GrepSearchResultState(
+                        path="/home/tadashi/develop/zivo/README.md",
+                        display_path="README.md",
+                        line_number=1,
+                        line_text="todo item",
+                    ),
                 ),
             ),
         ),
@@ -807,8 +819,8 @@ def test_grf_preview_completed_stores_results() -> None:
         state, TextReplacePreviewCompleted(request_id=10, result=preview_result)
     )
 
-    assert len(result.state.command_palette.grf_preview_results) == 1
-    assert result.state.command_palette.grf_total_match_count == 1
+    assert len(result.state.command_palette.grf.preview_results) == 1
+    assert result.state.command_palette.grf.total_match_count == 1
     assert result.state.pending_replace_preview_request_id is None
 
 def test_submit_grf_palette_warns_when_no_replace_text() -> None:
@@ -817,13 +829,16 @@ def test_submit_grf_palette_warns_when_no_replace_text() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                grep_results=(
+                    GrepSearchResultState(
+                        path="/home/tadashi/develop/zivo/README.md",
+                        display_path="README.md",
+                        line_number=1,
+                        line_text="todo item",
+                    ),
                 ),
             ),
         ),
@@ -838,14 +853,17 @@ def test_submit_grf_palette_warns_when_no_preview_results() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-            grf_grep_results=(
-                GrepSearchResultState(
-                    path="/home/tadashi/develop/zivo/README.md",
-                    display_path="README.md",
-                    line_number=1,
-                    line_text="todo item",
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                replacement_text="done",
+                grep_results=(
+                    GrepSearchResultState(
+                        path="/home/tadashi/develop/zivo/README.md",
+                        display_path="README.md",
+                        line_number=1,
+                        line_text="todo item",
+                    ),
                 ),
             ),
         ),
@@ -876,8 +894,11 @@ def test_grf_grep_search_completed_deduplicates_file_paths() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                replacement_text="done",
+            ),
         ),
         pending_grep_search_request_id=10,
         next_request_id=11,
@@ -1296,8 +1317,11 @@ def test_grf_filename_filter_with_invalid_regex_single_backslash() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_grep_results=all_results,
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                grep_results=all_results,
+            ),
         ),
     )
 
@@ -1305,11 +1329,11 @@ def test_grf_filename_filter_with_invalid_regex_single_backslash() -> None:
     result = reduce_app_state(state, SetGrepReplaceField(field="filename", value="re:\\"))
 
     assert result.state.command_palette is not None
-    assert result.state.command_palette.grf_filename_filter == "re:\\"
-    assert result.state.command_palette.grf_error_message is not None
-    assert "Invalid regex pattern" in result.state.command_palette.grf_error_message
-    assert result.state.command_palette.grf_preview_results == ()
-    assert result.state.command_palette.grf_total_match_count == 0
+    assert result.state.command_palette.grf.filename_filter == "re:\\"
+    assert result.state.command_palette.grf.error_message is not None
+    assert "Invalid regex pattern" in result.state.command_palette.grf.error_message
+    assert result.state.command_palette.grf.preview_results == ()
+    assert result.state.command_palette.grf.total_match_count == 0
 
 
 def test_grf_filename_filter_with_valid_regex_backslash() -> None:
@@ -1336,9 +1360,12 @@ def test_grf_filename_filter_with_valid_regex_backslash() -> None:
         state,
         command_palette=replace(
             state.command_palette,
-            grf_keyword="todo",
-            grf_replacement_text="done",
-            grf_grep_results=all_results,
+            grf=replace(
+                state.command_palette.grf,
+                keyword="todo",
+                replacement_text="done",
+                grep_results=all_results,
+            ),
         ),
     )
 
@@ -1346,7 +1373,7 @@ def test_grf_filename_filter_with_valid_regex_backslash() -> None:
     result = reduce_app_state(state, SetGrepReplaceField(field="filename", value="re:\\.py$"))
 
     assert result.state.command_palette is not None
-    assert result.state.command_palette.grf_filename_filter == "re:\\.py$"
-    assert result.state.command_palette.grf_error_message is None
+    assert result.state.command_palette.grf.filename_filter == "re:\\.py$"
+    assert result.state.command_palette.grf.error_message is None
     # Results should be filtered to .py files only
     assert result.state.pending_replace_preview_request_id == 1


### PR DESCRIPTION
## Summary
- `GrfPaletteState` frozen dataclass を `src/zivo/state/models.py` に追加
- `CommandPaletteState` から `grf_*` 12フィールドを削除し `grf: GrfPaletteState` に置き換え
- 全参照先（reducer, selector, input_palette, command_palette, selectors_panes, test）を新しいパスに更新
- `reducer_palette_shared.py` の `grf_field_value()` / `replace_grf_field()` をサブステート対応に修正

## テスト結果
```
uv run ruff check .  → All checks passed!
uv run pytest       → 1206 passed, 6 skipped
```

## 関連 Issue
Closes #925

## フォローアップ
全8サブステート抽出の完了。親 Issue #854
