### PR TITLE
Limit search workspace actions (#991)

### DIFF
--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from zivo.archive_utils import is_supported_archive_path
 from zivo.models import CustomActionContext, custom_action_matches
 from zivo.platform_support import is_split_terminal_supported
-from zivo.windows_paths import display_path
+from zivo.windows_paths import display_path, is_search_workspace_path
 
 from .entry_state_helpers import select_visible_entry_states
 from .models import AppState
@@ -29,6 +29,32 @@ class CommandPaletteItem:
     shortcut: str | None
     enabled: bool
     path: str | None = None
+
+
+SEARCH_WORKSPACE_COMMAND_IDS = frozenset(
+    {
+        "history_search",
+        "bookmark_search",
+        "go_back",
+        "go_forward",
+        "go_to_path",
+        "go_to_home_directory",
+        "undo_last_operation",
+        "new_tab",
+        "next_tab",
+        "previous_tab",
+        "close_current_tab",
+        "exit",
+        "select_all",
+        "show_attributes",
+        "open_in_editor",
+        "open_in_gui_editor",
+        "copy_path",
+        "toggle_hidden",
+        "show_about",
+        "edit_config",
+    }
+)
 
 
 def get_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, ...]:
@@ -323,7 +349,10 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
         ),
     ]
 
-    items.extend(_build_custom_action_items(state))
+    is_search_workspace = is_search_workspace_path(state.current_path)
+
+    if not is_search_workspace:
+        items.extend(_build_custom_action_items(state))
 
     if has_single_target:
         items.append(
@@ -334,39 +363,40 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                 enabled=True,
             )
         )
-        items.append(
-            CommandPaletteItem(
-                id="rename",
-                label="Rename",
-                shortcut="r",
-                enabled=True,
+        if not is_search_workspace:
+            items.append(
+                CommandPaletteItem(
+                    id="rename",
+                    label="Rename",
+                    shortcut="r",
+                    enabled=True,
+                )
             )
-        )
-        items.append(
-            CommandPaletteItem(
-                id="create_symlink",
-                label="Make symlink",
-                shortcut=None,
-                enabled=True,
+            items.append(
+                CommandPaletteItem(
+                    id="create_symlink",
+                    label="Make symlink",
+                    shortcut=None,
+                    enabled=True,
+                )
             )
-        )
-        items.append(
-            CommandPaletteItem(
-                id="compress_as_zip",
-                label="Compress as zip",
-                shortcut=None,
-                enabled=True,
+            items.append(
+                CommandPaletteItem(
+                    id="compress_as_zip",
+                    label="Compress as zip",
+                    shortcut=None,
+                    enabled=True,
+                )
             )
-        )
-        items.append(
-            CommandPaletteItem(
-                id="extract_archive",
-                label="Extract archive",
-                shortcut=None,
-                enabled=single_target_entry.kind == "file"
-                and is_supported_archive_path(single_target_entry.path),
+            items.append(
+                CommandPaletteItem(
+                    id="extract_archive",
+                    label="Extract archive",
+                    shortcut=None,
+                    enabled=single_target_entry.kind == "file"
+                    and is_supported_archive_path(single_target_entry.path),
+                )
             )
-        )
         items.append(
             CommandPaletteItem(
                 id="open_in_editor",
@@ -383,7 +413,7 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                 enabled=single_target_entry.kind == "file",
             )
         )
-    elif has_target:
+    elif has_target and not is_search_workspace:
         items.append(
             CommandPaletteItem(
                 id="compress_as_zip",
@@ -402,23 +432,25 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                 enabled=True,
             )
         )
+        if not is_search_workspace:
+            items.append(
+                CommandPaletteItem(
+                    id="delete_targets",
+                    label="Move to trash",
+                    shortcut="d",
+                    enabled=True,
+                )
+            )
+
+    if not is_search_workspace:
         items.append(
             CommandPaletteItem(
-                id="delete_targets",
-                label="Move to trash",
-                shortcut="d",
-                enabled=True,
+                id="empty_trash",
+                label="Empty trash",
+                shortcut=None,
+                enabled=_is_empty_trash_supported(),
             )
         )
-
-    items.append(
-        CommandPaletteItem(
-            id="empty_trash",
-            label="Empty trash",
-            shortcut=None,
-            enabled=_is_empty_trash_supported(),
-        )
-    )
 
     items.extend(
         [
@@ -426,25 +458,25 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                 id="open_file_manager",
                 label="Open in file manager",
                 shortcut="M",
-                enabled=True,
+                enabled=not is_search_workspace,
             ),
             CommandPaletteItem(
                 id="open_current_directory_in_gui_editor",
                 label="Open current directory in GUI editor",
                 shortcut=None,
-                enabled=True,
+                enabled=not is_search_workspace,
             ),
             CommandPaletteItem(
                 id="open_terminal",
                 label="Open terminal here",
                 shortcut="T",
-                enabled=True,
+                enabled=not is_search_workspace,
             ),
             CommandPaletteItem(
                 id="run_shell_command",
                 label="Run shell command",
                 shortcut="!",
-                enabled=True,
+                enabled=not is_search_workspace,
             ),
             CommandPaletteItem(
                 id="remove_bookmark" if current_path_is_bookmarked else "add_bookmark",
@@ -454,7 +486,7 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                     else "Bookmark this directory"
                 ),
                 shortcut="B",
-                enabled=True,
+                enabled=not is_search_workspace,
             ),
             CommandPaletteItem(
                 id="toggle_hidden",
@@ -478,17 +510,19 @@ def _build_command_palette_items(state: AppState) -> tuple[CommandPaletteItem, .
                 id="create_file",
                 label="Create file",
                 shortcut="n",
-                enabled=True,
+                enabled=not is_search_workspace,
             ),
             CommandPaletteItem(
                 id="create_dir",
                 label="Create directory",
                 shortcut="N",
-                enabled=True,
+                enabled=not is_search_workspace,
             )
         ]
     )
 
+    if is_search_workspace:
+        return tuple(item for item in items if item.id in SEARCH_WORKSPACE_COMMAND_IDS)
     return tuple(items)
 
 

--- a/src/zivo/state/input_browsing.py
+++ b/src/zivo/state/input_browsing.py
@@ -1,5 +1,7 @@
 """Browsing-mode key bindings and dispatcher."""
 
+from zivo.windows_paths import is_search_workspace_path
+
 from .actions import (
     Action,
     ActivateNextTab,
@@ -125,6 +127,27 @@ BROWSING_KEYMAP = {
     "shift+tab": "activate_previous_tab",
 }
 
+SEARCH_WORKSPACE_BLOCKED_COMMANDS = frozenset(
+    {
+        "begin_file_search",
+        "begin_grep_search",
+        "reload_directory",
+        "toggle_transfer_mode",
+        "begin_rename",
+        "begin_shell_command",
+        "delete_targets",
+        "permanent_delete_targets",
+        "open_terminal",
+        "open_terminal_window",
+        "open_file_manager",
+        "cut_targets",
+        "paste_clipboard",
+        "toggle_bookmark",
+        "create_file",
+        "create_dir",
+    }
+)
+
 
 def dispatch_browsing_input(
     state: AppState,
@@ -154,6 +177,11 @@ def dispatch_browsing_input(
 
     command = BROWSING_KEYMAP.get(key)
     if command is not None:
+        if (
+            is_search_workspace_path(state.current_path)
+            and command in SEARCH_WORKSPACE_BLOCKED_COMMANDS
+        ):
+            return warn("Unavailable in search workspace")
         handler = BROWSING_COMMAND_DISPATCH.get(command)
         if handler is not None:
             return handler(state, ctx)

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -17,6 +17,7 @@ from zivo.models import (
     StatusBarState,
 )
 from zivo.platform_support import is_split_terminal_supported
+from zivo.windows_paths import is_search_workspace_path
 
 from .models import AppState
 from .reducer_config import (
@@ -204,6 +205,15 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
                 "[ ] focus | y copy-to-pane | m move-to-pane | p/Esc close | q quit",
                 "Space select | c copy | x cut | v paste | d delete | r rename | z undo",
                 ". hidden | N new-dir | : palette",
+            )
+        )
+    if is_search_workspace_path(state.current_path):
+        return HelpBarState(
+            (
+                "enter open | e edit | O gui editor | i info | "
+                "/ filter | s sort | . hidden | [ ] bk/fwd | q quit",
+                "space select | c copy | z undo | ctrl+j/k prv",
+                ": palette",
             )
         )
     if state.config.help_bar.browsing:

--- a/src/zivo/ui/current_path_bar.py
+++ b/src/zivo/ui/current_path_bar.py
@@ -13,9 +13,9 @@ from textual.widgets import Static
 from zivo.windows_paths import (
     WINDOWS_DRIVES_LABEL,
     display_path,
+    is_search_workspace_path,
     is_windows_drives_root,
     is_windows_path,
-    is_search_workspace_path,
 )
 
 

--- a/tests/input_dispatch_browsing_cases.py
+++ b/tests/input_dispatch_browsing_cases.py
@@ -3,7 +3,25 @@
 import os
 
 from .input_dispatch_helpers import *
-from .state_test_helpers import reduce_state
+from .state_test_helpers import entry, pane, reduce_state
+
+SEARCH_WORKSPACE_PATH = (
+    "search://readme?target=files&hidden=false&root=%2Fhome%2Ftadashi%2Fdevelop%2Fzivo"
+)
+
+
+def build_search_workspace_state():
+    result_path = "/home/tadashi/develop/zivo/README.md"
+    state = build_initial_app_state()
+    return replace(
+        state,
+        current_path=SEARCH_WORKSPACE_PATH,
+        current_pane=pane(
+            SEARCH_WORKSPACE_PATH,
+            (entry(result_path, "file"),),
+            cursor_path=result_path,
+        ),
+    )
 
 
 def _reduce_state(state, action):
@@ -82,6 +100,58 @@ def test_browsing_k_dispatches_move_cursor() -> None:
             "/home/tadashi/develop/zivo/README.md",
         ),
     )
+
+
+def test_search_workspace_keeps_allowed_browsing_shortcuts() -> None:
+    state = build_search_workspace_state()
+
+    assert dispatch_key_input(state, key="c") == (
+        SetNotification(None),
+        CopyTargets(("/home/tadashi/develop/zivo/README.md",)),
+    )
+    assert dispatch_key_input(state, key="z") == (
+        SetNotification(None),
+        UndoLastOperation(),
+    )
+    assert dispatch_key_input(state, key=":") == (
+        SetNotification(None),
+        BeginCommandPalette(),
+    )
+
+
+def test_search_workspace_blocks_unavailable_browsing_shortcuts() -> None:
+    state = build_search_workspace_state()
+
+    for key in (
+        "x",
+        "v",
+        "d",
+        "D",
+        "delete",
+        "shift+delete",
+        "r",
+        "f",
+        "g",
+        "n",
+        "N",
+        "t",
+        "T",
+        "R",
+        "p",
+        "!",
+        "B",
+        "M",
+    ):
+        actions = dispatch_key_input(state, key=key)
+
+        assert actions == (
+            SetNotification(
+                NotificationState(
+                    level="warning",
+                    message="Unavailable in search workspace",
+                )
+            ),
+        )
 
 
 def test_browsing_prefix_key_starts_multi_key_sequence(monkeypatch) -> None:

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -5,9 +5,11 @@ from stat import S_IFREG
 import zivo.state.selectors as selectors_module
 from tests.state_test_helpers import entry, pane, reduce_state
 from zivo.models import (
+    ActionsConfig,
     AppConfig,
     BookmarkConfig,
     CreateZipArchiveRequest,
+    CustomActionConfig,
     DisplayConfig,
     EditorConfig,
     ExtractArchiveRequest,
@@ -88,6 +90,24 @@ from zivo.state.selectors import (
     compute_current_pane_visible_window,
     select_input_dialog_state,
 )
+
+SEARCH_WORKSPACE_PATH = (
+    "search://readme?target=files&hidden=false&root=%2Fhome%2Ftadashi%2Fdevelop%2Fzivo"
+)
+
+
+def build_search_workspace_state():
+    result_path = "/home/tadashi/develop/zivo/README.md"
+    state = build_initial_app_state()
+    return replace(
+        state,
+        current_path=SEARCH_WORKSPACE_PATH,
+        current_pane=pane(
+            SEARCH_WORKSPACE_PATH,
+            (entry(result_path, "file"),),
+            cursor_path=result_path,
+        ),
+    )
 
 
 def _reduce_state(state, action):
@@ -1293,6 +1313,22 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
     )
 
 
+def test_select_help_bar_for_search_workspace_shows_available_actions_only() -> None:
+    state = build_search_workspace_state()
+
+    help_state = select_help_bar_state(state)
+
+    assert help_state.lines == (
+        "enter open | e edit | O gui editor | i info | "
+        "/ filter | s sort | . hidden | [ ] bk/fwd | q quit",
+        "space select | c copy | z undo | ctrl+j/k prv",
+        ": palette",
+    )
+    assert "x cut" not in help_state.text
+    assert "d delete" not in help_state.text
+    assert "f find" not in help_state.text
+
+
 def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> None:
     state = _reduce_state(build_initial_app_state(), ToggleTransferMode())
 
@@ -1349,6 +1385,70 @@ def test_select_command_palette_state_marks_selected_and_enabled_items() -> None
     assert palette_state.items[0].enabled is True
     assert any(item.label == "Go back" and not item.enabled for item in palette_state.items)
     assert any(item.label == "Go forward" and not item.enabled for item in palette_state.items)
+
+
+def test_command_palette_items_for_search_workspace_are_limited_to_safe_actions() -> None:
+    state = replace(
+        build_search_workspace_state(),
+        config=AppConfig(
+            bookmarks=BookmarkConfig(paths=(SEARCH_WORKSPACE_PATH,)),
+            actions=ActionsConfig(
+                custom=(CustomActionConfig(name="Format project", command=("format",)),)
+            ),
+        ),
+        command_palette=CommandPaletteState(),
+    )
+
+    labels = [
+        item.label
+        for item in command_palette_module.get_command_palette_items(state)
+    ]
+
+    assert "History search" in labels
+    assert "Show bookmarks" in labels
+    assert "Go back" in labels
+    assert "Go forward" in labels
+    assert "Go to path" in labels
+    assert "Go to home directory" in labels
+    assert "Undo last file operation" in labels
+    assert "New tab" in labels
+    assert "Next tab" in labels
+    assert "Previous tab" in labels
+    assert "Close current tab" in labels
+    assert "Exit" in labels
+    assert "Select all" in labels
+    assert "Show attributes" in labels
+    assert "Open in editor" in labels
+    assert "Open in GUI editor" in labels
+    assert "Copy path" in labels
+    assert "Show hidden files" in labels
+    assert "About zivo" in labels
+    assert "Edit config" in labels
+
+    assert "Find files" not in labels
+    assert "Grep search" not in labels
+    assert "Reload directory" not in labels
+    assert "Toggle transfer mode" not in labels
+    assert "Replace text in selected files" not in labels
+    assert "Replace text in found files" not in labels
+    assert "Replace text in grep results" not in labels
+    assert "Grep in selected files" not in labels
+    assert "Grep and replace in selected files" not in labels
+    assert "Format project" not in labels
+    assert "Rename" not in labels
+    assert "Make symlink" not in labels
+    assert "Compress as zip" not in labels
+    assert "Extract archive" not in labels
+    assert "Move to trash" not in labels
+    assert "Empty trash" not in labels
+    assert "Open in file manager" not in labels
+    assert "Open current directory in GUI editor" not in labels
+    assert "Open terminal here" not in labels
+    assert "Run shell command" not in labels
+    assert "Remove bookmark" not in labels
+    assert "Bookmark this directory" not in labels
+    assert "Create file" not in labels
+    assert "Create directory" not in labels
 
 
 def test_select_command_palette_state_shows_single_target_commands_when_filtered() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "zivo"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "send2trash" },


### PR DESCRIPTION
## Summary
- Adds a dedicated help bar for the virtual search workspace opened from file search with Ctrl+w.
- Hides unavailable or unsafe commands from the search workspace command palette.
- Blocks unavailable direct shortcuts in the search workspace while keeping navigation, copy, info, editor, undo, hidden toggle, and palette access.

## Tests
- uv run ruff check .
- uv run pytest

Closes #991