### PR TITLE
Sort names in natural order (#1069)

### DIFF
--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -333,7 +333,7 @@ Notes:
 - Supports jumping from saved bookmarks plus adding or removing the current directory as a bookmark
 - Supports go-to-path input for direct navigation to a typed path
 - Supports filter input and continued list interaction after filtering
-- Switches sort by name / modified time / size and toggles directories-first ordering
+- Switches sort by name (natural sort: numeric runs ordered by value) / modified time / size and toggles directories-first ordering
 - Shows recursive directory sizes for visible directories when needed
 - Supports selection toggle, clear selection, copy / cut / paste
 - Supports left-right focus, copy / move between panes, and existing clipboard paste in two-pane transfer mode

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -333,7 +333,7 @@ stateDiagram-v2
 - bookmark 一覧からのジャンプと、現在ディレクトリの bookmark 追加 / 削除
 - go-to-path 入力による任意パスへの移動
 - filter 入力と filter 適用後の一覧継続操作
-- 名前 / 更新日時 / サイズソートと directory-first 切り替え
+- 名前（自然順） / 更新日時 / サイズソートと directory-first 切り替え
 - 必要に応じた可視ディレクトリの再帰サイズ表示
 - 選択トグル、選択解除、copy / cut / paste
 - 2ペイン転送モードでの左右フォーカス、左右間 copy / move、既存 clipboard paste

--- a/docs/configuration.ja.md
+++ b/docs/configuration.ja.md
@@ -41,7 +41,7 @@ Config Editor で `e` を押すと `config.toml` を開き、高度設定を編�
 | `display` | `theme` | 任意の組み込み Textual テーマ（例: `textual-dark`、`textual-light`、`dracula`、`tokyo-night`） | 起動時の UI テーマです。設定エディタでは変更内容が即座にプレビューされ、`s` で保存するとこの値が永続化されます。 |
 | `display` | `preview_syntax_theme` | `auto` またはサポートされている Pygments style（例: `one-dark`、`xcode`、`nord`、`gruvbox-dark`） | 右ペインのテキストプレビューに使うシンタックスハイライト配色です。`auto` を選ぶと、現在の light/dark に応じた既定配色を使います。設定エディタで右ペインにテキストプレビューが出ている場合は、その場で即時プレビューされます。 |
 | `display` | `preview_max_kib` | `64` / `128` / `256` / `512` / `1024` | 右ペインのファイルプレビューとプレビューサンプリングで読み込む最大量です。既定値は `64` です。大きな値にするとより深くプレビューできますが、I/O コストが増加します。 |
-| `display` | `default_sort_field` | `name` / `modified` / `size` | 中央ペインの初期ソート項目です。 |
+| `display` | `default_sort_field` | `name` / `modified` / `size` | 中央ペインの初期ソート項目です。`name` は自然順（数値部分を値で比較、例: `file2` が `file10` より先）で並び替えます。 |
 | `display` | `default_sort_descending` | `true` / `false` | `true` のとき、起動時のソートを降順にします。 |
 | `display` | `directories_first` | `true` / `false` | 中央ペインでディレクトリをファイルより先にまとめて表示します。 |
 | `behavior` | `confirm_delete` | `true` / `false` | ゴミ箱削除の前に確認ダイアログを表示します。`D` / `Shift+Delete` による完全削除は常に確認します。 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ those settings and preserves advanced, unknown, and custom TOML values.
 | `display` | `theme` | Any built-in Textual theme, for example `textual-dark`, `textual-light`, `dracula`, or `tokyo-night` | Default UI theme applied on startup. In the settings editor, theme changes are previewed immediately and are persisted when you save. |
 | `display` | `preview_syntax_theme` | `auto` or a supported Pygments style, for example `one-dark`, `xcode`, `nord`, or `gruvbox-dark` | Syntax-highlighting colors used by the right-pane text preview. `auto` keeps the current light/dark-based default selection. In the settings editor, changes are previewed immediately when a text preview is visible. |
 | `display` | `preview_max_kib` | `64` / `128` / `256` / `512` / `1024` | Maximum amount of text read for right-pane file previews and preview sampling. Defaults to `64`. Larger values allow deeper previews at the cost of more I/O. |
-| `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. |
+| `display` | `default_sort_field` | `name` / `modified` / `size` | Default sort field for the main pane. The `name` field uses natural sort (numeric runs ordered by value, e.g. `file2` before `file10`). |
 | `display` | `default_sort_descending` | `true` / `false` | Starts the main-pane sort in descending order when enabled. |
 | `display` | `directories_first` | `true` / `false` | Keeps directories grouped before files in the main pane. |
 | `behavior` | `confirm_delete` | `true` / `false` | Shows a confirmation dialog before moving items to trash. Permanent delete via `D` / `Shift+Delete` always asks for confirmation. |

--- a/src/zivo/adapters/filesystem.py
+++ b/src/zivo/adapters/filesystem.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Protocol
 
 from zivo.state.models import DirectoryEntryState
+from zivo.state.natural_sort import natural_sort_key
 
 from .filesystem_attributes import resolve_owner_group
 
@@ -47,7 +48,7 @@ class LocalFilesystemAdapter:
                 entry = _build_directory_entry_summary(child)
                 if entry is not None:
                     entries.append(entry)
-        entries.sort(key=lambda entry: (entry.kind != "dir", entry.name.casefold()))
+        entries.sort(key=lambda entry: (entry.kind != "dir", natural_sort_key(entry.name)))
         return tuple(entries)
 
     def inspect_entry(self, path: str) -> DirectoryEntryState | None:

--- a/src/zivo/services/archive_list.py
+++ b/src/zivo/services/archive_list.py
@@ -11,6 +11,7 @@ from typing import Protocol
 from zivo.archive_utils import detect_archive_format
 from zivo.models import ArchiveFormat
 from zivo.state.models import DirectoryEntryState
+from zivo.state.natural_sort import natural_sort_key
 
 
 class ArchiveListService(Protocol):
@@ -197,5 +198,5 @@ def _build_directory_entries(
             )
         )
 
-    directory_entries.sort(key=lambda e: (e.kind != "dir", e.name.casefold()))
+    directory_entries.sort(key=lambda e: (e.kind != "dir", natural_sort_key(e.name)))
     return tuple(directory_entries)

--- a/src/zivo/services/file_search.py
+++ b/src/zivo/services/file_search.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal, Protocol
 
 from zivo.state.models import FileSearchResultState, FileSearchTarget
+from zivo.state.natural_sort import natural_sort_key
 
 
 class FileSearchService(Protocol):
@@ -142,12 +143,12 @@ class LiveFileSearchService:
                     )
 
                     if max_results is not None and len(results) >= max_results:
-                        results.sort(key=lambda result: result.display_path.casefold())
+                        results.sort(key=lambda result: natural_sort_key(result.display_path))
                         return tuple(results)
             except (FileNotFoundError, PermissionError):
                 continue
 
-        results.sort(key=lambda result: result.display_path.casefold())
+        results.sort(key=lambda result: natural_sort_key(result.display_path))
         return tuple(results)
 
 
@@ -193,7 +194,7 @@ class FakeFileSearchService:
                 return ()
             if len(results) > max_results:
                 limited_results = tuple(
-                    sorted(results, key=lambda r: r.display_path.casefold())[:max_results]
+                    sorted(results, key=lambda r: natural_sort_key(r.display_path))[:max_results]
                 )
                 return limited_results
 

--- a/src/zivo/services/zip_compress.py
+++ b/src/zivo/services/zip_compress.py
@@ -11,6 +11,7 @@ from zivo.models import (
     CreateZipArchiveRequest,
     CreateZipArchiveResult,
 )
+from zivo.state.natural_sort import natural_sort_key
 
 ProgressCallback = Callable[[int, int, str | None], None]
 
@@ -180,7 +181,7 @@ def _append_entries(entries: list[_ZipEntry], source_path: Path, root_dir: Path)
         entries.append(_ZipEntry(source_path=source_path, arcname=arcname, is_dir=True))
         for child in sorted(
             source_path.iterdir(),
-            key=lambda path: (not path.is_dir(), path.name.casefold(), path.name),
+            key=lambda path: (not path.is_dir(), natural_sort_key(path.name)),
         ):
             _append_entries(entries, child, root_dir)
         return

--- a/src/zivo/state/entry_state_helpers.py
+++ b/src/zivo/state/entry_state_helpers.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from functools import lru_cache
 
 from .models import AppState, DirectoryEntryState, DirectorySizeCacheEntry, SortState
+from .natural_sort import natural_sort_key
 
 
 @lru_cache(maxsize=256)
@@ -147,23 +148,23 @@ def _sort_key(field: str):
         return lambda entry: (
             entry.modified_at is None,
             entry.modified_at or 0,
-            entry.name.casefold(),
+            natural_sort_key(entry.name),
         )
     if field == "size":
         return lambda entry: (
             entry.size_bytes is None,
             entry.size_bytes or -1,
-            entry.name.casefold(),
+            natural_sort_key(entry.name),
         )
-    return lambda entry: entry.name.casefold()
+    return lambda entry: natural_sort_key(entry.name)
 
 
 def _sort_size_key(descending: bool):
-    def key(entry: DirectoryEntryState) -> tuple[int, int, str]:
+    def key(entry: DirectoryEntryState) -> tuple[int, int, tuple]:
         if entry.size_bytes is None:
-            return (1, 0, entry.name.casefold())
+            return (1, 0, natural_sort_key(entry.name))
         value = -entry.size_bytes if descending else entry.size_bytes
-        return (0, value, entry.name.casefold())
+        return (0, value, natural_sort_key(entry.name))
 
     return key
 

--- a/src/zivo/state/natural_sort.py
+++ b/src/zivo/state/natural_sort.py
@@ -1,0 +1,42 @@
+"""Natural (human-friendly) sort key helper.
+
+Provides a single :func:`natural_sort_key` used by every name-based sort in
+the application so that ordering is consistent across panes, search results,
+path completion, and archive listings.
+"""
+
+import re
+
+# ASCII digits only by design. Unicode digit classes (superscripts, other
+# scripts' digits) are intentionally excluded for predictable ordering.
+_NUMBER_PATTERN = re.compile(r"([0-9]+)")
+
+
+def natural_sort_key(text: str) -> tuple:
+    """Return a sort key that orders ``text`` in natural order.
+
+    Numeric runs are compared by integer value, with the original digit
+    string as a tie-breaker, so ``part01 < part1 < part2`` and
+    ``file2 < file10``. Text segments are compared case-insensitively
+    (``casefold``). When two names share the same segment key (e.g.
+    ``File1`` / ``file1``), the original text breaks the tie deterministically
+    so the order never depends on the OS scandir order.
+
+    The returned ``(segments, text)`` pair keeps every comparison position
+    type-safe: segments are compared position-by-position (a numeric segment
+    ``(0, int, str)`` against another numeric segment, a text segment
+    ``(1, str)`` against another text segment), and the trailing ``text``
+    only participates once the segments fully match. That also makes a
+    shorter name sort before a longer name that extends it (``a < a1``).
+    """
+    key = []
+    for part in _NUMBER_PATTERN.split(text):
+        if not part:
+            continue
+        # A captured group is always pure ASCII digits; a text part never
+        # starts with an ASCII digit (it would otherwise have been matched).
+        if "0" <= part[0] <= "9":
+            key.append((0, int(part), part))
+        else:
+            key.append((1, part.casefold()))
+    return (tuple(key), text)

--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -490,6 +490,7 @@ def config_editor_field_description(field_index: int, config: AppConfig) -> tupl
     if field_id == "display.default_sort_field":
         return (
             "Sets the default sort field used when a directory is first loaded.",
+            "The 'name' field sorts entries in natural order (e.g. file2 before file10).",
             "You can still change sorting later from the running UI.",
             f"Current behavior: sort by `{config.display.default_sort_field}`.",
         )

--- a/src/zivo/state/reducer_path_helpers.py
+++ b/src/zivo/state/reducer_path_helpers.py
@@ -17,6 +17,7 @@ from zivo.windows_paths import (
 )
 
 from .models import DirectoryEntryState, FileSearchResultState
+from .natural_sort import natural_sort_key
 
 REGEX_FILE_SEARCH_PREFIX = "re:"
 REGEX_GREP_SEARCH_PREFIX = "re:"
@@ -103,7 +104,7 @@ def _list_matching_entry_paths(
                 matches.append(normalize_windows_path(child.path))
         except (OSError, PermissionError):
             return ()
-        matches.sort(key=lambda path: (ntpath.basename(path).casefold(), path.casefold()))
+        matches.sort(key=lambda path: (natural_sort_key(ntpath.basename(path)), path.casefold()))
         return tuple(matches)
 
     resolved = _resolve_input_path(raw_query, base_path)
@@ -134,7 +135,7 @@ def _list_matching_entry_paths(
     except (OSError, PermissionError):
         return ()
 
-    matches.sort(key=lambda path: (Path(path).name.casefold(), path))
+    matches.sort(key=lambda path: (natural_sort_key(Path(path).name), path))
     return tuple(matches)
 
 
@@ -306,7 +307,7 @@ def _list_windows_drive_candidates(prefix: str) -> tuple[str, ...]:
         for drive in list_windows_drive_paths()
         if not prefix or drive[0].casefold().startswith(prefix)
     )
-    return tuple(sorted(matches, key=lambda drive: drive.casefold()))
+    return tuple(sorted(matches, key=natural_sort_key))
 
 
 def _uses_windows_path_rules(base_path: str, query: str) -> bool:

--- a/src/zivo/state/selectors_shared.py
+++ b/src/zivo/state/selectors_shared.py
@@ -15,6 +15,7 @@ from zivo.models import (
 )
 from zivo.theme_support import preview_syntax_theme_for_app_theme
 
+from .entry_state_helpers import _sort_key, _sort_size_key
 from .entry_state_helpers import (
     current_entry_for_path as shared_current_entry_for_path,
 )
@@ -217,32 +218,6 @@ def _sort_entries_by_size(
     else:
         combined = sorted(entries, key=key)
     return tuple(combined)
-
-
-def _sort_key(field: str):
-    if field == "modified":
-        return lambda entry: (
-            entry.modified_at is None,
-            entry.modified_at or 0,
-            entry.name.casefold(),
-        )
-    if field == "size":
-        return lambda entry: (
-            entry.size_bytes is None,
-            entry.size_bytes or -1,
-            entry.name.casefold(),
-        )
-    return lambda entry: entry.name.casefold()
-
-
-def _sort_size_key(descending: bool):
-    def key(entry: DirectoryEntryState) -> tuple[int, int, str]:
-        if entry.size_bytes is None:
-            return (1, 0, entry.name.casefold())
-        value = -entry.size_bytes if descending else entry.size_bytes
-        return (0, value, entry.name.casefold())
-
-    return key
 
 
 def _format_sort_label(sort: SortState) -> str:

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -132,6 +132,59 @@ def test_select_current_entries_applies_filter_and_sort() -> None:
     assert [entry.name for entry in entries] == ["tests", "pyproject.toml"]
 
 
+def test_select_current_entries_sorts_names_naturally() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(
+                entry("/home/tadashi/develop/zivo/file1", "file"),
+                entry("/home/tadashi/develop/zivo/file10", "file"),
+                entry("/home/tadashi/develop/zivo/file2", "file"),
+                entry("/home/tadashi/develop/zivo/file20", "file"),
+                entry("/home/tadashi/develop/zivo/dir1", "dir"),
+            ),
+        ),
+    )
+
+    entries = select_current_entries(state)
+
+    assert [item.name for item in entries] == [
+        "dir1",
+        "file1",
+        "file2",
+        "file10",
+        "file20",
+    ]
+
+
+def test_select_current_entries_sorts_names_naturally_descending() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_pane=PaneState(
+            directory_path="/home/tadashi/develop/zivo",
+            entries=(
+                entry("/home/tadashi/develop/zivo/file1", "file"),
+                entry("/home/tadashi/develop/zivo/file10", "file"),
+                entry("/home/tadashi/develop/zivo/file2", "file"),
+                entry("/home/tadashi/develop/zivo/dir1", "dir"),
+            ),
+        ),
+    )
+    state = _reduce_state(
+        state, SetSort(field="name", descending=True, directories_first=True)
+    )
+
+    entries = select_current_entries(state)
+
+    assert [item.name for item in entries] == [
+        "dir1",
+        "file10",
+        "file2",
+        "file1",
+    ]
+
+
 def test_select_current_entries_hides_hidden_by_default() -> None:
     state = replace(
         build_initial_app_state(),

--- a/tests/test_natural_sort.py
+++ b/tests/test_natural_sort.py
@@ -1,0 +1,52 @@
+"""Tests for the natural sort key helper."""
+
+import pytest
+
+from zivo.state.natural_sort import natural_sort_key
+
+
+def _sorted(names):
+    return sorted(names, key=natural_sort_key)
+
+
+@pytest.mark.parametrize(
+    "names,expected",
+    [
+        (["file10", "file2", "file1"], ["file1", "file2", "file10"]),
+        (["10", "2", "1"], ["1", "2", "10"]),
+        (["a10b10", "a10b2", "a2b1"], ["a2b1", "a10b2", "a10b10"]),
+    ],
+)
+def test_natural_sort_key_orders_numeric_runs_by_value(names, expected):
+    assert _sorted(names) == expected
+
+
+def test_natural_sort_key_zero_pad_tiebreak():
+    assert _sorted(["part2", "part01", "part1"]) == ["part01", "part1", "part2"]
+
+
+def test_natural_sort_key_case_insensitive_with_deterministic_tiebreak():
+    # 'File1' / 'file1' share the same segment key; the original text breaks
+    # the tie by code point so the order never depends on scandir ordering.
+    assert _sorted(["file1", "File1"]) == ["File1", "file1"]
+
+
+def test_natural_sort_key_prefix_shorter_first():
+    assert _sorted(["a1", "a", "a10", "a2"]) == ["a", "a1", "a2", "a10"]
+
+
+def test_natural_sort_key_matches_casefold_order_for_digit_free_names():
+    assert _sorted(["pyproject.toml", "tests", "README.md"]) == sorted(
+        ["pyproject.toml", "tests", "README.md"], key=str.casefold
+    )
+
+
+def test_natural_sort_key_treats_only_ascii_digits_as_numbers():
+    # The superscript ² is not an ASCII digit, so it must not raise and must
+    # not be parsed as a number; 'a2' still sorts before 'a10'.
+    result = _sorted(["a10", "a²", "a2"])
+    assert result.index("a2") < result.index("a10")
+
+
+def test_natural_sort_key_empty_string_orders_first():
+    assert _sorted(["b", "", "a"]) == ["", "a", "b"]

--- a/tests/test_services_archive_list.py
+++ b/tests/test_services_archive_list.py
@@ -98,16 +98,19 @@ def test_archive_list_service_sorts_directories_first(tmp_path) -> None:
         archive.writestr("file1.txt", "content\n")
         archive.writestr("dir1/file.txt", "content\n")
         archive.writestr("file2.txt", "content\n")
+        archive.writestr("file10.txt", "content\n")
+        archive.writestr("file20.txt", "content\n")
 
     service = LiveArchiveListService()
     entries = service.list_archive_entries(str(archive_path))
 
-    assert entries[0].kind == "dir"
-    assert entries[0].name == "dir1"
-    assert entries[1].kind == "file"
-    assert entries[1].name == "file1.txt"
-    assert entries[2].kind == "file"
-    assert entries[2].name == "file2.txt"
+    assert [entry.name for entry in entries] == [
+        "dir1",
+        "file1.txt",
+        "file2.txt",
+        "file10.txt",
+        "file20.txt",
+    ]
 
 
 def test_archive_list_service_includes_file_size_for_files(tmp_path) -> None:

--- a/tests/test_services_file_search.py
+++ b/tests/test_services_file_search.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from zivo.services import InvalidFileSearchQueryError, LiveFileSearchService
+from zivo.state.natural_sort import natural_sort_key
 
 
 def test_live_file_search_service_matches_files_recursively(tmp_path) -> None:
@@ -197,7 +198,7 @@ def test_live_file_search_service_respects_max_results(tmp_path) -> None:
     assert len(results) == 10
     # 結果がソートされていることを確認
     display_paths = [result.display_path for result in results]
-    assert display_paths == sorted(display_paths, key=str.casefold)
+    assert display_paths == sorted(display_paths, key=natural_sort_key)
 
 
 def test_live_file_search_service_no_limit_when_max_results_is_none(tmp_path) -> None:
@@ -234,4 +235,4 @@ def test_live_file_search_service_returns_sorted_results_with_limit(tmp_path) ->
     assert len(results) == 3
     # 結果がソートされていることを確認（ただし、辞書順の最初の3件とは限らない）
     display_paths = [result.display_path for result in results]
-    assert display_paths == sorted(display_paths, key=str.casefold)
+    assert display_paths == sorted(display_paths, key=natural_sort_key)

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -53,6 +53,7 @@ from zivo.state.actions import (
     ToggleTransferMode,
 )
 from zivo.state.command_palette import parse_go_query, select_go_candidates
+from zivo.state.natural_sort import natural_sort_key
 from zivo.windows_paths import WINDOWS_DRIVES_ROOT
 
 
@@ -668,7 +669,7 @@ def test_set_command_palette_query_shows_root_directory_candidates_for_slash() -
                 for child in Path("/").iterdir()
                 if child.is_dir()
             ),
-            key=lambda path: (Path(path).name.casefold(), path),
+            key=lambda path: (natural_sort_key(Path(path).name), path),
         )
     )
 


### PR DESCRIPTION
Closes #1069

## 概要
名前順ソートを自然順（natural sort）へ変更。番号付きファイルが人間の直感に合う並び（`file1`, `file2`, `file10`）になる。従来の単純な casefold 辞書順では `file10` が `file2` より前に来ていた問題を解決。

## 変更内容
- **新設 `src/zivo/state/natural_sort.py`**: `natural_sort_key(text)` を提供。`(segments, text)` の2要素タプルを返し、異なるセグメント数の比較でも型衝突（str vs tuple）しない設計。ASCII `[0-9]` のみを数字として扱う。
- **共通ヘルパ集約**: `_sort_key` / `_sort_size_key` を `entry_state_helpers.py` に統一し、`selectors_shared.py` は import に切替（`_sort_entries` の `@lru_cache` 境界は維持）。
- **全比較箇所の置換**: メイン/サイドペイン、ファイルシステム初期ソート、アーカイブ一覧、Go候補補完、ファイル検索結果、zip 作成の各 name 比較を `natural_sort_key` に統一。内部処理（`text_replace` / `grep` / `trash`）は除外。
- **仕様**: `part01 < part1 < part2`（ゼロ埋め）。case 違いは元の名前で決定的 tie-break。
- **ドキュメント**: `configuration.md` / `.ja.md`, `architecture.en.md` / `.md`, config editor のインアプリ説明文に「`name` は自然順」を明記。

## テスト結果
- `uv run ruff check .`: クリア
- `uv run pytest`: **1344 passed, 9 skipped**
- 新規テスト: `tests/test_natural_sort.py`（境界ケース）、`state_selectors_cases.py` に name 自然順の統合テスト（昇順・降順）。
- 既存テストは数字なし/ゼロ埋めデータのため順序不変。更新が必要なアサーション（`file_search` / `palette_commands`）は自然順キーに更新済み。

## フォローアップ（別 Issue 想定）
- `selectors_shared.py` のデッドコード（`_select_visible_current_entry_states`）削除、`_filter_*` / `_overlay_directory_sizes` の重複解消（キャッシュ境界に関わるため本 PR とは分離）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)