### PR TITLE
[#981] Foreground terminal 起動時に exit で戻るメッセージを表示

### DIFF
--- a/src/zivo/app_runtime_execution.py
+++ b/src/zivo/app_runtime_execution.py
@@ -321,6 +321,9 @@ def run_foreground_external_launch(app: Any, effect: RunExternalLaunchEffect) ->
 
     try:
         with suspend_context:
+            if effect.request.kind == "open_terminal":
+                print("Zivo is suspended. Type 'exit' to return.")
+                sys.stdout.flush()
             app._external_launch_service.execute(effect.request)
     except OSError as error:
         app.refresh(repaint=True, layout=True)

--- a/tests/test_app_runtime.py
+++ b/tests/test_app_runtime.py
@@ -773,6 +773,36 @@ def test_handle_worker_state_changed_cleans_up_cancelled_workers_without_dispatc
     assert app.dispatched_actions == []
 
 
+def test_run_foreground_external_launch_shows_exit_message_for_terminal(
+    capsys,
+) -> None:
+    request = ExternalLaunchRequest(kind="open_terminal", path="/tmp")
+    app = _RecordingApp()
+
+    run_foreground_external_launch(
+        app,
+        RunExternalLaunchEffect(request_id=1, request=request),
+    )
+
+    captured = capsys.readouterr()
+    assert "exit" in captured.out
+
+
+def test_run_foreground_external_launch_skips_message_for_editor(
+    capsys,
+) -> None:
+    request = ExternalLaunchRequest(kind="open_editor", path="/tmp/project/README.md")
+    app = _RecordingApp()
+
+    run_foreground_external_launch(
+        app,
+        RunExternalLaunchEffect(request_id=1, request=request),
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
 def test_run_foreground_external_launch_maps_suspend_failures() -> None:
     request = ExternalLaunchRequest(kind="open_editor", path="/tmp/project/README.md")
     app = _RecordingApp(suspend_error=SuspendNotSupported("suspend unavailable"))


### PR DESCRIPTION
## Summary

- `t` キーで foreground terminal に入ったとき、シェルプロンプトの直前に `Zivo is suspended. Type 'exit' to return.` を表示する
- `e` キー（エディタ起動）や `T` キー（新規ターミナルウィンドウ）には影響しない

## Changes

- `src/zivo/app_runtime_execution.py` — `run_foreground_external_launch()` に3行追加
- `tests/test_app_runtime.py` — 新規テスト2件追加

## Test Results

```
1233 passed, 6 skipped in 74.54s
```

## Related Issue

Closes #981
