### PR TITLE
Fix #1012 debounce resized image previews

### DIFF
--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -1,6 +1,7 @@
 """Child pane widget that toggles between list and preview modes."""
 
 import re
+from pathlib import Path as FsPath
 
 from rich.color import Color
 from rich.style import Style
@@ -11,6 +12,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.message import Message
+from textual.timer import Timer
 from textual.widgets import Label, Static
 
 from zivo.models.shell_data import ChildPaneViewState
@@ -26,6 +28,7 @@ from .side_pane import SidePane
 
 _SGR_SEQUENCE_RE = re.compile(r"\x1b\[([0-9;]*)m")
 _KITTY_DELETE_ALL_IMAGES = "\033_Ga=d,d=A\033\\"
+_CHAFA_RESIZE_DEBOUNCE_SECONDS = 0.08
 
 
 class ChildPane(Vertical):
@@ -68,6 +71,9 @@ class ChildPane(Vertical):
         self._label_cache = _FileEntryLabelCache()
         self._chafa_cached_content: str | None = None
         self._last_chafa_width: int = 0
+        self._chafa_resize_timer: Timer | None = None
+        self._chafa_resize_request_id = 0
+        self._pending_chafa_resize_key: tuple[str, int, str] | None = None
 
     @property
     def list_view_id(self) -> str | None:
@@ -202,6 +208,7 @@ class ChildPane(Vertical):
             if not rendered:
                 self.call_after_refresh(self._refresh_rendered_content)
         if preview_identity_changed:
+            self._invalidate_chafa_resize_requests()
             object.__setattr__(self, "_chafa_cached_content", None)
             object.__setattr__(self, "_last_chafa_width", 0)
             object.__setattr__(self, "_kitty_cached", None)
@@ -211,6 +218,7 @@ class ChildPane(Vertical):
                 self.call_after_refresh(lambda: scroll_widget.scroll_home(animate=False))
 
     def on_unmount(self) -> None:
+        self._invalidate_chafa_resize_requests()
         if self._state.is_preview and self._state.preview_kind == "kitty":
             self._clear_kitty_content()
 
@@ -233,26 +241,11 @@ class ChildPane(Vertical):
                     and self._state.preview_path
                     and render_width != self._last_chafa_width
                 ):
-                    try:
-                        from pathlib import Path as FsPath
-
-                        from zivo.services.previews.core import (
-                            ChafaImagePreviewLoader,
-                        )
-
-                        loader = ChafaImagePreviewLoader()
-                        result = loader.load_preview(
-                            FsPath(self._state.preview_path),
-                            preview_columns=render_width,
-                            image_preview_format="symbols",
-                        )
-                        if result and result.content:
-                            object.__setattr__(
-                                self, "_chafa_cached_content", result.content
-                            )
-                        object.__setattr__(self, "_last_chafa_width", render_width)
-                    except Exception:
-                        pass
+                    self._schedule_chafa_resize_preview(
+                        self._state.preview_path,
+                        render_width,
+                        "symbols",
+                    )
 
                 widget.update(
                     self._render_preview(
@@ -396,12 +389,7 @@ class ChildPane(Vertical):
         image always fills the pane without overflowing the terminal.
         """
         try:
-            from pathlib import Path as FsPath
-
-            from zivo.services.previews.core import (
-                ChafaImagePreviewLoader,
-                resolve_image_preview_format,
-            )
+            from zivo.services.previews.core import resolve_image_preview_format
 
             scroll = self._preview_scroll_widget()
             region = scroll.region
@@ -420,16 +408,11 @@ class ChildPane(Vertical):
             last_path = getattr(self, "_last_kitty_path", None)
 
             if path == last_path and pane_width != last_width and path:
-                loader = ChafaImagePreviewLoader()
-                result = loader.load_preview(
-                    FsPath(path),
-                    preview_columns=pane_width,
-                    image_preview_format="kitty",
+                self._schedule_chafa_resize_preview(
+                    path,
+                    pane_width,
+                    "kitty",
                 )
-                if result and result.content:
-                    content = result.content
-                    object.__setattr__(self, "_kitty_cached", content)
-                object.__setattr__(self, "_last_kitty_width", pane_width)
             else:
                 cached = getattr(self, "_kitty_cached", None)
                 if path == last_path and cached is not None:
@@ -448,6 +431,134 @@ class ChildPane(Vertical):
             self._write_terminal_content(write)
         except Exception:
             pass
+
+    def _schedule_chafa_resize_preview(
+        self,
+        path: str,
+        preview_columns: int,
+        image_preview_format: str,
+    ) -> None:
+        key = (path, preview_columns, image_preview_format)
+        if self._pending_chafa_resize_key == key:
+            return
+        self._chafa_resize_request_id += 1
+        request_id = self._chafa_resize_request_id
+        self._pending_chafa_resize_key = key
+        if self._chafa_resize_timer is not None:
+            self._chafa_resize_timer.stop()
+        self._chafa_resize_timer = self.set_timer(
+            _CHAFA_RESIZE_DEBOUNCE_SECONDS,
+            lambda: self._start_chafa_resize_worker(
+                request_id,
+                path,
+                preview_columns,
+                image_preview_format,
+            ),
+            name=f"chafa-resize-debounce:{request_id}",
+        )
+
+    def _start_chafa_resize_worker(
+        self,
+        request_id: int,
+        path: str,
+        preview_columns: int,
+        image_preview_format: str,
+    ) -> None:
+        self._chafa_resize_timer = None
+        if (
+            request_id != self._chafa_resize_request_id
+            or self._pending_chafa_resize_key
+            != (path, preview_columns, image_preview_format)
+        ):
+            return
+
+        def _load_preview() -> None:
+            content: str | None = None
+            try:
+                from zivo.services.previews.core import ChafaImagePreviewLoader
+
+                loader = ChafaImagePreviewLoader()
+                result = loader.load_preview(
+                    FsPath(path),
+                    preview_columns=preview_columns,
+                    image_preview_format=image_preview_format,
+                )
+                if result and result.content:
+                    content = result.content
+            except Exception:
+                content = None
+            try:
+                self.app.call_from_thread(
+                    self._complete_chafa_resize_request,
+                    request_id,
+                    path,
+                    preview_columns,
+                    image_preview_format,
+                    content,
+                )
+            except Exception:
+                pass
+
+        self.run_worker(
+            _load_preview,
+            name=f"chafa-resize:{request_id}",
+            group=f"{self.id or 'child-pane'}:chafa-resize",
+            description="Regenerate resized image preview",
+            exit_on_error=False,
+            thread=True,
+        )
+
+    def _complete_chafa_resize_request(
+        self,
+        request_id: int,
+        path: str,
+        preview_columns: int,
+        image_preview_format: str,
+        content: str | None,
+    ) -> None:
+        key = (path, preview_columns, image_preview_format)
+        if (
+            request_id != self._chafa_resize_request_id
+            or self._pending_chafa_resize_key != key
+            or self._state.preview_path != path
+        ):
+            return
+        if image_preview_format == "symbols":
+            if self._state.preview_kind != "image":
+                return
+            if content:
+                object.__setattr__(self, "_chafa_cached_content", content)
+            object.__setattr__(self, "_last_chafa_width", preview_columns)
+            self._pending_chafa_resize_key = None
+            try:
+                widget = self._preview_widget()
+            except NoMatches:
+                return
+            widget.update(
+                self._render_preview(
+                    self._state,
+                    preview_columns,
+                    chafa_override=self._chafa_cached_content,
+                )
+            )
+            return
+
+        if image_preview_format != "kitty" or self._state.preview_kind != "kitty":
+            return
+        if content:
+            object.__setattr__(self, "_kitty_cached", content)
+        object.__setattr__(self, "_last_kitty_path", path)
+        object.__setattr__(self, "_last_kitty_width", preview_columns)
+        self._pending_chafa_resize_key = None
+        if content:
+            self._write_kitty_content(content)
+
+    def _invalidate_chafa_resize_requests(self) -> None:
+        self._chafa_resize_request_id += 1
+        self._pending_chafa_resize_key = None
+        if self._chafa_resize_timer is not None:
+            self._chafa_resize_timer.stop()
+            self._chafa_resize_timer = None
 
     @staticmethod
     def _should_clear_previous_kitty_preview(

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -105,6 +105,117 @@ def test_child_pane_renders_image_preview_as_ansi() -> None:
     assert renderable.no_wrap is True
 
 
+def test_child_pane_image_preview_resize_schedules_chafa_without_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pane = ChildPane(
+        ChildPaneViewState(
+            title="Preview: image.png",
+            preview_path="/tmp/image.png",
+            preview_content="seed\n",
+            preview_kind="image",
+        )
+    )
+    widget = SimpleNamespace(
+        size=SimpleNamespace(width=42),
+        updates=[],
+        update=lambda renderable: widget.updates.append(renderable),
+    )
+    timers: list[SimpleNamespace] = []
+
+    def fake_set_timer(
+        delay: float,
+        callback: object,
+        *,
+        name: str | None = None,
+        pause: bool = False,
+    ) -> SimpleNamespace:
+        timer = SimpleNamespace(
+            delay=delay,
+            callback=callback,
+            name=name,
+            pause=pause,
+            stop=Mock(),
+        )
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(pane, "_preview_widget", lambda: widget)
+    monkeypatch.setattr(pane, "set_timer", fake_set_timer)
+    monkeypatch.setattr(
+        pane,
+        "run_worker",
+        Mock(side_effect=AssertionError("worker should wait for debounce")),
+    )
+
+    assert pane._refresh_rendered_content(force=True) is True
+
+    assert len(timers) == 1
+    assert timers[0].name == "chafa-resize-debounce:1"
+    assert pane._last_chafa_width == 0
+    assert widget.updates[-1].plain == "seed\n"
+
+
+def test_child_pane_image_preview_resize_ignores_stale_chafa_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pane = ChildPane(
+        ChildPaneViewState(
+            title="Preview: image.png",
+            preview_path="/tmp/image.png",
+            preview_content="seed\n",
+            preview_kind="image",
+        )
+    )
+    widget = SimpleNamespace(
+        updates=[],
+        update=lambda renderable: widget.updates.append(renderable),
+    )
+    timers: list[SimpleNamespace] = []
+
+    def fake_set_timer(
+        delay: float,
+        callback: object,
+        *,
+        name: str | None = None,
+        pause: bool = False,
+    ) -> SimpleNamespace:
+        timer = SimpleNamespace(
+            delay=delay,
+            callback=callback,
+            name=name,
+            pause=pause,
+            stop=Mock(),
+        )
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(pane, "_preview_widget", lambda: widget)
+    monkeypatch.setattr(pane, "set_timer", fake_set_timer)
+
+    pane._schedule_chafa_resize_preview("/tmp/image.png", 40, "symbols")
+    pane._schedule_chafa_resize_preview("/tmp/image.png", 60, "symbols")
+    pane._complete_chafa_resize_request(
+        1,
+        "/tmp/image.png",
+        40,
+        "symbols",
+        "stale\n",
+    )
+    pane._complete_chafa_resize_request(
+        2,
+        "/tmp/image.png",
+        60,
+        "symbols",
+        "fresh\n",
+    )
+
+    assert timers[0].stop.called is True
+    assert pane._chafa_cached_content == "fresh\n"
+    assert pane._last_chafa_width == 60
+    assert widget.updates[-1].plain == "fresh\n"
+
+
 def test_side_pane_selected_directory_uses_text_only_highlight() -> None:
     styles = _style_map()
     entry = PaneEntry("docs", "dir", selected=True)


### PR DESCRIPTION
## Summary
- Debounce resized image preview regeneration in `ChildPane`
- Move chafa resize regeneration to a background Textual worker
- Ignore stale resize results so older widths cannot overwrite the latest preview
- Add UI tests for deferred resize loading and stale result handling

Closes #1012

## Tests
- `uv run pytest tests -k preview`
- `uv run ruff check src/zivo/ui/child_pane.py src/zivo/services/previews/core.py`
- `uv run pytest`
- `uv run ruff check .`
