### PR TITLE
#1098 transfer モードの Create コマンドをファイル作成の実体に整合

### DIFF
--- a/src/zivo/state/command_palette.py
+++ b/src/zivo/state/command_palette.py
@@ -1004,8 +1004,8 @@ def _build_transfer_command_palette_items(state: AppState) -> tuple[CommandPalet
         ),
         CommandPaletteItem(
             id="create",
-            label="Create file or directory",
-            shortcut="N",
+            label="Create file",
+            shortcut="n",
             enabled=_active_transfer_pane_state(state) is not None,
         ),
         CommandPaletteItem(

--- a/src/zivo/state/input_transfer.py
+++ b/src/zivo/state/input_transfer.py
@@ -32,6 +32,7 @@ from .selectors import compute_current_pane_visible_window
 TRANSFER_KEYMAP = {
     "D",
     "N",
+    "n",
     "c",
     "d",
     "delete",
@@ -83,7 +84,7 @@ TRANSFER_HELP_LINES = (
         ("r", "rename"),
         ("z", "undo"),
     ),
-    (("N", "new-dir"), (":", "palette")),
+    (("n", "new-file"), ("N", "new-dir"), (":", "palette")),
 )
 
 REMOVED_DIRECT_KEYS = frozenset({"i", "C", "B", "G", "M", "O", "T", "H", "R"})
@@ -185,6 +186,9 @@ def dispatch_transfer_input(
     if key == "q":
         return supported(BeginExitCurrentPath())
 
+    if key == "n":
+        return supported(BeginCreateInput("file"))
+
     if key == "N":
         return supported(BeginCreateInput("dir"))
 
@@ -221,7 +225,7 @@ def dispatch_transfer_input(
     return warn(
         "Use Tab to switch pane, space select, c copy-to-pane, "
         "m move-to-pane, d trash, D permanent-delete, r rename, z undo, "
-        "b bookmarks, . hidden, N new-dir, : palette, or p/Esc to close"
+        "b bookmarks, . hidden, n new-file, N new-dir, : palette, or p/Esc to close"
     )
 
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1391,12 +1391,12 @@ def test_select_help_bar_for_transfer_mode_prioritizes_transfer_actions() -> Non
     assert help_state.lines == (
         "enter dir | . hidden | Tab switch-pane | p/Esc close | q quit",
         "space select | c copy-to-pane | m move-to-pane | d delete | r rename | z undo",
-        "N new-dir | : palette",
+        "n new-file | N new-dir | : palette",
     )
     assert help_state.text == (
         "enter dir | . hidden | Tab switch-pane | p/Esc close | q quit\n"
         "space select | c copy-to-pane | m move-to-pane | d delete | r rename | z undo\n"
-        "N new-dir | : palette"
+        "n new-file | N new-dir | : palette"
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3251,7 +3251,7 @@ async def test_app_displays_transfer_help_bar() -> None:
     expected_help = (
         "enter dir | . hidden | Tab switch-pane | p/Esc close | q quit\n"
         "space select | c copy-to-pane | m move-to-pane | d delete | r rename | z undo\n"
-        "N new-dir | : palette"
+        "n new-file | N new-dir | : palette"
     )
 
     async with app.run_test() as pilot:

--- a/tests/test_help_keymaps.py
+++ b/tests/test_help_keymaps.py
@@ -43,6 +43,8 @@ def test_transfer_help_shortcuts_are_backed_by_the_transfer_keymap() -> None:
 
     assert advertised_keys <= TRANSFER_KEYMAP
     assert {"tab", "shift+tab", "p", "escape", "c", "m"} <= TRANSFER_KEYMAP
+    # n (new-file) / N (new-dir) are both bound so transfer matches browsing.
+    assert {"n", "N"} <= TRANSFER_KEYMAP
     assert {"[", "]", "y", "x", "v"}.isdisjoint(TRANSFER_KEYMAP)
 
 

--- a/tests/test_issue_1098_transfer_create.py
+++ b/tests/test_issue_1098_transfer_create.py
@@ -1,0 +1,55 @@
+"""Issue #1098: transfer モードの Create コマンド shortcut/label と実体の整合。
+
+transfer モードに n（ファイル作成）直接キーを追加して browsing モードと対称化し、
+パレットの Create 項目も実体（ファイル作成）に合わせて label="Create file",
+shortcut="n" に是正する。
+"""
+
+import zivo.state.command_palette as command_palette_module
+from tests.test_state_reducer import _reduce_state
+from zivo.state import build_initial_app_state, dispatch_key_input
+from zivo.state.actions import (
+    BeginCommandPalette,
+    BeginCreateInput,
+    SetNotification,
+    ToggleTransferMode,
+)
+
+
+def _transfer_mode_state():
+    return _reduce_state(build_initial_app_state(), ToggleTransferMode())
+
+
+def test_transfer_mode_n_creates_file() -> None:
+    """transfer モードの n キーはファイル作成プロンプトを開く（browsing と対称）。"""
+    state = _transfer_mode_state()
+
+    assert dispatch_key_input(state, key="n") == (
+        SetNotification(None),
+        BeginCreateInput("file"),
+    )
+
+
+def test_transfer_mode_uppercase_n_creates_directory() -> None:
+    """transfer モードの N キーはディレクトリ作成プロンプトを開く（従来挙動を維持）。"""
+    state = _transfer_mode_state()
+
+    assert dispatch_key_input(state, key="N") == (
+        SetNotification(None),
+        BeginCreateInput("dir"),
+    )
+
+
+def _transfer_palette_create_item():
+    state = _transfer_mode_state()
+    state = _reduce_state(state, BeginCommandPalette())
+    items = command_palette_module.get_command_palette_items(state)
+    return next(item for item in items if item.id == "create")
+
+
+def test_transfer_palette_create_item_matches_file_creation() -> None:
+    """transfer パレットの Create 項目は実体（ファイル作成）に一致する表示を持つ。"""
+    create_item = _transfer_palette_create_item()
+
+    assert create_item.label == "Create file"
+    assert create_item.shortcut == "n"


### PR DESCRIPTION
## 概要
Issue #1098: トランスファーモードのコマンドパレット「Create file or directory」項目で、label/shortcut 表示と実体（ファイル作成のみ）の3点の不一致を解消します。transfer モードに `n`（ファイル作成）直接キーを追加し、browsing モードと対称化します。

## 変更内容
- transfer モードに `n`（ファイル作成）直接キーを追加し、browsing と対称化
- transfer パレット Create 項目を実体に合わせて `label="Create file"`, `shortcut="n"` に是正
- transfer ヘルプバー・fallback メッセージに `n new-file` を追記

## 解決する不一致
| # | 問題 | 解決 |
|---|------|------|
| ① | パレット shortcut `N`（=dir作成キー）で誤認 | `n`（実体＝file作成）に是正 |
| ② | label「file or directory」の誇張 | `Create file` に是正 |
| ③ | file 作成の入り口がパレットのみ（直接キーなし）| 直接キー `n` を追加 |

## テスト結果
- `uv run ruff check .`: **All checks passed**
- `uv run pytest`: **1355 passed, 9 skipped**

## 確認方法（手動）
`uv run zivo` → `p` で transfer モード →
- `n`: ファイル作成プロンプト
- `N`: ディレクトリ作成プロンプト
- `:` パレットの Create 項目: 「Create file / n」表示でファイル作成を起動

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)