### PR TITLE
[#1111] Throttle pane rebuilds during resize

### DIFF
--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -28,6 +28,7 @@ from .pane_rendering import (
     truncate_middle,
 )
 from .pane_status import render_pane_status
+from .resize_debounce import ResizeDebouncer
 from .side_pane import SidePane
 
 _SGR_SEQUENCE_RE = re.compile(r"\x1b\[([0-9;]*)m")
@@ -87,6 +88,11 @@ class ChildPane(Vertical):
         self._chafa_resize_request_id = 0
         self._pending_chafa_resize_key: tuple[str, int, str] | None = None
         self._image_preview_loader = image_preview_loader or ChafaImagePreviewLoader()
+        self._resize_debouncer = ResizeDebouncer(
+            self,
+            self._refresh_after_resize,
+            name="child-pane-resize-debounce",
+        )
 
     @property
     def list_view_id(self) -> str | None:
@@ -160,6 +166,9 @@ class ChildPane(Vertical):
         self.call_after_refresh(self._refresh_rendered_content)
 
     def on_resize(self, _event: events.Resize) -> None:
+        self._resize_debouncer.schedule()
+
+    def _refresh_after_resize(self) -> None:
         self._refresh_metadata_bar()
         self._refresh_rendered_content()
 
@@ -262,6 +271,7 @@ class ChildPane(Vertical):
                 self.call_after_refresh(lambda: scroll_widget.scroll_home(animate=False))
 
     def on_unmount(self) -> None:
+        self._resize_debouncer.stop()
         self._invalidate_chafa_resize_requests()
         if self._state.is_preview and self._state.preview_kind == "kitty":
             self._clear_kitty_content()

--- a/src/zivo/ui/main_pane.py
+++ b/src/zivo/ui/main_pane.py
@@ -32,6 +32,7 @@ from .pane_rendering import (
     truncate_middle,
 )
 from .pane_status import render_pane_status
+from .resize_debounce import ResizeDebouncer
 from .summary_bar import SummaryBar
 
 
@@ -150,6 +151,11 @@ class MainPane(Vertical):
         self._last_table_width = 0
         self._last_clicked_path: str | None = None
         self._visible_columns: tuple[str, ...] = self.COLUMN_KEYS
+        self._resize_debouncer = ResizeDebouncer(
+            self,
+            self._refresh_after_resize,
+            name="main-pane-resize-debounce",
+        )
 
     @property
     def table_id(self) -> str | None:
@@ -193,6 +199,12 @@ class MainPane(Vertical):
         self.call_after_refresh(self._refresh_table_width)
 
     def on_resize(self, _event: events.Resize) -> None:
+        self._resize_debouncer.schedule()
+
+    def on_unmount(self) -> None:
+        self._resize_debouncer.stop()
+
+    def _refresh_after_resize(self) -> None:
         self._refresh_table_width()
 
     async def handle_table_row_clicked(self, row_index: int) -> None:

--- a/src/zivo/ui/resize_debounce.py
+++ b/src/zivo/ui/resize_debounce.py
@@ -1,0 +1,46 @@
+"""Helpers for coalescing expensive widget work during terminal resizes."""
+
+from collections.abc import Callable
+
+from textual.timer import Timer
+from textual.widget import Widget
+
+RESIZE_DEBOUNCE_SECONDS = 0.05
+
+
+class ResizeDebouncer:
+    """Run a resize callback once after a burst of resize events."""
+
+    def __init__(self, owner: Widget, callback: Callable[[], None], *, name: str) -> None:
+        self._owner = owner
+        self._callback = callback
+        self._name = name
+        self._timer: Timer | None = None
+        self._generation = 0
+
+    def schedule(self) -> None:
+        """Reset the debounce window and schedule the latest resize callback."""
+
+        self._generation += 1
+        generation = self._generation
+        if self._timer is not None:
+            self._timer.stop()
+        self._timer = self._owner.set_timer(
+            RESIZE_DEBOUNCE_SECONDS,
+            lambda: self._run(generation),
+            name=self._name,
+        )
+
+    def stop(self) -> None:
+        """Cancel pending work, including callbacks from stale timers."""
+
+        self._generation += 1
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+
+    def _run(self, generation: int) -> None:
+        if generation != self._generation:
+            return
+        self._timer = None
+        self._callback()

--- a/src/zivo/ui/side_pane.py
+++ b/src/zivo/ui/side_pane.py
@@ -18,6 +18,7 @@ from .pane_rendering import (
     _render_file_entries,
     _resolve_component_styles,
 )
+from .resize_debounce import ResizeDebouncer
 
 
 class SidePane(Vertical):
@@ -52,6 +53,11 @@ class SidePane(Vertical):
         self._last_clicked_path: str | None = None
         self._hovered_path: str | None = None
         self._label_cache = _FileEntryLabelCache()
+        self._resize_debouncer = ResizeDebouncer(
+            self,
+            self._refresh_after_resize,
+            name="side-pane-resize-debounce",
+        )
 
     @property
     def list_view_id(self) -> str | None:
@@ -88,6 +94,12 @@ class SidePane(Vertical):
         self.call_after_refresh(self._refresh_rendered_labels)
 
     def on_resize(self, _event: events.Resize) -> None:
+        self._resize_debouncer.schedule()
+
+    def on_unmount(self) -> None:
+        self._resize_debouncer.stop()
+
+    def _refresh_after_resize(self) -> None:
         self._refresh_rendered_labels()
 
     def on_click(self, event: events.Click) -> None:

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -29,6 +29,98 @@ from zivo.ui.panes import (
     build_entry_label,
     truncate_middle,
 )
+from zivo.ui.resize_debounce import ResizeDebouncer
+
+
+def test_resize_debouncer_runs_only_latest_scheduled_callback() -> None:
+    callbacks: list[object] = []
+    timers: list[SimpleNamespace] = []
+
+    class Owner:
+        def set_timer(self, delay: float, callback: object, *, name: str) -> SimpleNamespace:
+            timer = SimpleNamespace(delay=delay, callback=callback, name=name, stop=Mock())
+            timers.append(timer)
+            return timer
+
+    debouncer = ResizeDebouncer(Owner(), lambda: callbacks.append("refresh"), name="test-resize")
+
+    debouncer.schedule()
+    debouncer.schedule()
+    debouncer.schedule()
+
+    assert timers[0].delay == pytest.approx(0.05)
+    assert timers[0].stop.call_count == 1
+    assert timers[1].stop.call_count == 1
+    assert timers[2].stop.call_count == 0
+    timers[0].callback()
+    timers[1].callback()
+    assert callbacks == []
+
+    timers[2].callback()
+
+    assert callbacks == ["refresh"]
+    assert timers[2].name == "test-resize"
+
+
+def test_resize_debouncer_stop_ignores_pending_callback() -> None:
+    timers: list[SimpleNamespace] = []
+
+    class Owner:
+        def set_timer(self, _delay: float, callback: object, *, name: str) -> SimpleNamespace:
+            timer = SimpleNamespace(callback=callback, name=name, stop=Mock())
+            timers.append(timer)
+            return timer
+
+    callback = Mock()
+    debouncer = ResizeDebouncer(Owner(), callback, name="test-resize")
+    debouncer.schedule()
+    debouncer.stop()
+    timers[0].callback()
+
+    callback.assert_not_called()
+    timers[0].stop.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "pane_factory",
+    (
+        lambda: MainPane(
+            "Current",
+            (),
+            summary=CurrentSummaryState(item_count=0, selected_count=0, sort_label="Name"),
+        ),
+        lambda: SidePane("Parent", ()),
+        lambda: ChildPane(ChildPaneViewState(title="Child")),
+    ),
+)
+def test_panes_debounce_resize_refresh(pane_factory) -> None:
+    pane = pane_factory()
+    pane._resize_debouncer.schedule = Mock()  # type: ignore[method-assign]
+
+    pane.on_resize(SimpleNamespace())
+
+    pane._resize_debouncer.schedule.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "pane_factory",
+    (
+        lambda: MainPane(
+            "Current",
+            (),
+            summary=CurrentSummaryState(item_count=0, selected_count=0, sort_label="Name"),
+        ),
+        lambda: SidePane("Parent", ()),
+        lambda: ChildPane(ChildPaneViewState(title="Child")),
+    ),
+)
+def test_panes_stop_pending_resize_refresh_on_unmount(pane_factory) -> None:
+    pane = pane_factory()
+    pane._resize_debouncer.stop = Mock()  # type: ignore[method-assign]
+
+    pane.on_unmount()
+
+    pane._resize_debouncer.stop.assert_called_once_with()
 
 
 def _style_map() -> dict[str, Style]:


### PR DESCRIPTION
## Summary

- Add a shared resize debouncer for MainPane, SidePane, and ChildPane.
- Coalesce rapid resize events and stop pending timers during unmount.
- Add regression tests for stale callbacks, pane integration, and cleanup.

## Verification

- uv run ruff check .
- uv run pytest (1452 passed, 9 skipped)
- uv run pytest tests/test_ui_panes.py -q (62 passed)
- 1000-entry MainPane rebuild measurement: 8.81 ms; 30 rapid resize events produce 1 effective refresh.

Closes #1111