### PR TITLE
Fix #1036 WSL /mnt/c permission denied listing

### DIFF
--- a/src/zivo/adapters/filesystem.py
+++ b/src/zivo/adapters/filesystem.py
@@ -73,6 +73,8 @@ def _build_directory_entry_summary(entry: os.DirEntry[str]) -> DirectoryEntrySta
     hidden = entry.name.startswith(".")
     try:
         kind = "dir" if entry.is_dir(follow_symlinks=False) else "file"
+    except PermissionError:
+        return None
     except FileNotFoundError:
         if is_symlink:
             return DirectoryEntryState(
@@ -88,6 +90,8 @@ def _build_directory_entry_summary(entry: os.DirEntry[str]) -> DirectoryEntrySta
         try:
             if entry.is_dir():
                 kind = "dir"
+        except PermissionError:
+            return None
         except FileNotFoundError:
             return DirectoryEntryState(
                 path=entry.path,
@@ -99,6 +103,8 @@ def _build_directory_entry_summary(entry: os.DirEntry[str]) -> DirectoryEntrySta
 
     try:
         stat_result = entry.stat()
+    except PermissionError:
+        return None
     except FileNotFoundError:
         if is_symlink:
             return DirectoryEntryState(

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -8,6 +8,47 @@ import pytest
 from zivo.adapters import LocalFilesystemAdapter
 
 
+class _FakeScandir:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def __enter__(self):
+        return iter(self._entries)
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _FakeDirEntry:
+    def __init__(
+        self,
+        *,
+        name: str,
+        path: str,
+        kind: str = "file",
+        fail_is_dir: bool = False,
+        fail_stat: bool = False,
+    ) -> None:
+        self.name = name
+        self.path = path
+        self._kind = kind
+        self._fail_is_dir = fail_is_dir
+        self._fail_stat = fail_stat
+
+    def is_symlink(self) -> bool:
+        return False
+
+    def is_dir(self, follow_symlinks: bool = True) -> bool:
+        if self._fail_is_dir:
+            raise PermissionError("permission denied")
+        return self._kind == "dir"
+
+    def stat(self):
+        if self._fail_stat:
+            raise PermissionError("permission denied")
+        return SimpleNamespace(st_size=12, st_mtime=0, st_mode=0o100644)
+
+
 def test_local_filesystem_adapter_lists_entries_with_lightweight_directory_metadata(
     tmp_path,
 ) -> None:
@@ -62,6 +103,34 @@ def test_local_filesystem_adapter_list_directory_skips_owner_group_resolution(
     monkeypatch.setattr("builtins.__import__", _unexpected_import)
 
     entries = adapter.list_directory(str(tmp_path))
+
+    assert [entry.name for entry in entries] == ["docs", "README.md"]
+
+
+def test_local_filesystem_adapter_skips_entries_with_permission_denied_metadata(
+    monkeypatch,
+) -> None:
+    readable_file = _FakeDirEntry(name="README.md", path="/mnt/c/README.md")
+    readable_dir = _FakeDirEntry(name="docs", path="/mnt/c/docs", kind="dir")
+    blocked_kind = _FakeDirEntry(
+        name="blocked-kind",
+        path="/mnt/c/blocked-kind",
+        fail_is_dir=True,
+    )
+    blocked_stat = _FakeDirEntry(
+        name="blocked-stat",
+        path="/mnt/c/blocked-stat",
+        fail_stat=True,
+    )
+
+    def _fake_scandir(directory):
+        assert str(directory) == "/mnt/c"
+        return _FakeScandir((readable_file, blocked_kind, readable_dir, blocked_stat))
+
+    monkeypatch.setattr(os, "scandir", _fake_scandir)
+    adapter = LocalFilesystemAdapter()
+
+    entries = adapter.list_directory("/mnt/c")
 
     assert [entry.name for entry in entries] == ["docs", "README.md"]
 


### PR DESCRIPTION
## Summary
- Skip individual directory entries whose metadata cannot be read due to `PermissionError`
- Preserve existing handling for directories that cannot be opened at all
- Add adapter-level coverage for permission-denied `DirEntry.is_dir` and `DirEntry.stat` failures

Closes #1036

## Tests
- `uv run pytest tests/test_adapters_filesystem.py`
- `uv run pytest`
- `uv run ruff check .`
