### PR TITLE
[#1102] Restore preview syntax theme in config editor

### DIFF
--- a/src/zivo/state/reducer_config.py
+++ b/src/zivo/state/reducer_config.py
@@ -562,7 +562,7 @@ def config_editor_field_description(field_index: int, config: AppConfig) -> tupl
 
 CONFIG_EDITOR_CATEGORIES: tuple[tuple[str, tuple[int, ...]], ...] = (
     ("Editors", (0, 1)),
-    ("Appearance", (3, 2)),
+    ("Appearance", (3, 2, 10)),
     ("Preview", (5, 6, 8, 9)),
     ("Sorting", (13, 14, 15)),
     ("Safety", (18,)),

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -2304,6 +2304,7 @@ def test_select_config_dialog_state_formats_editor_lines() -> None:
     assert "> Theme: textual-dark" in dialog.lines
     assert "  Text preview: true" in dialog.lines
     assert "  Image preview: true" in dialog.lines
+    assert "  Preview syntax theme: auto" in dialog.lines
     assert "  ── Sorting ──" in dialog.lines
     assert "  Default sort field: name" in dialog.lines
     assert "  ── Selected Setting ──" in dialog.lines

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -811,6 +811,24 @@ def test_move_config_editor_cursor_clamps_to_visible_settings() -> None:
     assert next_state.config_editor is not None
     assert next_state.config_editor.cursor_index == 18
 
+
+def test_move_config_editor_cursor_reaches_preview_syntax_theme() -> None:
+    state = replace(
+        build_initial_app_state(config_path="/tmp/zivo/config.toml"),
+        ui_mode="CONFIG",
+        config_editor=ConfigEditorState(
+            path="/tmp/zivo/config.toml",
+            draft=build_initial_app_state().config,
+            cursor_index=2,
+        ),
+    )
+
+    next_state = _reduce_state(state, MoveConfigEditorCursor(delta=1))
+
+    assert next_state.config_editor is not None
+    assert next_state.config_editor.cursor_index == 10
+
+
 def test_cycle_config_editor_editor_command_updates_draft_and_dirty_state() -> None:
     state = replace(
         build_initial_app_state(config_path="/tmp/zivo/config.toml"),


### PR DESCRIPTION
## Summary
- Restore `preview_syntax_theme` to the config editor Appearance category
- Ensure the setting is rendered and reachable by visual cursor navigation

## Tests
- `uv run ruff check .`
- `uv run pytest -q` (1369 passed, 9 skipped)

Fixes #1102