### PR TITLE
Fix #1000 Avoid buffering grep JSON output

### DIFF
--- a/src/zivo/services/grep_search.py
+++ b/src/zivo/services/grep_search.py
@@ -83,14 +83,16 @@ class LiveGrepSearchService:
             raise OSError(f"Not found: {self.rg_executable}") from error
 
         try:
-            stdout_lines: list[str] = []
+            results: list[GrepSearchResultState] = []
             assert process.stdout is not None
             for line in process.stdout:
                 if is_cancelled is not None and is_cancelled():
                     process.kill()
                     process.wait()
                     return ()
-                stdout_lines.append(line)
+                result = self._parse_result_line(root, line)
+                if result is not None:
+                    results.append(result)
             stderr_text = ""
             if process.stderr is not None:
                 stderr_text = process.stderr.read()
@@ -106,7 +108,7 @@ class LiveGrepSearchService:
             if self._is_nonfatal_ripgrep_error(return_code, stderr_text, stripped_query):
                 return tuple(
                     sorted(
-                        self._parse_results(root, stdout_lines),
+                        results,
                         key=lambda result: (result.display_path.casefold(), result.line_number),
                     )
                 )
@@ -114,7 +116,6 @@ class LiveGrepSearchService:
                 raise InvalidGrepSearchQueryError(message)
             raise OSError(message)
 
-        results = self._parse_results(root, stdout_lines)
         return tuple(
             sorted(
                 results,
@@ -153,41 +154,36 @@ class LiveGrepSearchService:
         command.append(".")
         return command
 
-    def _parse_results(
+    def _parse_result_line(
         self,
         root: Path,
-        stdout_lines: list[str],
-    ) -> list[GrepSearchResultState]:
-        results: list[GrepSearchResultState] = []
-        for line in stdout_lines:
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if payload.get("type") != "match":
-                continue
-            data = payload.get("data", {})
-            path_text = data.get("path", {}).get("text")
-            raw_line = data.get("lines", {}).get("text", "")
-            line_number = data.get("line_number")
-            column_number = _first_submatch_column(data.get("submatches"))
-            if not isinstance(path_text, str) or not isinstance(raw_line, str):
-                continue
-            if not isinstance(line_number, int):
-                continue
-            absolute_path = Path(path_text)
-            if not absolute_path.is_absolute():
-                absolute_path = (root / path_text).resolve()
-            results.append(
-                GrepSearchResultState(
-                    path=str(absolute_path),
-                    display_path=self._relative_display_path(root, absolute_path),
-                    line_number=line_number,
-                    line_text=raw_line.rstrip("\r\n"),
-                    column_number=column_number,
-                )
-            )
-        return results
+        line: str,
+    ) -> GrepSearchResultState | None:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        if payload.get("type") != "match":
+            return None
+        data = payload.get("data", {})
+        path_text = data.get("path", {}).get("text")
+        raw_line = data.get("lines", {}).get("text", "")
+        line_number = data.get("line_number")
+        column_number = _first_submatch_column(data.get("submatches"))
+        if not isinstance(path_text, str) or not isinstance(raw_line, str):
+            return None
+        if not isinstance(line_number, int):
+            return None
+        absolute_path = Path(path_text)
+        if not absolute_path.is_absolute():
+            absolute_path = (root / path_text).resolve()
+        return GrepSearchResultState(
+            path=str(absolute_path),
+            display_path=self._relative_display_path(root, absolute_path),
+            line_number=line_number,
+            line_text=raw_line.rstrip("\r\n"),
+            column_number=column_number,
+        )
 
     @staticmethod
     def _relative_display_path(root: Path, path: Path) -> str:

--- a/tests/test_services_grep_search.py
+++ b/tests/test_services_grep_search.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 
@@ -13,6 +14,115 @@ skip_if_windows_permission_semantics = pytest.mark.skipif(
     shutil.which("rg") is None or os.name == "nt",
     reason="permission-denied grep coverage is not reliable on native Windows runners",
 )
+
+
+class _FakeTextStream:
+    def __init__(self, lines: tuple[str, ...] = (), read_text: str = "") -> None:
+        self._lines = lines
+        self._read_text = read_text
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def read(self) -> str:
+        return self._read_text
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeGrepProcess:
+    def __init__(
+        self,
+        stdout_lines: tuple[str, ...],
+        *,
+        return_code: int = 0,
+        stderr_text: str = "",
+    ) -> None:
+        self.stdout = _FakeTextStream(stdout_lines)
+        self.stderr = _FakeTextStream(read_text=stderr_text)
+        self.return_code = return_code
+        self.killed = False
+
+    def wait(self) -> int:
+        return self.return_code
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def _rg_match_line(
+    path: str,
+    *,
+    line_number: int,
+    text: str,
+    start: int = 0,
+) -> str:
+    return json.dumps(
+        {
+            "type": "match",
+            "data": {
+                "path": {"text": path},
+                "lines": {"text": text},
+                "line_number": line_number,
+                "submatches": [{"start": start}],
+            },
+        }
+    )
+
+
+def test_live_grep_search_service_parses_stdout_lines_as_they_are_read(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    process = _FakeGrepProcess(
+        (
+            _rg_match_line("z.txt", line_number=2, text="TODO: z\n", start=6),
+            json.dumps({"type": "begin", "data": {"path": {"text": "z.txt"}}}),
+            "{not json}\n",
+            _rg_match_line("a.txt", line_number=1, text="TODO: a\r\n", start=0),
+        )
+    )
+
+    monkeypatch.setattr(
+        "zivo.services.grep_search.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+
+    results = LiveGrepSearchService().search(str(root), "todo", show_hidden=False)
+
+    assert [result.display_label for result in results] == [
+        "a.txt:1: TODO: a",
+        "z.txt:2: TODO: z",
+    ]
+    assert [result.column_number for result in results] == [1, 7]
+    assert process.stdout.closed
+    assert process.stderr.closed
+
+
+def test_live_grep_search_service_keeps_nonfatal_error_partial_results(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    process = _FakeGrepProcess(
+        (_rg_match_line("README.md", line_number=3, text="TODO\n"),),
+        return_code=2,
+        stderr_text="",
+    )
+
+    monkeypatch.setattr(
+        "zivo.services.grep_search.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+
+    results = LiveGrepSearchService().search(str(root), "todo", show_hidden=False)
+
+    assert [result.display_label for result in results] == ["README.md:3: TODO"]
 
 
 @skip_if_no_rg


### PR DESCRIPTION
## Summary

- Parse `rg --json` stdout one line at a time in `LiveGrepSearchService`
- Avoid storing raw JSON output lines before converting matches to `GrepSearchResultState`
- Preserve existing sorting, cancellation, invalid regex, and nonfatal ripgrep error behavior
- Add service coverage for mixed match/non-match/invalid JSON output and nonfatal partial results

Fixes #1000

## Tests

- `uv run pytest tests/test_services_grep_search.py -q`
- `uv run pytest tests/test_state_reducer_palette_search.py -q`
- `uv run ruff check .`
- `uv run pytest`