### PR TITLE
[#1122] Integrate preview metadata into attribute bar

### DIFF
--- a/src/zivo/app.tcss
+++ b/src/zivo/app.tcss
@@ -103,6 +103,15 @@ Screen {
     color: $text-muted;
 }
 
+.pane-metadata-bar {
+    height: 1;
+    width: 1fr;
+    padding: 0 1;
+    background: $surface;
+    color: $text-muted;
+    overflow: hidden;
+}
+
 .pane-status {
     layer: status;
     height: 1fr;

--- a/src/zivo/models/shell_data.py
+++ b/src/zivo/models/shell_data.py
@@ -180,7 +180,7 @@ class PaneStatusViewState:
 
 @dataclass(frozen=True)
 class MetadataItemViewState:
-    """Compact metadata row used as a preview fallback."""
+    """One labeled metadata item used by fallback and attribute-bar views."""
 
     label: str
     value: str
@@ -201,7 +201,7 @@ class ChildPaneViewState:
     preview_start_line: int | None = None
     preview_highlight_line: int | None = None
     syntax_theme: str = "monokai"
-    permissions_label: str = ""
+    metadata_bar: tuple[MetadataItemViewState, ...] = ()
     preview_word_wrap: bool = False
     preview_scroll_hint: str | None = None
     view_kind: str = "entries"

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -34,7 +34,7 @@ from .selectors_shared import (
     _format_child_preview_title,
     _format_current_entry_name_detail,
     _format_entry_size_label_from_cache,
-    _format_permissions_detail_label,
+    _format_permissions_label,
     _format_side_pane_name_detail_from_cache,
     _format_size_label,
     _format_sort_label,
@@ -202,13 +202,13 @@ def _select_child_pane_for_cursor_base(
         _select_active_app_theme(state),
         _select_active_preview_syntax_theme(state),
     )
-    permissions_label = _format_permissions_detail_label(cursor_entry) if cursor_entry else ""
     palette_preview = _select_command_palette_preview_pane(state, syntax_theme)
     if palette_preview is not None:
         return palette_preview
 
+    metadata_bar = _select_child_metadata_bar(state, cursor_entry)
     if cursor_entry is None:
-        return _build_child_entries_view((), syntax_theme, permissions_label)
+        return _build_child_entries_view((), syntax_theme, metadata_bar)
 
     if (
         state.pending_child_pane_request_id is not None
@@ -218,7 +218,7 @@ def _select_child_pane_for_cursor_base(
             "loading",
             "Loading preview…" if cursor_entry.kind == "file" else "Loading directory…",
             syntax_theme,
-            permissions_label=permissions_label,
+            metadata_bar=metadata_bar,
         )
 
     is_archive = cursor_entry.kind == "file" and is_supported_archive_path(cursor_entry.path)
@@ -229,7 +229,7 @@ def _select_child_pane_for_cursor_base(
             state.child_pane.mode != "entries"
             or cursor_entry.path != state.child_pane.directory_path
         ):
-            return _build_child_entries_view((), syntax_theme, permissions_label)
+            return _build_child_entries_view((), syntax_theme, metadata_bar)
     elif state.child_pane.mode != "preview" or cursor_entry.path != state.child_pane.preview_path:
         preview_disabled_message = _detect_preview_disabled_message(
             cursor_entry,
@@ -255,12 +255,11 @@ def _select_child_pane_for_cursor_base(
                 syntax_theme,
                 actions=(PaneActionViewState("edit_config", "Edit config", ":"),),
                 metadata=tuple(metadata),
-                permissions_label=permissions_label,
             )
         return _build_child_entries_view(
             (),
             syntax_theme,
-            permissions_label,
+            metadata_bar,
         )
 
     if state.child_pane.mode == "preview" and state.child_pane.preview_content is not None:
@@ -275,7 +274,7 @@ def _select_child_pane_for_cursor_base(
             state.child_pane.preview_start_line,
             state.child_pane.preview_highlight_line,
             syntax_theme,
-            permissions_label,
+            metadata_bar,
             state.config.display.preview_word_wrap,
             preview_scroll_hint=_browsing_preview_scroll_hint(state),
         )
@@ -288,7 +287,6 @@ def _select_child_pane_for_cursor_base(
             state.child_pane.preview_message,
             state.child_pane.preview_metadata,
             syntax_theme,
-            permissions_label,
         )
 
     if state.child_pane.mode == "preview" and state.child_pane.preview_reason is not None:
@@ -298,7 +296,6 @@ def _select_child_pane_for_cursor_base(
             None,
             state.child_pane.preview_metadata,
             syntax_theme,
-            permissions_label,
         )
 
     visible_entries = _select_side_pane_entry_states(state.child_pane.entries, state.show_hidden)
@@ -314,13 +311,54 @@ def _select_child_pane_for_cursor_base(
             "empty",
             "Empty directory",
             syntax_theme,
-            permissions_label=permissions_label,
+            metadata_bar=metadata_bar,
         )
     return _build_child_entries_view(
         entries,
         syntax_theme,
-        permissions_label,
+        metadata_bar,
     )
+
+
+def _select_child_metadata_bar(
+    state: AppState,
+    cursor_entry: DirectoryEntryState | None,
+) -> tuple[MetadataItemViewState, ...]:
+    """Return lightweight attributes for the selected child-pane target.
+
+    The bar intentionally uses metadata already present in browser state.
+    Owner/group resolution remains an optional value and is never triggered
+    by rendering; detailed inspection keeps its existing lazy path.
+    """
+
+    if cursor_entry is None:
+        return ()
+
+    size_bytes = cursor_entry.size_bytes
+    if cursor_entry.kind == "dir":
+        cached_size = _directory_size_cache_by_path(state.directory_size_cache).get(
+            cursor_entry.path
+        )
+        if cached_size is not None and cached_size.status == "ready":
+            size_bytes = cached_size.size_bytes
+        else:
+            size_bytes = None
+
+    items: list[MetadataItemViewState] = []
+    if size_bytes is not None:
+        items.append(MetadataItemViewState("Size", _format_size_label(size_bytes)))
+    if cursor_entry.permissions_mode is not None:
+        items.append(
+            MetadataItemViewState(
+                "Permissions", _format_permissions_label(cursor_entry.permissions_mode)
+            )
+        )
+    owner_group = " ".join(
+        value for value in (cursor_entry.owner, cursor_entry.group) if value
+    )
+    if owner_group:
+        items.append(MetadataItemViewState("Owner/group", owner_group))
+    return tuple(items)
 
 
 def select_child_pane_for_cursor(
@@ -374,10 +412,7 @@ def _format_child_semantic_title(
         role = "Preview" if cursor_entry.kind == "file" else "Contents"
         return f"{role} · {target_name} · loading"
     if view.is_preview or cursor_entry.kind == "file":
-        title = f"Preview · {target_name}"
-        if cursor_entry.size_bytes is not None:
-            title += f" · {_format_size_label(cursor_entry.size_bytes)}"
-        return title
+        return f"Preview · {target_name}"
 
     return f"Contents · {target_name} · {len(view.entries)} items"
 
@@ -769,13 +804,13 @@ def _select_side_pane_entries(
 def _build_child_entries_view(
     entries: tuple[PaneEntry, ...],
     syntax_theme: str,
-    permissions_label: str = "",
+    metadata_bar: tuple[MetadataItemViewState, ...] = (),
 ) -> ChildPaneViewState:
     return ChildPaneViewState(
         title="Child Directory",
         entries=entries,
         syntax_theme=syntax_theme,
-        permissions_label=permissions_label,
+        metadata_bar=metadata_bar,
         view_kind="entries",
     )
 
@@ -791,7 +826,7 @@ def _build_child_preview_view(
     preview_start_line: int | None,
     preview_highlight_line: int | None,
     syntax_theme: str,
-    permissions_label: str = "",
+    metadata_bar: tuple[MetadataItemViewState, ...] = (),
     preview_word_wrap: bool = False,
     preview_scroll_hint: str | None = None,
 ) -> ChildPaneViewState:
@@ -806,7 +841,7 @@ def _build_child_preview_view(
         preview_start_line=preview_start_line,
         preview_highlight_line=preview_highlight_line,
         syntax_theme=syntax_theme,
-        permissions_label=permissions_label,
+        metadata_bar=metadata_bar,
         preview_word_wrap=preview_word_wrap,
         preview_scroll_hint=preview_scroll_hint,
         view_kind="preview",
@@ -821,12 +856,12 @@ def _build_child_status_view(
     detail: str | None = None,
     actions: tuple[PaneActionViewState, ...] = (),
     metadata: tuple[MetadataItemViewState, ...] = (),
-    permissions_label: str = "",
+    metadata_bar: tuple[MetadataItemViewState, ...] = (),
 ) -> ChildPaneViewState:
     return ChildPaneViewState(
         title="Preview" if kind not in {"empty", "loading"} else "Child Directory",
         syntax_theme=syntax_theme,
-        permissions_label=permissions_label,
+        metadata_bar=metadata_bar,
         view_kind=kind,
         status=PaneStatusViewState(kind=kind, title=title, detail=detail, actions=actions),
         metadata=metadata,
@@ -839,7 +874,6 @@ def _build_preview_fallback_view(
     message: str | None,
     metadata_state,
     syntax_theme: str,
-    permissions_label: str,
 ) -> ChildPaneViewState:
     titles = {
         "unsupported": "Preview unavailable for this file type",
@@ -888,7 +922,6 @@ def _build_preview_fallback_view(
         preview_path=preview_path,
         preview_message=message,
         syntax_theme=syntax_theme,
-        permissions_label=permissions_label,
         view_kind=reason,
         status=PaneStatusViewState(
             kind=reason,

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -3,6 +3,7 @@
 import re
 from pathlib import Path as FsPath
 
+from rich.cells import cell_len
 from rich.color import Color
 from rich.style import Style
 from rich.syntax import Syntax
@@ -15,7 +16,7 @@ from textual.message import Message
 from textual.timer import Timer
 from textual.widgets import Label, Static
 
-from zivo.models.shell_data import ChildPaneViewState
+from zivo.models.shell_data import ChildPaneViewState, MetadataItemViewState
 from zivo.services.previews.core import ChafaImagePreviewLoader, ImagePreviewLoader
 
 from .pane_rendering import (
@@ -24,6 +25,7 @@ from .pane_rendering import (
     _guess_preview_lexer,
     _render_file_entries,
     _resolve_component_styles,
+    truncate_middle,
 )
 from .pane_status import render_pane_status
 from .side_pane import SidePane
@@ -103,8 +105,8 @@ class ChildPane(Vertical):
         return f"{self.id}-preview-help" if self.id else None
 
     @property
-    def permissions_id(self) -> str | None:
-        return f"{self.id}-permissions" if self.id else None
+    def metadata_bar_id(self) -> str | None:
+        return f"{self.id}-metadata-bar" if self.id else None
 
     def compose(self) -> ComposeResult:
         yield Label(self._state.display_title, classes="pane-title")
@@ -144,19 +146,21 @@ class ChildPane(Vertical):
         yield list_content
         yield preview_scroll
         yield preview_help
-        permissions = Static(
-            self._state.permissions_label,
-            id=self.permissions_id,
-            classes="pane-permissions",
+        metadata_bar = Static(
+            self._render_metadata_bar(self._state.metadata_bar, 0),
+            id=self.metadata_bar_id,
+            classes="pane-metadata-bar",
         )
-        permissions.can_focus = False
-        yield permissions
+        metadata_bar.can_focus = False
+        yield metadata_bar
 
     def on_mount(self) -> None:
         self._ft_styles = _resolve_component_styles(self)
+        self.call_after_refresh(self._refresh_metadata_bar)
         self.call_after_refresh(self._refresh_rendered_content)
 
     def on_resize(self, _event: events.Resize) -> None:
+        self._refresh_metadata_bar()
         self._refresh_rendered_content()
 
     def on_click(self, event: events.Click) -> None:
@@ -238,8 +242,11 @@ class ChildPane(Vertical):
         ):
             preview_help.update(state.preview_scroll_hint or "")
             preview_help.display = state.preview_scroll_hint is not None
-        if state.permissions_label != previous_state.permissions_label:
-            self._permissions_widget().update(state.permissions_label)
+        if state.metadata_bar != previous_state.metadata_bar:
+            try:
+                self._refresh_metadata_bar(force=True)
+            except NoMatches:
+                pass
         if render_signature_changed or mode_changed:
             rendered = self._refresh_rendered_content(force=True)
             if not rendered:
@@ -364,8 +371,48 @@ class ChildPane(Vertical):
     def _preview_help_widget(self) -> Label:
         return self.query_one(f"#{self.preview_help_id}", Label)
 
-    def _permissions_widget(self) -> Static:
-        return self.query_one(f"#{self.permissions_id}", Static)
+    def _metadata_bar_widget(self) -> Static:
+        return self.query_one(f"#{self.metadata_bar_id}", Static)
+
+    def _refresh_metadata_bar(self, *, force: bool = False) -> bool:
+        try:
+            widget = self._metadata_bar_widget()
+        except NoMatches:
+            return False
+        render_width = max(0, widget.size.width - 2)
+        if render_width <= 0:
+            return False
+        rendered = self._render_metadata_bar(self._state.metadata_bar, render_width)
+        if force or str(widget.renderable) != rendered:
+            widget.update(rendered)
+        return True
+
+    @staticmethod
+    def _render_metadata_bar(
+        items: tuple[MetadataItemViewState, ...],
+        max_width: int,
+    ) -> str:
+        """Render one-line attributes, dropping lower-priority items first."""
+
+        if max_width <= 0 or not items:
+            return ""
+        separator = " · "
+        values = [item.value for item in items]
+        visible: list[str] = []
+        for value in values:
+            candidate = separator.join((*visible, value))
+            if cell_len(candidate) > max_width:
+                break
+            visible.append(value)
+        if not visible:
+            return truncate_middle(values[0], max_width)
+        rendered = separator.join(visible)
+        if len(visible) < len(values):
+            ellipsis = " …"
+            if cell_len(rendered + ellipsis) <= max_width:
+                return rendered + ellipsis
+            return truncate_middle(rendered, max_width)
+        return rendered
 
     def preview_render_width(self) -> int:
         """Return the currently available preview width in terminal cells."""

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1120,6 +1120,88 @@ def test_select_shell_data_exposes_semantic_pane_headers() -> None:
     assert shell.child_pane.display_title.startswith("Contents · ")
 
 
+def test_child_preview_moves_size_into_metadata_bar() -> None:
+    initial_state = build_initial_app_state()
+    path = "/home/tadashi/develop/zivo/README.md"
+    state = replace(
+        initial_state,
+        current_pane=replace(initial_state.current_pane, cursor_path=path),
+        child_pane=PaneState(
+            directory_path=initial_state.current_path,
+            entries=(),
+            mode="preview",
+            preview_path=path,
+            preview_content="# Preview\n",
+        ),
+    )
+
+    child = select_shell_data(state).child_pane
+
+    assert child.display_title == "Preview · README.md"
+    assert [(item.label, item.value) for item in child.metadata_bar] == [
+        ("Size", "2.1KiB"),
+    ]
+
+
+def test_child_directory_uses_cached_size_and_permissions_in_metadata_bar() -> None:
+    initial_state = build_initial_app_state()
+    path = "/home/tadashi/develop/zivo/docs"
+    directory = DirectoryEntryState(
+        path,
+        "docs",
+        "dir",
+        modified_at=initial_state.current_pane.entries[0].modified_at,
+        permissions_mode=0o40755,
+    )
+    state = replace(
+        initial_state,
+        current_pane=replace(initial_state.current_pane, entries=(directory,), cursor_path=path),
+        child_pane=PaneState(
+            directory_path=initial_state.current_path,
+            entries=(),
+            mode="entries",
+        ),
+        directory_size_cache=(DirectorySizeCacheEntry(path, "ready", size_bytes=4096),),
+    )
+
+    child = select_shell_data(state).child_pane
+
+    assert child.display_title == "Contents · docs · 0 items"
+    assert [(item.label, item.value) for item in child.metadata_bar] == [
+        ("Size", "4.0KiB"),
+        ("Permissions", "drwxr-xr-x (755)"),
+    ]
+
+
+def test_preview_fallback_does_not_duplicate_attribute_bar() -> None:
+    initial_state = build_initial_app_state()
+    path = f"{initial_state.current_path}/data.bin"
+    state = replace(
+        initial_state,
+        current_pane=replace(
+            initial_state.current_pane,
+            entries=(DirectoryEntryState(path, "data.bin", "file", size_bytes=2048),),
+            cursor_path=path,
+        ),
+        child_pane=PaneState(
+            directory_path=initial_state.current_path,
+            entries=(),
+            mode="preview",
+            preview_path=path,
+            preview_reason="unsupported",
+            preview_metadata=PreviewMetadataState(
+                display_name="data.bin",
+                type_label="BIN",
+                size_bytes=2048,
+            ),
+        ),
+    )
+
+    child = select_shell_data(state).child_pane
+
+    assert child.metadata_bar == ()
+
+
 def test_select_shell_data_hides_cursor_while_filtering() -> None:
     state = _reduce_state(build_initial_app_state(), BeginFilterInput())
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1070,6 +1070,55 @@ async def test_app_renders_text_preview_in_child_pane_for_file_cursor() -> None:
 
 
 @pytest.mark.asyncio
+async def test_app_renders_preview_metadata_bar_for_file_cursor() -> None:
+    path = str(Path("/tmp/zivo-preview-metadata").resolve())
+    readme = f"{path}/README.md"
+    loader = FakeBrowserSnapshotLoader(
+        snapshots={
+            path: BrowserSnapshot(
+                current_path=path,
+                parent_pane=PaneState(
+                    directory_path="/tmp",
+                    entries=(DirectoryEntryState(path, "zivo-preview-metadata", "dir"),),
+                    cursor_path=path,
+                ),
+                current_pane=PaneState(
+                    directory_path=path,
+                    entries=(
+                        DirectoryEntryState(
+                            readme,
+                            "README.md",
+                            "file",
+                            size_bytes=2_150,
+                            permissions_mode=0o100644,
+                            owner="alice",
+                            group="staff",
+                        ),
+                    ),
+                    cursor_path=readme,
+                ),
+                child_pane=PaneState(
+                    directory_path=path,
+                    entries=(),
+                    mode="preview",
+                    preview_path=readme,
+                    preview_content="# Title\npreview body\n",
+                ),
+            )
+        }
+    )
+    app = create_app(snapshot_loader=loader, initial_path=path)
+
+    async with app.run_test(size=(120, 20)):
+        await _wait_for_snapshot_loaded(app, path)
+        await _wait_for_child_preview(app, "Preview · README.md", "# Title")
+
+        metadata_bar = app.query_one("#child-pane-metadata-bar", Static)
+
+        assert str(metadata_bar.renderable) == "2.1KiB · -rw-r--r-- (644) · alice staff"
+
+
+@pytest.mark.asyncio
 async def test_app_renders_image_preview_in_child_pane_for_file_cursor() -> None:
     path = str(Path("/tmp/zivo-image-preview").resolve())
     image = f"{path}/preview.png"

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -12,6 +12,7 @@ from zivo.models import (
     CurrentPaneSizeUpdate,
     CurrentSummaryState,
     HelpBarState,
+    MetadataItemViewState,
     PaneEntry,
 )
 from zivo.ui.help_bar import HelpBar
@@ -81,6 +82,20 @@ def test_truncate_middle_preserves_file_extension_when_possible() -> None:
 def test_truncate_middle_handles_extremely_narrow_widths() -> None:
     assert truncate_middle("README.md", 1) == "~"
     assert truncate_middle("README.md", 2) == "~d"
+
+
+def test_child_metadata_bar_keeps_priority_order_at_narrow_widths() -> None:
+    items = (
+        MetadataItemViewState("Size", "2.1MiB"),
+        MetadataItemViewState("Permissions", "-rw-r--r-- (644)"),
+        MetadataItemViewState("Owner/group", "alice staff"),
+    )
+
+    assert ChildPane._render_metadata_bar(items, 80) == (
+        "2.1MiB · -rw-r--r-- (644) · alice staff"
+    )
+    assert ChildPane._render_metadata_bar(items, 28) == "2.1MiB · -rw-r--r-- (644) …"
+    assert ChildPane._render_metadata_bar(items, 8) == "2.1MiB …"
 
 
 def test_build_entry_label_truncates_full_name_detail_string() -> None:


### PR DESCRIPTION
## Summary
- remove file size from the preview title and move it into a responsive attribute bar
- apply the same lightweight metadata treatment to file and directory targets
- keep fallback metadata and Show attributes as the detailed path without duplicate rendering

## Product review
- reviewed with product-spec-review
- retained only metadata already available in browser state
- avoided owner/group lookups and new recursive directory-size work

## Tests
- `uv run ruff check .`
- `uv run pytest -q` (1437 passed, 9 skipped)

Closes #1122