### PR TITLE
perf: reduce directory size selector cache lookups

### DIFF
--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -25,12 +25,13 @@ from .models import (
 )
 from .selectors_shared import (
     SIDE_PANE_SORT,
+    _directory_size_cache_by_path,
     _find_current_cursor_index,
     _format_child_preview_title,
     _format_current_entry_name_detail,
-    _format_entry_size_label,
+    _format_entry_size_label_from_cache,
     _format_permissions_detail_label,
-    _format_side_pane_name_detail,
+    _format_side_pane_name_detail_from_cache,
     _format_sort_label,
     _format_tab_label,
     _select_active_app_theme,
@@ -508,15 +509,16 @@ def _select_current_pane_row_updates(
     changed_paths: tuple[str, ...],
 ) -> tuple[CurrentPaneRowUpdate, ...]:
     changed_path_set = frozenset(changed_paths)
+    cache_by_path = _directory_size_cache_by_path(directory_size_cache)
     return tuple(
         CurrentPaneRowUpdate(
             path=entry.path,
             entry=_to_pane_entry(
                 entry,
                 name_detail=_format_current_entry_name_detail(entry),
-                size_label_override=_format_entry_size_label(
+                size_label_override=_format_entry_size_label_from_cache(
                     entry,
-                    directory_size_cache,
+                    cache_by_path,
                     display_directory_sizes=display_directory_sizes,
                 ),
                 selected=entry.path in selected_paths,
@@ -537,12 +539,13 @@ def _select_current_pane_size_updates(
     changed_paths: tuple[str, ...],
 ) -> tuple[CurrentPaneSizeUpdate, ...]:
     changed_path_set = frozenset(changed_paths)
+    cache_by_path = _directory_size_cache_by_path(directory_size_cache)
     return tuple(
         CurrentPaneSizeUpdate(
             path=entry.path,
-            size_label=_format_entry_size_label(
+            size_label=_format_entry_size_label_from_cache(
                 entry,
-                directory_size_cache,
+                cache_by_path,
                 display_directory_sizes=display_directory_sizes,
             ),
             row_index=row_index,
@@ -571,13 +574,14 @@ def _select_current_pane_entries(
     selected_paths: frozenset[str],
     cut_paths: frozenset[str],
 ) -> tuple[PaneEntry, ...]:
+    cache_by_path = _directory_size_cache_by_path(directory_size_cache)
     return tuple(
         _to_pane_entry(
             entry,
             name_detail=_format_current_entry_name_detail(entry),
-            size_label_override=_format_entry_size_label(
+            size_label_override=_format_entry_size_label_from_cache(
                 entry,
-                directory_size_cache,
+                cache_by_path,
                 display_directory_sizes=display_directory_sizes,
             ),
             selected=entry.path in selected_paths,
@@ -595,12 +599,13 @@ def _select_side_pane_entries(
     selected_path: str | None,
     cut_paths: frozenset[str],
 ) -> tuple[PaneEntry, ...]:
+    cache_by_path = _directory_size_cache_by_path(directory_size_cache)
     return tuple(
         _to_pane_entry(
             entry,
-            name_detail=_format_side_pane_name_detail(
+            name_detail=_format_side_pane_name_detail_from_cache(
                 entry,
-                directory_size_cache,
+                cache_by_path,
                 display_directory_sizes=display_directory_sizes,
             ),
             selected=entry.path == selected_path,

--- a/src/zivo/state/selectors_shared.py
+++ b/src/zivo/state/selectors_shared.py
@@ -718,11 +718,24 @@ def _format_entry_size_label(
     *,
     display_directory_sizes: bool,
 ) -> str:
+    return _format_entry_size_label_from_cache(
+        entry,
+        _directory_size_cache_by_path(directory_size_cache),
+        display_directory_sizes=display_directory_sizes,
+    )
+
+
+def _format_entry_size_label_from_cache(
+    entry: DirectoryEntryState,
+    cache_by_path: dict[str, DirectorySizeCacheEntry],
+    *,
+    display_directory_sizes: bool,
+) -> str:
     if entry.kind != "dir":
         return _format_size_label(entry.size_bytes)
     if not display_directory_sizes:
         return "-"
-    cached_entry = _directory_size_cache_by_path(directory_size_cache).get(entry.path)
+    cached_entry = cache_by_path.get(entry.path)
     if cached_entry is None or cached_entry.status == "failed":
         return "-"
     if cached_entry.status == "pending":
@@ -736,11 +749,24 @@ def _format_side_pane_name_detail(
     *,
     display_directory_sizes: bool,
 ) -> str | None:
+    return _format_side_pane_name_detail_from_cache(
+        entry,
+        _directory_size_cache_by_path(directory_size_cache),
+        display_directory_sizes=display_directory_sizes,
+    )
+
+
+def _format_side_pane_name_detail_from_cache(
+    entry: DirectoryEntryState,
+    cache_by_path: dict[str, DirectorySizeCacheEntry],
+    *,
+    display_directory_sizes: bool,
+) -> str | None:
     if entry.kind != "dir":
         return None
-    size_label = _format_entry_size_label(
+    size_label = _format_entry_size_label_from_cache(
         entry,
-        directory_size_cache,
+        cache_by_path,
         display_directory_sizes=display_directory_sizes,
     )
     if size_label == "-":


### PR DESCRIPTION
## Summary
- Reuse a single directory-size cache lookup map within pane selector loops
- Add cache-map based size label helpers while keeping existing tuple-based wrappers
- Preserve existing directory size display behavior for ready/pending/failed cache entries

Closes #1002

## Tests
- `uv run ruff check src/zivo/state/selectors_shared.py src/zivo/state/selectors_panes.py`
- `uv run pytest tests/test_state_selectors_panes.py tests/test_state_selectors_ui.py -q`
- `uv run pytest tests/test_app.py -k "refresh or large_directory_smoke_with_1000_entries" -q`
- `uv run python scripts/benchmark_current_pane_projection.py --entries 10000 --iterations 200`
- `uv run ruff check .`
- `uv run pytest`

## Benchmark
```text
current pane projection benchmark (entries=10000, iterations=200, terminal_height=24)

mode      op                rendered_rows  mean_ms  p95_ms
--------  ----------------  -------------  -------  ------
full      cursor_move               10000     7.75    8.53
full      page_scroll               10000     7.61    8.42
full      selection_toggle          10000     8.27    9.11
full      directory_size_reflect    10000    12.00   13.21
viewport  cursor_move                  15     5.29    6.00
viewport  page_scroll                  15     5.40    6.10
viewport  selection_toggle             15     5.50    6.19
viewport  directory_size_reflect       15     5.46    6.12
```
