### PR TITLE
Fix #1013 Reuse chafa preview loader in child pane

### DIFF
--- a/src/zivo/services/previews/core.py
+++ b/src/zivo/services/previews/core.py
@@ -308,6 +308,7 @@ class ImagePreviewLoader(Protocol):
         path: Path,
         *,
         preview_columns: int,
+        image_preview_format: str = "symbols",
     ) -> FilePreviewState | None: ...
 
 

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -16,6 +16,7 @@ from textual.timer import Timer
 from textual.widgets import Label, Static
 
 from zivo.models.shell_data import ChildPaneViewState
+from zivo.services.previews.core import ChafaImagePreviewLoader, ImagePreviewLoader
 
 from .pane_rendering import (
     FILE_TYPE_COMPONENT_CLASSES,
@@ -58,6 +59,7 @@ class ChildPane(Vertical):
         self,
         state: ChildPaneViewState,
         *,
+        image_preview_loader: ImagePreviewLoader | None = None,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
@@ -74,6 +76,7 @@ class ChildPane(Vertical):
         self._chafa_resize_timer: Timer | None = None
         self._chafa_resize_request_id = 0
         self._pending_chafa_resize_key: tuple[str, int, str] | None = None
+        self._image_preview_loader = image_preview_loader or ChafaImagePreviewLoader()
 
     @property
     def list_view_id(self) -> str | None:
@@ -475,10 +478,7 @@ class ChildPane(Vertical):
         def _load_preview() -> None:
             content: str | None = None
             try:
-                from zivo.services.previews.core import ChafaImagePreviewLoader
-
-                loader = ChafaImagePreviewLoader()
-                result = loader.load_preview(
+                result = self._image_preview_loader.load_preview(
                     FsPath(path),
                     preview_columns=preview_columns,
                     image_preview_format=image_preview_format,

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -216,6 +216,47 @@ def test_child_pane_image_preview_resize_ignores_stale_chafa_results(
     assert widget.updates[-1].plain == "fresh\n"
 
 
+def test_child_pane_reuses_image_preview_loader_for_resize_workers() -> None:
+    class StubImagePreviewLoader:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int, str, int]] = []
+
+        def load_preview(
+            self,
+            path,
+            *,
+            preview_columns: int,
+            image_preview_format: str = "symbols",
+        ):
+            self.calls.append(
+                (str(path), preview_columns, image_preview_format, id(self))
+            )
+            return SimpleNamespace(content=f"{preview_columns}:{image_preview_format}\n")
+
+    loader = StubImagePreviewLoader()
+    pane = ChildPane(
+        ChildPaneViewState(
+            title="Preview: image.png",
+            preview_path="/tmp/image.png",
+            preview_content="seed\n",
+            preview_kind="image",
+        ),
+        image_preview_loader=loader,
+    )
+    pane.run_worker = lambda worker, **_kwargs: worker()  # type: ignore[method-assign]
+
+    pane._chafa_resize_request_id = 1
+    pane._pending_chafa_resize_key = ("/tmp/image.png", 40, "symbols")
+    pane._start_chafa_resize_worker(1, "/tmp/image.png", 40, "symbols")
+    pane._pending_chafa_resize_key = ("/tmp/image.png", 60, "symbols")
+    pane._start_chafa_resize_worker(1, "/tmp/image.png", 60, "symbols")
+
+    assert loader.calls == [
+        ("/tmp/image.png", 40, "symbols", id(loader)),
+        ("/tmp/image.png", 60, "symbols", id(loader)),
+    ]
+
+
 def test_side_pane_selected_directory_uses_text_only_highlight() -> None:
     styles = _style_map()
     entry = PaneEntry("docs", "dir", selected=True)


### PR DESCRIPTION
## Summary
- Reuse a `ChafaImagePreviewLoader` instance from `ChildPane` resize preview workers
- Align the image preview loader protocol with the `image_preview_format` argument used by resize paths
- Add coverage proving resize workers reuse the injected loader

Closes #1013

## Tests
- `uv run pytest tests -k preview`
- `uv run ruff check src/zivo/ui/child_pane.py src/zivo/services/previews/core.py tests/test_ui_panes.py`
- `uv run pytest`
