### PR TITLE
fix(#949): respect show_hidden setting when resolving cursor path

### DIFF
--- a/src/zivo/app_runtime_search.py
+++ b/src/zivo/app_runtime_search.py
@@ -84,6 +84,7 @@ def schedule_browser_snapshot(app: Any, effect: LoadBrowserSnapshotEffect) -> No
             app._snapshot_loader.load_browser_snapshot,
             effect.path,
             effect.cursor_path,
+            show_hidden=app._app_state.show_hidden,
             enable_image_preview=effect.enable_image_preview,
             enable_pdf_preview=effect.enable_pdf_preview,
             enable_office_preview=effect.enable_office_preview,
@@ -170,6 +171,7 @@ def schedule_progressive_browser_snapshot(app: Any, effect: LoadCurrentPaneEffec
             app._snapshot_loader.load_current_pane_snapshot,
             effect.path,
             effect.cursor_path,
+            show_hidden=app._app_state.show_hidden,
         ),
         WorkerSpec(
             name=f"progressive-snapshot-phase1:{effect.request_id}",

--- a/src/zivo/services/browser_snapshot.py
+++ b/src/zivo/services/browser_snapshot.py
@@ -186,13 +186,14 @@ class LiveBrowserSnapshotLoader:
         path: str,
         cursor_path: str | None = None,
         *,
+        show_hidden: bool = False,
         enable_image_preview: bool = True,
         enable_pdf_preview: bool = True,
         enable_office_preview: bool = True,
     ) -> BrowserSnapshot:
         resolved_path, parent_path = resolve_parent_directory_path(path)
         current_entries = self._list_directory(resolved_path)
-        resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path)
+        resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path, show_hidden)
 
         if parent_path is None:
             parent_directory_path = resolved_path
@@ -307,6 +308,8 @@ class LiveBrowserSnapshotLoader:
         self,
         path: str,
         cursor_path: str | None,
+        *,
+        show_hidden: bool = False,
     ) -> tuple[str, PaneState, PaneState]:
         """Load current pane + minimal parent (Phase 1 of progressive loading).
 
@@ -315,7 +318,7 @@ class LiveBrowserSnapshotLoader:
         """
         resolved_path, parent_path = resolve_parent_directory_path(path)
         current_entries = self._list_directory(resolved_path)
-        resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path)
+        resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path, show_hidden)
 
         if parent_path is None:
             parent_directory_path = resolved_path
@@ -656,6 +659,7 @@ class FakeBrowserSnapshotLoader:
         path: str,
         cursor_path: str | None = None,
         *,
+        show_hidden: bool = False,
         enable_image_preview: bool = True,
         enable_pdf_preview: bool = True,
         enable_office_preview: bool = True,
@@ -715,9 +719,11 @@ class FakeBrowserSnapshotLoader:
         self,
         path: str,
         cursor_path: str | None,
+        *,
+        show_hidden: bool = False,
     ) -> tuple[str, PaneState, PaneState]:
         """Load current pane + minimal parent (Phase 1 of progressive loading)."""
-        snapshot = self.load_browser_snapshot(path, cursor_path)
+        snapshot = self.load_browser_snapshot(path, cursor_path, show_hidden=show_hidden)
         return snapshot.current_path, snapshot.current_pane, snapshot.parent_pane
 
     def load_parent_child_panes(
@@ -891,11 +897,17 @@ def _build_fallback_snapshot(path: str, cursor_path: str | None) -> BrowserSnaps
     )
 
 
-def _resolve_cursor_path(entries, cursor_path: str | None) -> str | None:
+def _resolve_cursor_path(
+    entries,
+    cursor_path: str | None,
+    show_hidden: bool = False,
+) -> str | None:
     if cursor_path and _contains_path(entries, cursor_path):
         return cursor_path
     if not entries:
         return None
+    if show_hidden:
+        return entries[0].path
     for entry in entries:
         if not entry.hidden:
             return entry.path

--- a/src/zivo/state/reducer_navigation_shared.py
+++ b/src/zivo/state/reducer_navigation_shared.py
@@ -220,7 +220,17 @@ def promote_child_pane_to_current(
     path: str,
 ) -> AppState:
     promoted_entries = state.child_pane.entries
-    promoted_cursor_path = normalize_cursor_path(promoted_entries, None)
+    if state.show_hidden or not promoted_entries:
+        promoted_cursor_path = normalize_cursor_path(promoted_entries, None)
+    else:
+        first_visible = next(
+            (e for e in promoted_entries if not e.hidden), None
+        )
+        promoted_cursor_path = (
+            comparable_path(first_visible.path)
+            if first_visible
+            else comparable_path(promoted_entries[0].path)
+        )
     return replace(
         state,
         current_path=comparable_path(path),

--- a/tests/test_app_runtime.py
+++ b/tests/test_app_runtime.py
@@ -86,6 +86,7 @@ class _RecordingSnapshotLoader:
         path: str,
         cursor_path: str | None = None,
         *,
+        show_hidden: bool = False,
         enable_image_preview: bool = True,
         enable_pdf_preview: bool = True,
         enable_office_preview: bool = True,
@@ -131,6 +132,8 @@ class _RecordingSnapshotLoader:
         self,
         path: str,
         cursor_path: str | None,
+        *,
+        show_hidden: bool = False,
     ) -> tuple[str, PaneState, PaneState]:
         self.load_current_pane_snapshot_calls.append((path, cursor_path))
         pane = PaneState(directory_path=path, entries=(), cursor_path=cursor_path)

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -10,7 +10,7 @@ from zivo.services import (
     FakeBrowserSnapshotLoader,
     LiveBrowserSnapshotLoader,
 )
-from zivo.services.browser_snapshot import FilePreviewState
+from zivo.services.browser_snapshot import FilePreviewState, _resolve_cursor_path
 from zivo.state import BrowserSnapshot, GrepSearchResultState
 from zivo.state.models import DirectoryEntryState, PaneState
 
@@ -881,6 +881,68 @@ def test_live_browser_snapshot_loader_invalidates_selected_directory_cache_entry
         str(docs),
         str(project),
     ]
+
+
+def test_resolve_cursor_path_returns_cursor_path_when_found() -> None:
+    entries = (
+        DirectoryEntryState("/a/.hidden", ".hidden", "file", hidden=True),
+        DirectoryEntryState("/a/visible", "visible", "file"),
+    )
+    result = _resolve_cursor_path(entries, "/a/visible")
+    assert result == "/a/visible"
+
+
+def test_resolve_cursor_path_returns_none_when_entries_empty() -> None:
+    result = _resolve_cursor_path((), None)
+    assert result is None
+
+
+def test_resolve_cursor_path_skips_hidden_when_show_hidden_false() -> None:
+    entries = (
+        DirectoryEntryState("/a/.hidden", ".hidden", "dir", hidden=True),
+        DirectoryEntryState("/a/.config", ".config", "dir", hidden=True),
+        DirectoryEntryState("/a/data", "data", "dir"),
+        DirectoryEntryState("/a/src", "src", "dir"),
+    )
+    result = _resolve_cursor_path(entries, None, show_hidden=False)
+    assert result == "/a/data"
+
+
+def test_resolve_cursor_path_returns_first_entry_when_all_hidden() -> None:
+    entries = (
+        DirectoryEntryState("/a/.hidden", ".hidden", "dir", hidden=True),
+        DirectoryEntryState("/a/.config", ".config", "dir", hidden=True),
+    )
+    result = _resolve_cursor_path(entries, None, show_hidden=False)
+    assert result == "/a/.hidden"
+
+
+def test_resolve_cursor_path_does_not_skip_hidden_when_show_hidden_true() -> None:
+    entries = (
+        DirectoryEntryState("/a/.hidden", ".hidden", "dir", hidden=True),
+        DirectoryEntryState("/a/.config", ".config", "dir", hidden=True),
+        DirectoryEntryState("/a/data", "data", "dir"),
+    )
+    result = _resolve_cursor_path(entries, None, show_hidden=True)
+    assert result == "/a/.hidden"
+
+
+def test_resolve_cursor_path_returns_first_entry_when_cursor_missing() -> None:
+    entries = (
+        DirectoryEntryState("/a/src", "src", "dir"),
+        DirectoryEntryState("/a/docs", "docs", "dir"),
+    )
+    result = _resolve_cursor_path(entries, "/a/missing", show_hidden=False)
+    assert result == "/a/src"
+
+
+def test_resolve_cursor_path_skips_hidden_by_default() -> None:
+    entries = (
+        DirectoryEntryState("/a/.hidden", ".hidden", "dir", hidden=True),
+        DirectoryEntryState("/a/visible", "visible", "dir"),
+    )
+    result = _resolve_cursor_path(entries, None)
+    assert result == "/a/visible"
 
 
 def test_fake_browser_snapshot_loader_prefers_requested_cursor_path() -> None:


### PR DESCRIPTION
## Summary

- `show_hidden` 設定に応じてカーソル初期位置の解決を適切に制御する

## Changes

### Bug A: 階層移動後に子パネルが空になる

`promote_child_pane_to_current` が生エントリの先頭（隠しディレクトリ `.git` 等）をカーソル位置に設定していたため、UI でフィルタリングされ `cursor_entry=None` → 子パネル空に。

**修正**: `show_hidden=False` の場合、最初の非隠しエントリをカーソル位置にする。

### Bug B: 隠しファイル表示 ON でも隠しエントリをスキップ

`_resolve_cursor_path` の #948 修正が `show_hidden` 状態を考慮せず常に隠しエントリをスキップしていた。

**修正**: `show_hidden` パラメータを追加。`True` の場合は隠しエントリをスキップしない。

### 影響範囲

- `LiveBrowserSnapshotLoader` / `FakeBrowserSnapshotLoader` / `_RecordingSnapshotLoader` に `show_hidden` パラメータ追加
- `schedule_browser_snapshot` / `schedule_progressive_browser_snapshot` で `app._app_state.show_hidden` をスルー
- `promote_child_pane_to_current` で `show_hidden` を考慮したカーソル解決
- `_resolve_cursor_path` のユニットテスト 7ケース追加

## Test Results

- 1216 passed, 6 skipped
- lint (ruff) all checks passed
