### PR TITLE
Fix #985: Search Workspace で size と更新日時が表示されない問題を修正

### DIFF
--- a/src/zivo/windows_paths.py
+++ b/src/zivo/windows_paths.py
@@ -264,13 +264,15 @@ def file_search_result_to_directory_entry(result: object) -> object:
         result: A FileSearchResultState instance
 
     Returns:
-        A DirectoryEntryState with path, name, and kind
+        A DirectoryEntryState with path, name, kind, size_bytes, and modified_at
 
     Raises:
         TypeError: If result is not a FileSearchResultState
     """
+    from datetime import datetime
     from pathlib import Path
 
+    from zivo.adapters.filesystem_attributes import resolve_owner_group
     from zivo.models.shell_data import EntryKind
 
     # Import here to avoid circular dependency
@@ -278,9 +280,40 @@ def file_search_result_to_directory_entry(result: object) -> object:
 
     if isinstance(result, FileSearchResultState):
         kind: EntryKind = "dir" if result.entry_type == "directory" else "file"
-        return DirectoryEntryState(
-            path=result.path,
-            name=Path(result.path).name,
-            kind=kind,
-        )
+        path = Path(result.path)
+
+        # ファイルのメタデータを取得
+        try:
+            stat_result = path.stat()
+            size_bytes = None if kind == "dir" else stat_result.st_size
+            modified_at = datetime.fromtimestamp(stat_result.st_mtime)
+            permissions_mode = stat_result.st_mode
+            hidden = path.name.startswith(".")
+            symlink = path.is_symlink()
+
+            # オーナー/グループ情報を取得
+            owner, group = resolve_owner_group(stat_result)
+
+            return DirectoryEntryState(
+                path=result.path,
+                name=path.name,
+                kind=kind,
+                size_bytes=size_bytes,
+                modified_at=modified_at,
+                hidden=hidden,
+                permissions_mode=permissions_mode,
+                owner=owner,
+                group=group,
+                symlink=symlink,
+            )
+        except (FileNotFoundError, PermissionError, OSError):
+            # ファイルが見つからない、アクセス権限がない、その他のエラーの場合
+            # 基本的な情報のみを含む DirectoryEntryState を返す
+            return DirectoryEntryState(
+                path=result.path,
+                name=path.name,
+                kind=kind,
+                hidden=path.name.startswith("."),
+            )
+
     raise TypeError(f"Expected FileSearchResultState, got {type(result)}")

--- a/tests/test_windows_paths.py
+++ b/tests/test_windows_paths.py
@@ -1,0 +1,150 @@
+"""Tests for windows_paths module functions."""
+
+import os
+from datetime import datetime
+
+import pytest
+
+from zivo.state.models import FileSearchResultState
+from zivo.windows_paths import file_search_result_to_directory_entry
+
+
+def test_file_search_result_to_directory_entry_includes_size_and_modified_at(tmp_path):
+    """ファイル検索結果から DirectoryEntryState への変換で size と modified_at が設定されること"""
+    # テスト用ファイルを作成
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("content", encoding="utf-8")
+
+    # FileSearchResultState を作成
+    result = FileSearchResultState(
+        path=str(test_file),
+        display_path="test.txt",
+        entry_type="file",
+    )
+
+    # 変換を実行
+    entry = file_search_result_to_directory_entry(result)
+
+    # 検証
+    assert entry.path == str(test_file)
+    assert entry.name == "test.txt"
+    assert entry.kind == "file"
+    assert entry.size_bytes == len("content")
+    assert entry.modified_at is not None
+    assert isinstance(entry.modified_at, datetime)
+
+
+def test_file_search_result_to_directory_entry_for_directory(tmp_path):
+    """ディレクトリの場合、size_bytes が None であること"""
+    test_dir = tmp_path / "docs"
+    test_dir.mkdir()
+
+    result = FileSearchResultState(
+        path=str(test_dir),
+        display_path="docs",
+        entry_type="directory",
+    )
+
+    entry = file_search_result_to_directory_entry(result)
+
+    assert entry.kind == "dir"
+    assert entry.size_bytes is None
+    assert entry.modified_at is not None
+    assert isinstance(entry.modified_at, datetime)
+
+
+def test_file_search_result_to_directory_entry_handles_hidden_files(tmp_path):
+    """隠しファイルの hidden フラグが正しく設定されること"""
+    hidden_file = tmp_path / ".hidden"
+    hidden_file.write_text("secret", encoding="utf-8")
+
+    result = FileSearchResultState(
+        path=str(hidden_file),
+        display_path=".hidden",
+        entry_type="file",
+    )
+
+    entry = file_search_result_to_directory_entry(result)
+
+    assert entry.hidden is True
+
+
+def test_file_search_result_to_directory_entry_handles_missing_files(tmp_path):
+    """ファイルが存在しない場合、基本情報のみの DirectoryEntryState が返されること"""
+    missing_file = tmp_path / "missing.txt"
+
+    result = FileSearchResultState(
+        path=str(missing_file),
+        display_path="missing.txt",
+        entry_type="file",
+    )
+
+    entry = file_search_result_to_directory_entry(result)
+
+    # 基本情報は利用可能
+    assert entry.path == str(missing_file)
+    assert entry.name == "missing.txt"
+    assert entry.kind == "file"
+    # メタデータは利用不可
+    assert entry.size_bytes is None
+    assert entry.modified_at is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires extra Windows privileges")
+def test_file_search_result_to_directory_entry_marks_symlinks(tmp_path):
+    """シンボリックリンクの symlink フラグが正しく設定されること"""
+    target = tmp_path / "target.txt"
+    target.write_text("content", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    link.symlink_to(target)
+
+    result = FileSearchResultState(
+        path=str(link),
+        display_path="link.txt",
+        entry_type="file",
+    )
+
+    entry = file_search_result_to_directory_entry(result)
+
+    assert entry.symlink is True
+
+
+def test_file_search_result_to_directory_entry_raises_type_error_for_invalid_input():
+    """FileSearchResultState 以外の型が渡された場合、TypeError が発生すること"""
+    with pytest.raises(TypeError, match="Expected FileSearchResultState"):
+        file_search_result_to_directory_entry("not a FileSearchResultState")
+
+
+def test_file_search_result_to_directory_entry_for_empty_file(tmp_path):
+    """空のファイルの場合、size_bytes が 0 であること"""
+    empty_file = tmp_path / "empty.txt"
+    empty_file.write_text("", encoding="utf-8")
+
+    result = FileSearchResultState(
+        path=str(empty_file),
+        display_path="empty.txt",
+        entry_type="file",
+    )
+
+    entry = file_search_result_to_directory_entry(result)
+
+    assert entry.size_bytes == 0
+    assert entry.modified_at is not None
+
+
+def test_file_search_result_to_directory_entry_for_unicode_filename(tmp_path):
+    """Unicode を含むファイル名で正しく動作すること"""
+    unicode_file = tmp_path / "テストファイル.txt"
+    unicode_file.write_text("content", encoding="utf-8")
+
+    result = FileSearchResultState(
+        path=str(unicode_file),
+        display_path="テストファイル.txt",
+        entry_type="file",
+    )
+
+    entry = file_search_result_to_directory_entry(result)
+
+    assert entry.name == "テストファイル.txt"
+    assert entry.size_bytes == len("content")
+    assert entry.modified_at is not None


### PR DESCRIPTION
## 概要

Issue #985「Search Workspaceでsizeと更新日時が表示されない」を修正しました。

## 原因

`src/zivo/windows_paths.py` の `file_search_result_to_directory_entry` 関数が、`FileSearchResultState` から `DirectoryEntryState` へ変換する際に、ファイルのメタデータ（サイズと更新日時）を取得・設定していませんでした。

## 変更内容

### 1. `file_search_result_to_directory_entry` 関数の拡張

- `path.stat()` でファイルのメタデータを取得
- `size_bytes`: ファイルの場合はサイズ、ディレクトリの場合は `None`
- `modified_at`: `datetime.fromtimestamp(stat_result.st_mtime)` で変換
- `hidden`, `symlink`, `permissions_mode`, `owner`, `group` も適切に設定
- エラー処理: `FileNotFoundError`, `PermissionError`, `OSError` をキャッチし、基本情報のみを返す（Graceful Degradation 方針）

### 2. テストの追加

新規テストファイル `tests/test_windows_paths.py` を作成し、以下をテスト：
- 正常系: ファイル、ディレクトリ、隠しファイル、シンボリックリンク
- エラー系: ファイルが存在しない、TypeError
- エッジケース: 空ファイル、Unicode ファイル名

## テスト結果

- 新規テスト: 8 件すべてパス
- 関連テスト: 55 件すべてパス
- Lint: `ruff check` で問題なし

## 実装計画

詳細な実装計画は Issue コメントを参照してください。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>