### PR TITLE
perf: reduce side pane hover rerendering

### DIFF
--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -17,6 +17,7 @@ from zivo.models.shell_data import ChildPaneViewState
 
 from .pane_rendering import (
     FILE_TYPE_COMPONENT_CLASSES,
+    _FileEntryLabelCache,
     _guess_preview_lexer,
     _render_file_entries,
     _resolve_component_styles,
@@ -64,6 +65,7 @@ class ChildPane(Vertical):
         self._last_render_signature: object | None = None
         self._last_clicked_path: str | None = None
         self._hovered_path: str | None = None
+        self._label_cache = _FileEntryLabelCache()
         self._chafa_cached_content: str | None = None
         self._last_chafa_width: int = 0
 
@@ -148,17 +150,25 @@ class ChildPane(Vertical):
             return
         meta = event.style.meta
         path = meta.get("entry_path")
-        new_path = str(path) if path is not None else None
+        if path is None:
+            return
+        new_path = str(path)
+        if not self._label_cache.contains_path(new_path):
+            return
         if new_path != self._hovered_path:
+            previous_path = self._hovered_path
             self._hovered_path = new_path
-            self._refresh_rendered_content(force=True)
+            if not self._refresh_hovered_labels(previous_path, new_path):
+                self._refresh_rendered_content(force=True)
 
     def on_leave(self, _event: events.Leave) -> None:
         if self._state.is_preview:
             return
         if self._hovered_path is not None:
+            previous_path = self._hovered_path
             self._hovered_path = None
-            self._refresh_rendered_content(force=True)
+            if not self._refresh_hovered_labels(previous_path, None):
+                self._refresh_rendered_content(force=True)
 
     async def set_state(self, state: ChildPaneViewState) -> None:
         if state == self._state:
@@ -273,7 +283,7 @@ class ChildPane(Vertical):
         ):
             return True
         widget.update(
-            _render_file_entries(
+            self._label_cache.rebuild(
                 self._state.entries,
                 render_width,
                 self._ft_styles,
@@ -284,6 +294,32 @@ class ChildPane(Vertical):
         )
         self._last_render_width = render_width
         self._last_render_signature = render_signature
+        return True
+
+    def _refresh_hovered_labels(
+        self, previous_path: str | None, next_path: str | None
+    ) -> bool:
+        try:
+            widget = self._list_widget()
+        except NoMatches:
+            return False
+        render_width = max(0, widget.size.width - SidePane.ENTRY_HORIZONTAL_PADDING)
+        if render_width <= 0:
+            return False
+        if render_width != self._last_render_width:
+            return False
+        if self._render_signature(self._state) != self._last_render_signature:
+            return False
+        rendered = self._label_cache.update_hover(
+            previous_path,
+            next_path,
+            self._ft_styles,
+            selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+            selected_cut_style=self.SELECTED_CUT_STYLE,
+        )
+        if rendered is None:
+            return False
+        widget.update(rendered)
         return True
 
     def _list_widget(self) -> Static:

--- a/src/zivo/ui/pane_rendering.py
+++ b/src/zivo/ui/pane_rendering.py
@@ -253,3 +253,83 @@ def _render_file_entries(
             for entry in entries
         ]
     )
+
+
+def _join_file_labels(labels: Sequence[Text]) -> Text:
+    """Join pre-rendered file labels into the pane's single Text block."""
+
+    if not labels:
+        return Text()
+    return Text("\n").join(labels)
+
+
+class _FileEntryLabelCache:
+    """Cache rendered side-pane labels for targeted hover updates."""
+
+    def __init__(self) -> None:
+        self.entries: tuple[PaneEntry, ...] = ()
+        self.render_width = 0
+        self.labels: list[Text] = []
+        self.path_to_index: dict[str, int] = {}
+
+    def contains_path(self, path: str) -> bool:
+        return path in self.path_to_index
+
+    def rebuild(
+        self,
+        entries: Sequence[PaneEntry],
+        render_width: int,
+        styles: dict[str, Style],
+        *,
+        selected_directory_style: str,
+        selected_cut_style: str,
+        hovered_path: str | None = None,
+    ) -> Text:
+        self.entries = tuple(entries)
+        self.render_width = render_width
+        self.labels = [
+            _render_file_label(
+                entry,
+                render_width,
+                styles,
+                selected_directory_style=selected_directory_style,
+                selected_cut_style=selected_cut_style,
+                hovered_path=hovered_path,
+            )
+            for entry in self.entries
+        ]
+        self.path_to_index = {}
+        for index, entry in enumerate(self.entries):
+            self.path_to_index.setdefault(entry.path, index)
+        return self.renderable()
+
+    def renderable(self) -> Text:
+        return _join_file_labels(self.labels)
+
+    def update_hover(
+        self,
+        previous_path: str | None,
+        next_path: str | None,
+        styles: dict[str, Style],
+        *,
+        selected_directory_style: str,
+        selected_cut_style: str,
+    ) -> Text | None:
+        changed_indexes = {
+            self.path_to_index[path]
+            for path in (previous_path, next_path)
+            if path is not None and path in self.path_to_index
+        }
+        if not changed_indexes:
+            return None
+
+        for index in sorted(changed_indexes):
+            self.labels[index] = _render_file_label(
+                self.entries[index],
+                self.render_width,
+                styles,
+                selected_directory_style=selected_directory_style,
+                selected_cut_style=selected_cut_style,
+                hovered_path=next_path,
+            )
+        return self.renderable()

--- a/src/zivo/ui/side_pane.py
+++ b/src/zivo/ui/side_pane.py
@@ -14,6 +14,7 @@ from zivo.models.shell_data import PaneEntry
 
 from .pane_rendering import (
     FILE_TYPE_COMPONENT_CLASSES,
+    _FileEntryLabelCache,
     _render_file_entries,
     _resolve_component_styles,
 )
@@ -50,6 +51,7 @@ class SidePane(Vertical):
         self._last_render_width = 0
         self._last_clicked_path: str | None = None
         self._hovered_path: str | None = None
+        self._label_cache = _FileEntryLabelCache()
 
     @property
     def list_view_id(self) -> str | None:
@@ -93,15 +95,23 @@ class SidePane(Vertical):
     def on_mouse_move(self, event: events.MouseMove) -> None:
         meta = event.style.meta
         path = meta.get("entry_path")
-        new_path = str(path) if path is not None else None
+        if path is None:
+            return
+        new_path = str(path)
+        if not self._label_cache.contains_path(new_path):
+            return
         if new_path != self._hovered_path:
+            previous_path = self._hovered_path
             self._hovered_path = new_path
-            self._refresh_rendered_labels(force=True)
+            if not self._refresh_hovered_labels(previous_path, new_path):
+                self._refresh_rendered_labels(force=True)
 
     def on_leave(self, _event: events.Leave) -> None:
         if self._hovered_path is not None:
+            previous_path = self._hovered_path
             self._hovered_path = None
-            self._refresh_rendered_labels(force=True)
+            if not self._refresh_hovered_labels(previous_path, None):
+                self._refresh_rendered_labels(force=True)
 
     async def set_entries(self, entries: Sequence[PaneEntry]) -> None:
         """Replace the rendered entries without remounting the pane."""
@@ -113,7 +123,7 @@ class SidePane(Vertical):
         content = self._content_widget()
         render_width = self._entry_width(content)
         content.update(
-            _render_file_entries(
+            self._label_cache.rebuild(
                 next_entries,
                 render_width,
                 self._ft_styles,
@@ -134,7 +144,7 @@ class SidePane(Vertical):
         if render_width <= 0 or (not force and render_width == self._last_render_width):
             return
         content.update(
-            _render_file_entries(
+            self._label_cache.rebuild(
                 self._entries,
                 render_width,
                 self._ft_styles,
@@ -144,6 +154,30 @@ class SidePane(Vertical):
             )
         )
         self._last_render_width = render_width
+
+    def _refresh_hovered_labels(
+        self, previous_path: str | None, next_path: str | None
+    ) -> bool:
+        try:
+            content = self._content_widget()
+        except NoMatches:
+            return False
+        render_width = self._entry_width(content)
+        if render_width <= 0:
+            return False
+        if render_width != self._last_render_width:
+            return False
+        rendered = self._label_cache.update_hover(
+            previous_path,
+            next_path,
+            self._ft_styles,
+            selected_directory_style=self.SELECTED_DIRECTORY_STYLE,
+            selected_cut_style=self.SELECTED_CUT_STYLE,
+        )
+        if rendered is None:
+            return False
+        content.update(rendered)
+        return True
 
     def _content_widget(self) -> Static:
         return self.query_one(f"#{self.list_view_id}", Static)

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -7,9 +7,11 @@ from rich.text import Text
 from textual.widgets import DataTable
 
 from zivo.models import ChildPaneViewState, CurrentPaneRowUpdate, CurrentSummaryState, PaneEntry
+from zivo.ui.pane_rendering import _FileEntryLabelCache
 from zivo.ui.panes import (
     ChildPane,
     MainPane,
+    SidePane,
     _ft_resolve_style,
     _guess_preview_lexer,
     _render_file_label,
@@ -326,6 +328,87 @@ def test_render_cell_selected_entry() -> None:
     )
     assert result.plain == "file.txt"
     assert result.style == styles["ft-selected"]
+
+
+def test_file_entry_label_cache_updates_only_changed_hover_rows(monkeypatch) -> None:
+    styles = _style_map()
+    entries = tuple(
+        PaneEntry(f"file-{index}.txt", "file", path=f"/path/file-{index}.txt")
+        for index in range(100)
+    )
+    cache = _FileEntryLabelCache()
+    cache.rebuild(
+        entries,
+        40,
+        styles,
+        selected_directory_style="ft-directory-sel",
+        selected_cut_style="ft-cut",
+    )
+
+    calls: list[str] = []
+
+    def counting_render_file_label(
+        entry,
+        render_width,
+        styles,
+        *,
+        selected_directory_style,
+        selected_cut_style,
+        hovered_path=None,
+    ):
+        calls.append(entry.path)
+        return _render_file_label(
+            entry,
+            render_width,
+            styles,
+            selected_directory_style=selected_directory_style,
+            selected_cut_style=selected_cut_style,
+            hovered_path=hovered_path,
+        )
+
+    monkeypatch.setattr(
+        "zivo.ui.pane_rendering._render_file_label",
+        counting_render_file_label,
+    )
+
+    rendered = cache.update_hover(
+        None,
+        "/path/file-10.txt",
+        styles,
+        selected_directory_style="ft-directory-sel",
+        selected_cut_style="ft-cut",
+    )
+
+    assert rendered is not None
+    assert calls == ["/path/file-10.txt"]
+
+    calls.clear()
+    rendered = cache.update_hover(
+        "/path/file-10.txt",
+        "/path/file-11.txt",
+        styles,
+        selected_directory_style="ft-directory-sel",
+        selected_cut_style="ft-cut",
+    )
+
+    assert rendered is not None
+    assert calls == ["/path/file-10.txt", "/path/file-11.txt"]
+
+
+def test_side_pane_mouse_move_without_entry_meta_does_not_refresh() -> None:
+    pane = SidePane(
+        "Parent",
+        (PaneEntry("file.txt", "file", path="/path/file.txt"),),
+        id="parent-pane",
+    )
+    pane._refresh_hovered_labels = Mock(return_value=True)  # type: ignore[method-assign]
+    pane._refresh_rendered_labels = Mock()  # type: ignore[method-assign]
+    event = SimpleNamespace(style=SimpleNamespace(meta={}))
+
+    pane.on_mouse_move(event)
+
+    pane._refresh_hovered_labels.assert_not_called()
+    pane._refresh_rendered_labels.assert_not_called()
 
 
 def test_style_without_background_keeps_foreground_and_text_attributes() -> None:


### PR DESCRIPTION
## Summary
- add cached side-pane label rendering for targeted hover updates
- update parent and child pane list hover handling to avoid full label regeneration on mouse move
- keep click/double-click and visual styling behavior unchanged

Closes #1001

## Tests
- `uv run pytest tests/test_ui_panes.py -q`
- `uv run pytest tests/test_app.py -k large_directory_smoke_with_1000_entries -q`
- `uv run ruff check .`
- `uv run pytest`