### PR TITLE
perf: speed up MainPane row fallback lookup (#1011)

### DIFF
--- a/src/zivo/ui/main_pane.py
+++ b/src/zivo/ui/main_pane.py
@@ -105,6 +105,7 @@ class MainPane(Vertical):
         super().__init__(id=id, classes=classes)
         self._title = title
         self._entries = tuple(entries)
+        self._path_row_index = self._build_path_row_index(self._entries)
         self._summary = summary
         self._cursor_index = cursor_index
         self._cursor_visible = cursor_visible
@@ -188,6 +189,7 @@ class MainPane(Vertical):
 
         previous_entries = self._entries
         self._entries = next_entries
+        self._path_row_index = self._build_path_row_index(self._entries)
         self._cursor_index = cursor_index
         table = self.query_one(DataTable)
         if entries_changed:
@@ -276,6 +278,7 @@ class MainPane(Vertical):
             return
 
         self._entries = tuple(next_entries)
+        self._path_row_index = self._build_path_row_index(self._entries)
         table = self.query_one(DataTable)
         for row_key, entry in changed_rows:
             try:
@@ -312,6 +315,7 @@ class MainPane(Vertical):
             return
 
         self._entries = tuple(next_entries)
+        self._path_row_index = self._build_path_row_index(self._entries)
         table = self.query_one(DataTable)
         column_widths = self._allocate_column_widths(table)
         for row_key, entry in changed_rows:
@@ -406,16 +410,21 @@ class MainPane(Vertical):
     def _slot_row_key(index: int) -> str:
         return f"{MainPane.ROW_KEY_PREFIX}{index}"
 
+    @staticmethod
+    def _build_path_row_index(entries: Sequence[PaneEntry]) -> dict[str, int]:
+        path_row_index: dict[str, int] = {}
+        for index, entry in enumerate(entries):
+            if entry.path and entry.path not in path_row_index:
+                path_row_index[entry.path] = index
+        return path_row_index
+
     def _resolve_row_index(self, row_index: int, path: str) -> int | None:
         if 0 <= row_index < len(self._entries):
             if not path or self._entries[row_index].path == path:
                 return row_index
         if not path:
             return None
-        for index, entry in enumerate(self._entries):
-            if entry.path == path:
-                return index
-        return None
+        return self._path_row_index.get(path)
 
     def _build_row_cells(
         self,

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -621,6 +621,100 @@ def test_apply_size_updates_updates_only_target_slot() -> None:
     assert table.update_cell.call_args.args[1] == "size"
 
 
+def test_apply_size_updates_resolves_stale_row_index_by_path_index() -> None:
+    summary = CurrentSummaryState(item_count=3, selected_count=0, sort_label="Name")
+    entries = (
+        PaneEntry("a.txt", "file", path="/path/a.txt", size_label="1 B"),
+        PaneEntry("b.txt", "file", path="/path/b.txt", size_label="2 B"),
+        PaneEntry("c.txt", "file", path="/path/c.txt", size_label="3 B"),
+    )
+    pane = MainPane(title="Test", entries=entries, summary=summary)
+    table = Mock(spec=DataTable)
+    pane.query_one = Mock(return_value=table)
+
+    pane.apply_size_updates(
+        (
+            CurrentPaneSizeUpdate(
+                path="/path/c.txt",
+                size_label="4 B",
+                row_index=0,
+            ),
+        )
+    )
+
+    assert pane._entries[2].size_label == "4 B"
+    table.update_cell.assert_called_once()
+    assert table.update_cell.call_args.args[0] == "__slot__:2"
+
+
+def test_apply_size_updates_path_fallback_keeps_first_duplicate_match() -> None:
+    summary = CurrentSummaryState(item_count=3, selected_count=0, sort_label="Name")
+    entries = (
+        PaneEntry("first.txt", "file", path="/path/shared.txt", size_label="1 B"),
+        PaneEntry("other.txt", "file", path="/path/other.txt", size_label="2 B"),
+        PaneEntry("second.txt", "file", path="/path/shared.txt", size_label="3 B"),
+    )
+    pane = MainPane(title="Test", entries=entries, summary=summary)
+    table = Mock(spec=DataTable)
+    pane.query_one = Mock(return_value=table)
+
+    pane.apply_size_updates(
+        (
+            CurrentPaneSizeUpdate(
+                path="/path/shared.txt",
+                size_label="4 B",
+                row_index=1,
+            ),
+        )
+    )
+
+    assert pane._entries[0].size_label == "4 B"
+    assert pane._entries[2].size_label == "3 B"
+    table.update_cell.assert_called_once()
+    assert table.update_cell.call_args.args[0] == "__slot__:0"
+
+
+def test_set_entries_refreshes_path_row_index() -> None:
+    summary = CurrentSummaryState(item_count=2, selected_count=0, sort_label="Name")
+    entries = (
+        PaneEntry("a.txt", "file", path="/path/a.txt", size_label="1 B"),
+        PaneEntry("b.txt", "file", path="/path/b.txt", size_label="2 B"),
+    )
+    next_entries = (
+        PaneEntry("c.txt", "file", path="/path/c.txt", size_label="3 B"),
+        PaneEntry("d.txt", "file", path="/path/d.txt", size_label="4 B"),
+    )
+    pane = MainPane(title="Test", entries=entries, summary=summary)
+    table = Mock(spec=DataTable)
+    table.size.width = 80
+    table.cell_padding = 1
+    pane._last_table_width = 80
+    pane.query_one = Mock(return_value=table)
+
+    pane.set_entries(next_entries)
+    table.reset_mock()
+
+    pane.apply_size_updates(
+        (
+            CurrentPaneSizeUpdate(
+                path="/path/a.txt",
+                size_label="9 B",
+                row_index=1,
+            ),
+            CurrentPaneSizeUpdate(
+                path="/path/d.txt",
+                size_label="5 B",
+                row_index=0,
+            ),
+        )
+    )
+
+    assert pane._entries[0].size_label == "3 B"
+    assert pane._entries[1].size_label == "5 B"
+    table.update_cell.assert_called_once()
+    assert table.update_cell.call_args.args[0] == "__slot__:1"
+
+
 def test_set_entries_clears_stale_hover_cursor() -> None:
     summary = CurrentSummaryState(item_count=2, selected_count=0, sort_label="Name")
     entries = (


### PR DESCRIPTION
## Summary
- Add a `path -> row_index` index inside `MainPane` for stale row-index fallback resolution.
- Keep existing behavior for correct row indexes, empty paths, and duplicate paths by preserving the first matching path.
- Refresh the index whenever `_entries` is replaced by full entry updates or targeted row/size updates.

## Tests
- `uv run pytest tests/test_ui_panes.py`
- `uv run pytest tests/test_app.py -k 'refresh or large_directory_smoke_with_1000_entries'`
- `uv run ruff check src/zivo/ui/main_pane.py tests/test_ui_panes.py`
- `uv run ruff check .`
- `uv run pytest`

## Manual Test
- Launch `uv run zivo` and confirm row updates such as selection, cut state, sorting/filtering, and directory-size updates behave the same in a large directory.

Closes #1011
