### PR TITLE
Release v0.29.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,19 +1,28 @@
- Name               Version  License                                        URL                                                
- Pygments           2.19.2   BSD License                                    https://pygments.org                               
- Send2Trash         2.1.0    BSD-3-Clause                                   https://github.com/arsenetar/send2trash            
- iniconfig          2.3.0    MIT                                            https://github.com/pytest-dev/iniconfig            
- linkify-it-py      2.1.0    MIT License                                    https://github.com/tsutsu3/linkify-it-py           
- markdown-it-py     4.0.0    MIT License                                    https://github.com/executablebooks/markdown-it-py  
- mdit-py-plugins    0.5.0    MIT License                                    https://github.com/executablebooks/mdit-py-plugins 
- mdurl              0.1.2    MIT License                                    https://github.com/executablebooks/mdurl           
- packaging          26.0     Apache-2.0 OR BSD-2-Clause                     https://github.com/pypa/packaging                  
- platformdirs       4.9.4    MIT                                            https://github.com/tox-dev/platformdirs            
- pluggy             1.6.0    MIT License                                    UNKNOWN
- pytest             9.0.2    MIT                                            https://docs.pytest.org/en/latest/                 
- pytest-asyncio     1.3.0    Apache-2.0                                     https://github.com/pytest-dev/pytest-asyncio       
- rich               14.3.3   MIT License                                    https://github.com/Textualize/rich                 
- ruff               0.15.7   MIT                                            https://docs.astral.sh/ruff                        
- textual            0.89.1   MIT License                                    https://github.com/Textualize/textual              
- typing_extensions  4.15.0   PSF-2.0                                        https://github.com/python/typing_extensions        
- uc-micro-py        2.0.0    MIT License                                    https://github.com/tsutsu3/uc.micro-py             
- zivo               0.12.0   MIT License                                    https://github.com/devgamesan/zivo                 
+ Name               Version  License                             URL                                                
+ PyYAML             6.0.3    MIT License                         https://pyyaml.org/                                
+ Pygments           2.20.0   BSD-2-Clause                        https://pygments.org                               
+ Send2Trash         2.1.0    BSD-3-Clause                        https://github.com/arsenetar/send2trash            
+ cfgv               3.5.0    MIT                                 https://github.com/asottile/cfgv                   
+ distlib            0.4.0    Python Software Foundation License  https://github.com/pypa/distlib                    
+ filelock           3.29.0   MIT                                 https://github.com/tox-dev/py-filelock             
+ identify           2.6.19   MIT                                 https://github.com/pre-commit/identify             
+ iniconfig          2.3.0    MIT                                 https://github.com/pytest-dev/iniconfig            
+ linkify-it-py      2.1.0    MIT License                         https://github.com/tsutsu3/linkify-it-py           
+ markdown-it-py     4.0.0    MIT License                         https://github.com/executablebooks/markdown-it-py  
+ mdit-py-plugins    0.5.0    MIT License                         https://github.com/executablebooks/mdit-py-plugins 
+ mdurl              0.1.2    MIT License                         https://github.com/executablebooks/mdurl           
+ nodeenv            1.10.0   BSD License                         https://github.com/ekalinin/nodeenv                
+ packaging          26.0     Apache-2.0 OR BSD-2-Clause          https://github.com/pypa/packaging                  
+ platformdirs       4.9.4    MIT                                 https://github.com/tox-dev/platformdirs            
+ pluggy             1.6.0    MIT License                         UNKNOWN                                            
+ pre_commit         4.6.0    MIT                                 https://github.com/pre-commit/pre-commit           
+ pytest             9.0.3    MIT                                 https://docs.pytest.org/en/latest/                 
+ pytest-asyncio     1.3.0    Apache-2.0                          https://github.com/pytest-dev/pytest-asyncio       
+ python-discovery   1.2.2    MIT License                         https://github.com/tox-dev/python-discovery        
+ rich               14.3.3   MIT License                         https://github.com/Textualize/rich                 
+ ruff               0.15.7   MIT                                 https://docs.astral.sh/ruff                        
+ textual            0.89.1   MIT License                         https://github.com/Textualize/textual              
+ typing_extensions  4.15.0   PSF-2.0                             https://github.com/python/typing_extensions        
+ uc-micro-py        2.0.0    MIT License                         https://github.com/tsutsu3/uc.micro-py             
+ virtualenv         21.3.0   MIT                                 https://github.com/pypa/virtualenv                 
+ zivo               0.29.0   MIT License                         https://github.com/devgamesan/zivo                 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zivo"
-version = "0.27.0"
+version = "0.29.0"
 description = "zivo is a simple and intuitive TUI file manager that lets you browse, search, and operate files without memorizing commands — a Zero-friction Interface for Viewing & Operations."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "zivo"
-version = "0.27.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "send2trash" },


### PR DESCRIPTION
This PR merges the release branch v0.29.0 into main.

## 変更内容
- `pyproject.toml` の version を 0.27.0 → 0.29.0 に bump
- `uv.lock` の再生成（zivo v0.29.0）
- `NOTICE.txt` の再生成（zivo v0.29.0、`pre-commit` 等 dev 依存の追加と依存バージョン更新を反映）

## 備考
- develop が v0.28.0 リリース時のバージョン bump マージバック漏れで 0.27.0 に滞留していたため、0.28.0 をスキップして 0.29.0 に bump します。
- develop と main は機能面で同一のため、本 PR はバージョン不整合の解消と NOTICE.txt の陳腐化解消が主目的です。