### PR TITLE
#950 転送モード時のCurrent Pathの表示仕様変更

### DIFF
--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -138,9 +138,20 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
     )
     if state.layout_mode != "transfer":
         return shell
+    active_pane = (
+        state.transfer_left
+        if state.active_transfer_pane == "left"
+        else state.transfer_right
+    )
+    transfer_current_path = (
+        active_pane.current_path
+        if active_pane
+        else state.current_pane.directory_path
+    )
     return replace(
         shell,
         layout_mode="transfer",
+        current_path=transfer_current_path,
         transfer_left=_select_transfer_pane(state, "left"),
         transfer_right=_select_transfer_pane(state, "right"),
     )


### PR DESCRIPTION
## Summary
- 転送モード中、画面上部の `CurrentPathBar` にアクティブな転送ペインのパスを表示するよう変更
- 変更前: ブラウザモードのパスが固定表示されていた
- 変更後: アクティブペイン（左右どちらか）の current_path を表示

## Changes
- `src/zivo/state/selectors.py`: `select_shell_data()` 内で転送モード時に `current_path` をアクティブペインのパスで上書き

## Test Results
- 1214 passed, 6 skipped (regressionなし)
- ruff check 合格

## Follow-up
- なし