### PR TITLE
Fix #964: navigate to active transfer pane directory when closing transfer mode

### DIFF
--- a/src/zivo/state/reducer_transfer.py
+++ b/src/zivo/state/reducer_transfer.py
@@ -25,6 +25,7 @@ from .actions import (
     MoveTransferCursorAndSelectRange,
     MoveTransferCursorByPage,
     PasteClipboardToTransferPane,
+    RequestBrowserSnapshot,
     SelectAllVisibleTransferEntries,
     SetTransferCursorPath,
     ToggleTransferMode,
@@ -123,16 +124,28 @@ def _handle_toggle_transfer_mode(
     action: ToggleTransferMode,
     reduce_state: ReducerFn,
 ) -> ReduceResult:
-    del action, reduce_state
+    del action
     if state.layout_mode == "transfer":
-        return finalize(
-            replace(
-                state,
-                layout_mode="browser",
-                transfer_left=None,
-                transfer_right=None,
-                notification=NotificationState(level="info", message="Transfer mode closed"),
-            )
+        active = (
+            state.transfer_left
+            if state.active_transfer_pane == "left"
+            else state.transfer_right
+        )
+        closed_state = replace(
+            state,
+            layout_mode="browser",
+            transfer_left=None,
+            transfer_right=None,
+            notification=NotificationState(
+                level="info", message="Transfer mode closed"
+            ),
+        )
+        new_path = active.current_path if active else state.current_path
+        return reduce_state(
+            closed_state,
+            RequestBrowserSnapshot(
+                new_path, cursor_path=new_path, blocking=True
+            ),
         )
     left = TransferPaneState(
         pane=state.current_pane, current_path=state.current_path, history=state.history


### PR DESCRIPTION
## Summary
- 転送モード解除時（`p`キーまたはEscape）、アクティブな転送ペインのカレントディレクトリに移動した状態で通常のブラウザモードに戻るように変更
- 従来は転送モードに入る前のパスに戻っていたが、解除時にアクティブペインのパスへ遷移するようになった
- `_handle_toggle_transfer_mode` で解除時に `reduce_state` 経由で `RequestBrowserSnapshot` を発行し、非同期にディレクトリエントリをロードする

## Test Results
- 1214 passed, 6 skipped
- 既存の転送モード関連テスト全件パス確認済み

## Follow-up
- 特になし