### PR TITLE
Fix #988: find画面でのヘルプバー修正

### DIFF
--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -151,7 +151,7 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             return HelpBarState(
                 (
                     "type filename | ↑↓ or Ctrl+j/k select | enter jump | "
-                    "Ctrl+W workspace | Ctrl+e edit | Ctrl+o GUI | esc cancel",
+                    "Ctrl+w workspace | Ctrl+e edit | Ctrl+o GUI | esc cancel",
                 )
             )
         if state.command_palette is not None and state.command_palette.source == "grep_search":

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1504,7 +1504,7 @@ def test_select_help_bar_state_for_file_search_palette() -> None:
 
     assert help_bar.lines == (
         "type filename | ↑↓ or Ctrl+j/k select | enter jump | "
-        "Ctrl+W workspace | Ctrl+e edit | Ctrl+o GUI | esc cancel",
+        "Ctrl+w workspace | Ctrl+e edit | Ctrl+o GUI | esc cancel",
     )
 
 


### PR DESCRIPTION
## 概要
Issue #988 の修正です。

find files 画面で search workspace を表示するためのキーバインドは \`ctrl + w\` ですが、ヘルプバーには \`Ctrl+W\` と大文字で表示されていました。実際のキーバインドに合わせて \`Ctrl+w\` に修正しました。

## 変更内容

### 1. \`src/zivo/state/selectors_ui.py\`
- ヘルプバーの表示文字列で \`Ctrl+W\` を \`Ctrl+w\` に修正

### 2. \`tests/state_selectors_cases.py\`
- テスト内の期待値文字列で \`Ctrl+W\` を \`Ctrl+w\` に修正

## 修正内容
- \`Ctrl+W workspace\` → \`Ctrl+w workspace\`

## テスト
- すべてのユニットテストが成功（1246 passed, 6 skipped）
- 該当テスト \`test_select_help_bar_state_for_file_search_palette()\` が成功

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>