### PR TITLE
[#1096] 空ディレクトリ案内をコマンドパレット経由(:)から直接キー(n/N)に変更

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -661,7 +661,8 @@ class zivoApp(App[None]):
     async def _dispatch_pane_action(self, action_id: str) -> None:
         actions = {
             "clear_filter": CancelFilterInput(),
-            "create": BeginCreateInput("file"),
+            "create_file": BeginCreateInput("file"),
+            "create_dir": BeginCreateInput("dir"),
             "show_attributes": ShowAttributes(),
             "edit_config": BeginConfigEditor(),
         }

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -196,7 +196,8 @@ def _select_current_pane_status(
             title="Empty directory",
             detail="Create a file or directory to get started",
             actions=(
-                PaneActionViewState("create", "Create", ":"),
+                PaneActionViewState("create_file", "New file", "n"),
+                PaneActionViewState("create_dir", "New directory", "N"),
             ),
         )
     return PaneStatusViewState(kind="empty", title="No visible items")

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -3679,8 +3679,11 @@ def test_select_shell_data_distinguishes_empty_and_filtered_empty_directory() ->
     shell = select_shell_data(state)
     assert shell.current_pane_status is not None
     assert shell.current_pane_status.kind == "empty"
-    assert [action.action_id for action in shell.current_pane_status.actions] == ["create"]
-    assert [action.shortcut for action in shell.current_pane_status.actions] == [":"]
+    assert [action.action_id for action in shell.current_pane_status.actions] == [
+        "create_file",
+        "create_dir",
+    ]
+    assert [action.shortcut for action in shell.current_pane_status.actions] == ["n", "N"]
 
     filtered = replace(
         state,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6431,9 +6431,10 @@ async def test_app_renders_empty_directory_action_and_routes_it_to_create_flow()
         status = app.query_one("#current-pane-status", Static)
         assert status.display is True
         assert "Empty directory" in str(status.renderable)
-        assert "[:] Create" in str(status.renderable)
+        assert "[n] New file" in str(status.renderable)
+        assert "[N] New directory" in str(status.renderable)
 
-        await app.on_main_pane_action_clicked(MainPane.ActionClicked("create"))
+        await app.on_main_pane_action_clicked(MainPane.ActionClicked("create_file"))
 
         assert app.app_state.ui_mode == "CREATE"
         assert app.app_state.pending_input is not None


### PR DESCRIPTION
## 概要

空ディレクトリ表示時のセンターペイン案内を、コマンドパレット経由（`[:] Create`）から直接キー（`n` / `N`）に変更します。

Closes #1096

## 背景

- ファイル作成（`n`）・ディレクトリ作成（`N`）の直接キーバインドが既に存在するにもかかわらず、案内はパレット経由だった。
- パレットの `create` はファイル作成（`BeginCreateInput("file")`）にしか変換されず、案内経路からはディレクトリ作成に辿り着けなかった。

## 変更内容

- `src/zivo/state/selectors.py`: 空ディレクトリ案内のアクションを `create`(shortcut `:`) から `create_file`(`n` / New file) と `create_dir`(`N` / New directory) の2つに変更。
- `src/zivo/app.py`: `_dispatch_pane_action` の action_id マッピングを `create` から `create_file` / `create_dir` に更新（クリックでそれぞれの作成フローへ遷移）。
- テスト: `tests/state_selectors_cases.py`・`tests/test_app.py` の該当 assert を新しい action_id / shortcut / 表示文言 / クリック遷移に更新。

表示例: `[n] New file  [N] New directory`

## テスト結果

- `uv run ruff check .` → All checks passed
- `uv run pytest` → **1340 passed, 9 skipped**

## スコープ外（フォローアップ）

Issue 補足で言及されたトランスファーペイン向けパレット項目（`command_palette.py` の `Create file or directory` / shortcut `N` / 実体はファイル作成のみ）の不一致は、本 Issue とは独立した別問題のため別 Issue で切り出します。
