### PR TITLE
#967 TransferモードのCurrent Pathでもマウスクリックでジャンプできるようにする

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -86,6 +86,7 @@ from zivo.state.actions import (
     EnterTransferDirectory,
     ExitCurrentPath,
     FocusTransferPane,
+    NavigateTransferToPath,
     OpenPathWithDefaultApp,
     RequestBrowserSnapshot,
     SetCursorPath,
@@ -585,6 +586,9 @@ class zivoApp(App[None]):
         """Handle path segment clicks from the CurrentPathBar widget."""
 
         if self._app_state.layout_mode == "transfer":
+            await self.dispatch_actions(
+                (NavigateTransferToPath(message.path),),
+            )
             return
         await self.dispatch_actions(
             (RequestBrowserSnapshot(message.path, blocking=True),),

--- a/src/zivo/state/actions.py
+++ b/src/zivo/state/actions.py
@@ -156,6 +156,7 @@ from .actions_navigation import (
     MoveTransferCursor,
     MoveTransferCursorAndSelectRange,
     MoveTransferCursorByPage,
+    NavigateTransferToPath,
     OpenNewTab,
     OpenPathInEditor,
     OpenPathInGuiEditor,
@@ -387,6 +388,7 @@ Action = (
     | EnterTransferDirectory
     | GoToTransferParent
     | GoToTransferHome
+    | NavigateTransferToPath
     | TransferCopyToOppositePane
     | TransferMoveToOppositePane
     | PasteClipboardToTransferPane

--- a/src/zivo/state/actions_navigation.py
+++ b/src/zivo/state/actions_navigation.py
@@ -268,6 +268,13 @@ class GoToTransferHome:
 
 
 @dataclass(frozen=True)
+class NavigateTransferToPath:
+    """Navigate the active transfer pane to a specific path (e.g. from path bar click)."""
+
+    path: str
+
+
+@dataclass(frozen=True)
 class TransferCopyToOppositePane:
     """Copy active transfer targets into the opposite pane directory."""
 

--- a/src/zivo/state/reducer_transfer.py
+++ b/src/zivo/state/reducer_transfer.py
@@ -24,6 +24,7 @@ from .actions import (
     MoveTransferCursor,
     MoveTransferCursorAndSelectRange,
     MoveTransferCursorByPage,
+    NavigateTransferToPath,
     PasteClipboardToTransferPane,
     RequestBrowserSnapshot,
     SelectAllVisibleTransferEntries,
@@ -489,6 +490,20 @@ def _handle_go_to_transfer_home(
     )
 
 
+def _handle_navigate_transfer_to_path(
+    state: AppState,
+    action: NavigateTransferToPath,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    del reduce_state
+    return request_transfer_pane_snapshot(
+        state,
+        state.active_transfer_pane,
+        action.path,
+        invalidate_paths=browser_snapshot_invalidation_paths(action.path),
+    )
+
+
 def _handle_transfer_copy_to_opposite_pane(
     state: AppState,
     action: TransferCopyToOppositePane,
@@ -687,6 +702,7 @@ _TRANSFER_HANDLERS: dict[type[Action], Callable[[AppState, Action, ReducerFn], R
     EnterTransferDirectory: _handle_enter_transfer_directory,
     GoToTransferParent: _handle_go_to_transfer_parent,
     GoToTransferHome: _handle_go_to_transfer_home,
+    NavigateTransferToPath: _handle_navigate_transfer_to_path,
     TransferCopyToOppositePane: _handle_transfer_copy_to_opposite_pane,
     TransferMoveToOppositePane: _handle_transfer_move_to_opposite_pane,
     PasteClipboardToTransferPane: _handle_paste_clipboard_to_transfer_pane,

--- a/tests/test_current_path_bar.py
+++ b/tests/test_current_path_bar.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from rich.style import Style
 from rich.text import Text
@@ -276,7 +278,7 @@ async def test_app_current_path_bar_segment_click_navigates(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_app_current_path_bar_segment_click_ignored_in_transfer_mode(
+async def test_app_current_path_bar_segment_click_navigates_active_transfer_pane(
     tmp_path,
 ) -> None:
     from tests.test_app import _build_snapshot, _wait_for_snapshot_loaded
@@ -284,6 +286,7 @@ async def test_app_current_path_bar_segment_click_ignored_in_transfer_mode(
     from zivo.services import FakeBrowserSnapshotLoader
     from zivo.state import DirectoryEntryState
     from zivo.state.actions import ToggleTransferMode
+    from zivo.ui import CurrentPathBar
 
     path = str(tmp_path)
     readme = tmp_path / "README.md"
@@ -300,14 +303,26 @@ async def test_app_current_path_bar_segment_click_ignored_in_transfer_mode(
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
     async with app.run_test(size=(120, 20)):
-        from zivo.ui import CurrentPathBar
-
         await _wait_for_snapshot_loaded(app, path)
 
         await app.dispatch_actions((ToggleTransferMode(),))
         assert app.app_state.layout_mode == "transfer"
 
         await app.on_current_path_bar_path_segment_clicked(
-            CurrentPathBar.PathSegmentClicked(path="/nonexistent"),
+            CurrentPathBar.PathSegmentClicked(path=path),
         )
-        assert app.app_state.current_path == path
+
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while True:
+            active_pane = (
+                app.app_state.transfer_left
+                if app.app_state.active_transfer_pane == "left"
+                else app.app_state.transfer_right
+            )
+            assert active_pane is not None
+            if active_pane.pending_snapshot_request_id is None:
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError("transfer pane snapshot did not finish")
+            await asyncio.sleep(0.01)
+        assert active_pane.current_path == path


### PR DESCRIPTION
## Summary

- Browse モードで実装済みの Current Path バーのパスセグメントクリック機能を Transfer モードでも有効化
- Transfer モードのアクティブペインの Current Path バーのセグメントをクリックすると、そのパスへペインが遷移する

## Changes

- **`NavigateTransferToPath` アクションを追加** (`src/zivo/state/actions_navigation.py`)
  - アクティブな Transfer ペインを任意のパスへ遷移させるためのアクション
- **リデューサーハンドラを追加** (`src/zivo/state/reducer_transfer.py`)
  - `request_transfer_pane_snapshot()` を呼び出し、非ブロッキングでスナップショットをロード
- **`app.py` のガードを解除** (`src/zivo/app.py`)
  - Transfer モード時にパスクリックを無視していた早期 return を `NavigateTransferToPath` の dispatch に変更
- **既存テストを更新** (`tests/test_current_path_bar.py`)
  - `test_app_current_path_bar_segment_click_ignored_in_transfer_mode` を遷移を検証するテストに変更

## Test Results

- `uv run ruff check .` → All checks passed
- `uv run pytest` → 1231 passed, 6 skipped