### PR TITLE
#970 dirs on/offを非表示

### DIFF
--- a/src/zivo/models/shell_data.py
+++ b/src/zivo/models/shell_data.py
@@ -335,7 +335,7 @@ def build_dummy_shell_data() -> ThreePaneShellData:
         current_summary=CurrentSummaryState(
             item_count=len(current_entries),
             selected_count=0,
-            sort_label="name asc dirs:on",
+            sort_label="name asc",
         ),
         current_context_input=None,
         help=HelpBarState(

--- a/src/zivo/state/selectors_shared.py
+++ b/src/zivo/state/selectors_shared.py
@@ -247,8 +247,7 @@ def _sort_size_key(descending: bool):
 
 def _format_sort_label(sort: SortState) -> str:
     direction = "desc" if sort.descending else "asc"
-    directories = "on" if sort.directories_first else "off"
-    return f"{sort.field} {direction} dirs:{directories}"
+    return f"{sort.field} {direction}"
 
 
 def compute_search_visible_window(terminal_height: int, *, extra_rows: int = 0) -> int:

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1245,7 +1245,7 @@ def test_select_shell_data_includes_selected_cut_and_contextual_models() -> None
     assert shell.parent_entries[0].cut is False
     assert shell.current_context_input is not None
     assert shell.current_context_input.value == "read"
-    assert shell.current_summary.sort_label == "name asc dirs:on"
+    assert shell.current_summary.sort_label == "name asc"
     assert shell.status.message == "Ready"
 
 
@@ -1257,7 +1257,7 @@ def test_select_current_summary_state_keeps_summary_format() -> None:
     assert (
         f"{summary.item_count} items | {summary.selected_count} selected | "
         f"sort: {summary.sort_label}"
-    ) == "5 items | 0 selected | sort: name asc dirs:on"
+    ) == "5 items | 0 selected | sort: name asc"
 
 
 def test_select_status_bar_exposes_notification_level() -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -966,7 +966,7 @@ async def test_app_uses_cwd_for_default_initial_path(tmp_path, monkeypatch) -> N
         status_bar = await _wait_for_status_bar(app)
 
         assert str(current_path_bar.renderable) == f"Current Path: {tmp_path}"
-        assert str(summary_bar.renderable) == ("2 items | 0 selected | sort: name asc dirs:on")
+        assert str(summary_bar.renderable) == ("2 items | 0 selected | sort: name asc")
         assert str(status_bar.renderable) == ""
 
 
@@ -1987,7 +1987,7 @@ async def test_app_keyboard_input_updates_selection_and_child_pane() -> None:
         assert app.app_state.current_pane.cursor_path == f"{path}/src"
         assert child_names == ["main.py"]
         assert str(current_path_bar.renderable) == f"Current Path: {path}"
-        assert str(summary_bar.renderable) == ("3 items | 1 selected | sort: name asc dirs:on")
+        assert str(summary_bar.renderable) == ("3 items | 1 selected | sort: name asc")
         assert str(status_bar.renderable) == ""
 
         current_table = app.query_one("#current-pane-table", DataTable)
@@ -2535,7 +2535,7 @@ async def test_app_capital_R_drops_selection_for_missing_entries() -> None:
 
         assert app.app_state.current_pane.selected_paths == set()
         assert app.app_state.current_pane.cursor_path == f"{path}/src"
-        assert str(summary_bar.renderable) == ("1 items | 0 selected | sort: name asc dirs:on")
+        assert str(summary_bar.renderable) == ("1 items | 0 selected | sort: name asc")
         assert str(status_bar.renderable) == ""
 
 
@@ -2583,7 +2583,7 @@ async def test_app_navigation_clears_selection_in_new_directory() -> None:
 
         assert app.app_state.current_pane.selected_paths == set()
         assert app.app_state.current_path == docs
-        assert str(summary_bar.renderable) == ("1 items | 0 selected | sort: name asc dirs:on")
+        assert str(summary_bar.renderable) == ("1 items | 0 selected | sort: name asc")
         assert str(status_bar.renderable) == ""
 
 
@@ -3096,7 +3096,7 @@ async def test_app_child_snapshot_failure_shows_error() -> None:
 
         assert _side_pane_lines(child_list) == []
         assert str(current_path_bar.renderable) == f"Current Path: {path}"
-        assert str(summary_bar.renderable) == "2 items | 0 selected | sort: name asc dirs:on"
+        assert str(summary_bar.renderable) == "2 items | 0 selected | sort: name asc"
         assert str(status_bar.renderable) == "error: permission denied"
         await _wait_for_child_pane_runtime_idle(app, timeout=1.0)
 
@@ -5572,7 +5572,7 @@ async def test_app_sort_shortcuts_keep_side_panes_fixed_and_update_status_bar() 
             "archive",
             "notes.txt",
         ]
-        assert str(summary_bar.renderable) == ("3 items | 0 selected | sort: name desc dirs:off")
+        assert str(summary_bar.renderable) == ("3 items | 0 selected | sort: name desc")
 
 
 @pytest.mark.asyncio
@@ -6175,7 +6175,7 @@ async def test_app_main_flow_round_trip_on_live_filesystem(tmp_path) -> None:
         await asyncio.sleep(0.05)
 
         summary_bar = await _wait_for_summary_bar(app)
-        assert str(summary_bar.renderable) == ("4 items | 0 selected | sort: name desc dirs:on")
+        assert str(summary_bar.renderable) == ("4 items | 0 selected | sort: name desc")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- ソートラベルに表示されていた `dirs:on` / `dirs:off` を非表示にしました
- `directories_first` 機能自体は維持し、表示ラベルのみ削除しています

### 表示変化
- Before: `sort: name asc dirs:on`
- After: `sort: name asc`

### 変更ファイル
- `src/zivo/state/selectors_shared.py` — `_format_sort_label` から `dirs:{on/off}` 部分を削除
- `src/zivo/models/shell_data.py` — スナップショットデータ更新
- `tests/test_app.py` — アサーション修正 (7箇所)
- `tests/state_selectors_cases.py` — アサーション修正 (2箇所)

### テスト
- `uv run ruff check .` — All checks passed
- `uv run pytest` — 1231 passed, 6 skipped