### PR TITLE
perf: avoid tuple allocation in file search

### DIFF
--- a/src/zivo/services/file_search.py
+++ b/src/zivo/services/file_search.py
@@ -119,35 +119,33 @@ class LiveFileSearchService:
                 return ()
             directory = stack.pop()
             try:
-                children = tuple(directory.iterdir())
+                for child in directory.iterdir():
+                    if is_cancelled is not None and is_cancelled():
+                        return ()
+                    if not show_hidden and child.name.startswith("."):
+                        continue
+                    is_dir = _is_walkable_directory(child)
+                    if is_dir:
+                        stack.append(child)
+                    if search_target == "directories" and not is_dir:
+                        continue
+                    if search_target == "files" and is_dir:
+                        continue
+                    if not parsed_query.matches(child.name):
+                        continue
+                    results.append(
+                        FileSearchResultState(
+                            path=str(child),
+                            display_path=child.relative_to(root).as_posix(),
+                            entry_type="directory" if is_dir else "file",
+                        )
+                    )
+
+                    if max_results is not None and len(results) >= max_results:
+                        results.sort(key=lambda result: result.display_path.casefold())
+                        return tuple(results)
             except (FileNotFoundError, PermissionError):
                 continue
-
-            for child in children:
-                if is_cancelled is not None and is_cancelled():
-                    return ()
-                if not show_hidden and child.name.startswith("."):
-                    continue
-                is_dir = _is_walkable_directory(child)
-                if is_dir:
-                    stack.append(child)
-                if search_target == "directories" and not is_dir:
-                    continue
-                if search_target == "files" and is_dir:
-                    continue
-                if not parsed_query.matches(child.name):
-                    continue
-                results.append(
-                    FileSearchResultState(
-                        path=str(child),
-                        display_path=child.relative_to(root).as_posix(),
-                        entry_type="directory" if is_dir else "file",
-                    )
-                )
-
-                if max_results is not None and len(results) >= max_results:
-                    results.sort(key=lambda result: result.display_path.casefold())
-                    return tuple(results)
 
         results.sort(key=lambda result: result.display_path.casefold())
         return tuple(results)


### PR DESCRIPTION
## Summary
- Stream `directory.iterdir()` directly in `LiveFileSearchService.search()` instead of materializing children into a tuple.
- Preserve existing cancellation, filtering, `max_results`, and final sorting behavior.

Closes #1008

## Tests
- `uv run ruff check src/zivo/services/file_search.py`
- `uv run pytest tests -k file_search`