### PR TITLE
Fix #986: Search workspace で current path が URL エンコードされて表示される問題を修正

### DIFF
--- a/src/zivo/ui/current_path_bar.py
+++ b/src/zivo/ui/current_path_bar.py
@@ -12,8 +12,10 @@ from textual.widgets import Static
 
 from zivo.windows_paths import (
     WINDOWS_DRIVES_LABEL,
+    display_path,
     is_windows_drives_root,
     is_windows_path,
+    is_search_workspace_path,
 )
 
 
@@ -71,6 +73,10 @@ class CurrentPathBar(Static):
 
         if is_windows_drives_root(path):
             rendered.append(WINDOWS_DRIVES_LABEL)
+            return rendered
+
+        if is_search_workspace_path(path):
+            rendered.append(display_path(path))
             return rendered
 
         parts = CurrentPathBar._get_path_parts(path)

--- a/src/zivo/windows_paths.py
+++ b/src/zivo/windows_paths.py
@@ -84,6 +84,15 @@ def display_path(path: str) -> str:
 
     if is_windows_drives_root(path):
         return WINDOWS_DRIVES_LABEL
+
+    if is_search_workspace_path(path):
+        params = parse_search_workspace_path(path)
+        query = params["query"] or "all"
+        parts = [f"search:{query}"]
+        if params["root"]:
+            parts.append(f" (root:{params['root']})")
+        return "".join(parts)
+
     return path
 
 

--- a/tests/test_windows_paths.py
+++ b/tests/test_windows_paths.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import pytest
 
 from zivo.state.models import FileSearchResultState
-from zivo.windows_paths import file_search_result_to_directory_entry
+from zivo.windows_paths import display_path, file_search_result_to_directory_entry
 
 
 def test_file_search_result_to_directory_entry_includes_size_and_modified_at(tmp_path):
@@ -148,3 +148,40 @@ def test_file_search_result_to_directory_entry_for_unicode_filename(tmp_path):
     assert entry.name == "テストファイル.txt"
     assert entry.size_bytes == len("content")
     assert entry.modified_at is not None
+
+
+def test_display_path_for_search_workspace_with_query_and_root():
+    """search workspace パスのクエリと root が正しくデコードされること"""
+    path = "search://filename%3Apy?target=all&hidden=false&root=%2Fhome"
+    result = display_path(path)
+    assert result == "search:filename:py (root:/home)"
+
+
+def test_display_path_for_search_workspace_without_root():
+    """root がない search workspace パスが正しく表示されること"""
+    path = "search://?target=all&hidden=false"
+    result = display_path(path)
+    assert result == "search:all"
+
+
+def test_display_path_for_search_workspace_with_empty_query():
+    """クエリが空の場合、'all' と表示されること"""
+    path = "search://?target=all&hidden=false&root=%2Fhome"
+    result = display_path(path)
+    assert result == "search:all (root:/home)"
+
+
+def test_display_path_for_regular_path():
+    """通常のパスがそのまま返されること"""
+    path = "/home/user/documents"
+    result = display_path(path)
+    assert result == path
+
+
+def test_display_path_for_windows_drives_root():
+    """Windows drives root が正しく表示されること"""
+    from zivo.windows_paths import WINDOWS_DRIVES_LABEL
+
+    path = "::zivo::windows-drives::"
+    result = display_path(path)
+    assert result == WINDOWS_DRIVES_LABEL


### PR DESCRIPTION
## 概要
Issue #986 の修正です。

Search workspace で `search://` で始まる仮想パスに含まれる URL エンコードされた文字（`%2F` など）が、そのまま UI に表示されており、ユーザーにとって読みづらい状態でした。この問題を修正し、ユーザーフレンドリーな表示形式を実現しました。

## 変更内容

### 1. `src/zivo/windows_paths.py`
- `display_path()` 関数を拡張し、search workspace パス用の表示処理を追加
- 既存の `parse_search_workspace_path()` 関数を活用し、URL デコード済みのパラメータを使用

### 2. `src/zivo/ui/current_path_bar.py`
- `_render_path()` メソッドに search workspace 用の分岐を追加
- `is_search_workspace_path` と `display_path` をインポートに追加

### 3. `tests/test_windows_paths.py`
- `display_path()` の search workspace 用テストを追加
- クエリと root の組み合わせパターンを網羅

## 表示形式の例
- `search://filename%3Apy?target=all&hidden=false&root=%2Fhome` → `search:filename:py (root:/home)`
- `search://?target=all&hidden=false` → `search:all`

## テスト
- すべてのユニットテストが成功（1246 passed, 6 skipped）
- 新規テスト 5 件を追加し、すべて成功

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>