### PR TITLE
Fix #1009 Avoid unnecessary grep result sorting

### DIFF
--- a/src/zivo/services/grep_search.py
+++ b/src/zivo/services/grep_search.py
@@ -84,6 +84,8 @@ class LiveGrepSearchService:
 
         try:
             results: list[GrepSearchResultState] = []
+            previous_sort_key: tuple[str, int] | None = None
+            results_are_sorted = True
             assert process.stdout is not None
             for line in process.stdout:
                 if is_cancelled is not None and is_cancelled():
@@ -92,6 +94,10 @@ class LiveGrepSearchService:
                     return ()
                 result = self._parse_result_line(root, line)
                 if result is not None:
+                    sort_key = _grep_result_sort_key(result)
+                    if previous_sort_key is not None and sort_key < previous_sort_key:
+                        results_are_sorted = False
+                    previous_sort_key = sort_key
                     results.append(result)
             stderr_text = ""
             if process.stderr is not None:
@@ -106,22 +112,12 @@ class LiveGrepSearchService:
         if return_code not in {0, 1}:
             message = stderr_text.strip() or "grep search failed"
             if self._is_nonfatal_ripgrep_error(return_code, stderr_text, stripped_query):
-                return tuple(
-                    sorted(
-                        results,
-                        key=lambda result: (result.display_path.casefold(), result.line_number),
-                    )
-                )
+                return _ordered_grep_results(results, results_are_sorted)
             if is_regex_grep_search_query(stripped_query):
                 raise InvalidGrepSearchQueryError(message)
             raise OSError(message)
 
-        return tuple(
-            sorted(
-                results,
-                key=lambda result: (result.display_path.casefold(), result.line_number),
-            )
-        )
+        return _ordered_grep_results(results, results_are_sorted)
 
     def _build_command(
         self,
@@ -251,3 +247,16 @@ def _first_submatch_column(submatches: object) -> int:
         if isinstance(start, int):
             return max(1, start + 1)
     return 1
+
+
+def _ordered_grep_results(
+    results: list[GrepSearchResultState],
+    results_are_sorted: bool,
+) -> tuple[GrepSearchResultState, ...]:
+    if results_are_sorted:
+        return tuple(results)
+    return tuple(sorted(results, key=_grep_result_sort_key))
+
+
+def _grep_result_sort_key(result: GrepSearchResultState) -> tuple[str, int]:
+    return (result.display_path.casefold(), result.line_number)

--- a/tests/test_services_grep_search.py
+++ b/tests/test_services_grep_search.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import os
 import shutil
@@ -101,6 +102,76 @@ def test_live_grep_search_service_parses_stdout_lines_as_they_are_read(
     assert [result.column_number for result in results] == [1, 7]
     assert process.stdout.closed
     assert process.stderr.closed
+
+
+def test_live_grep_search_service_skips_sort_for_ordered_stdout_lines(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    process = _FakeGrepProcess(
+        (
+            _rg_match_line("a.txt", line_number=1, text="TODO: a\n"),
+            _rg_match_line("a.txt", line_number=2, text="TODO: a2\n"),
+            _rg_match_line("z.txt", line_number=1, text="TODO: z\n"),
+        )
+    )
+    sorted_calls = 0
+
+    def counting_sorted(*args, **kwargs):
+        nonlocal sorted_calls
+        sorted_calls += 1
+        return builtins.sorted(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "zivo.services.grep_search.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr("zivo.services.grep_search.sorted", counting_sorted, raising=False)
+
+    results = LiveGrepSearchService().search(str(root), "todo", show_hidden=False)
+
+    assert [result.display_label for result in results] == [
+        "a.txt:1: TODO: a",
+        "a.txt:2: TODO: a2",
+        "z.txt:1: TODO: z",
+    ]
+    assert sorted_calls == 0
+
+
+def test_live_grep_search_service_sorts_when_stdout_order_regresses(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    process = _FakeGrepProcess(
+        (
+            _rg_match_line("z.txt", line_number=1, text="TODO: z\n"),
+            _rg_match_line("a.txt", line_number=1, text="TODO: a\n"),
+        )
+    )
+    sorted_calls = 0
+
+    def counting_sorted(*args, **kwargs):
+        nonlocal sorted_calls
+        sorted_calls += 1
+        return builtins.sorted(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "zivo.services.grep_search.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr("zivo.services.grep_search.sorted", counting_sorted, raising=False)
+
+    results = LiveGrepSearchService().search(str(root), "todo", show_hidden=False)
+
+    assert [result.display_label for result in results] == [
+        "a.txt:1: TODO: a",
+        "z.txt:1: TODO: z",
+    ]
+    assert sorted_calls == 1
 
 
 def test_live_grep_search_service_keeps_nonfatal_error_partial_results(


### PR DESCRIPTION
## Summary
- Track grep result sort keys while reading ripgrep JSON output.
- Skip `sorted()` when results are already ordered by `(display_path.casefold(), line_number)`.
- Reuse the same ordered-result helper for normal and nonfatal partial-result returns.

## Tests
- `uv run pytest tests -k grep_search`
- `uv run ruff check src/zivo/services/grep_search.py tests/test_services_grep_search.py`
- `uv run ruff check .`
- `uv run pytest`

Closes #1009
