### PR TITLE
[#1113] Avoid rebuilding MainPane path index for deltas

### DIFF
--- a/src/zivo/ui/main_pane.py
+++ b/src/zivo/ui/main_pane.py
@@ -403,7 +403,6 @@ class MainPane(Vertical):
             return
 
         self._entries = tuple(next_entries)
-        self._path_row_index = self._build_path_row_index(self._entries)
         table = self.query_one(DataTable)
         for row_key, entry in changed_rows:
             try:
@@ -417,7 +416,8 @@ class MainPane(Vertical):
         if not updates:
             return
 
-        changed_rows: list[tuple[str, PaneEntry]] = []
+        changed_rows: list[tuple[str, PaneEntry, int]] = []
+        path_index_changed = False
         next_entries: list[PaneEntry] | None = None
         update_by_row = {
             row_index: entry
@@ -434,17 +434,18 @@ class MainPane(Vertical):
             if next_entries is None:
                 next_entries = list(self._entries)
             next_entries[row_index] = next_entry
-            changed_rows.append((self._slot_row_key(row_index), next_entry))
+            changed_rows.append((self._slot_row_key(row_index), next_entry, row_index))
+            path_index_changed = path_index_changed or next_entry.path != entry.path
 
         if not changed_rows:
             return
 
         self._entries = tuple(next_entries)
-        self._path_row_index = self._build_path_row_index(self._entries)
+        if path_index_changed:
+            self._path_row_index = self._build_path_row_index(self._entries)
         table = self.query_one(DataTable)
         column_widths = self._allocate_column_widths(table, self._visible_columns)
-        for row_key, entry in changed_rows:
-            row_index = self._path_row_index.get(entry.path)
+        for row_key, entry, row_index in changed_rows:
             next_cells = self._build_row_cells(entry, column_widths, row_index=row_index)
             for column_key, next_cell in zip(
                 self._visible_columns,

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -874,6 +874,7 @@ def test_apply_row_updates_updates_slot_key_for_visible_row() -> None:
         PaneEntry("b.txt", "file", path="/path/b.txt"),
     )
     pane = MainPane(title="Test", entries=entries, summary=summary)
+    path_row_index = pane._path_row_index
     table = Mock(spec=DataTable)
     table.size.width = 80
     table.cell_padding = 1
@@ -890,6 +891,7 @@ def test_apply_row_updates_updates_slot_key_for_visible_row() -> None:
     )
 
     assert pane._entries[1].name == "renamed.txt"
+    assert pane._path_row_index is path_row_index
     assert table.update_cell.call_count == 4
     assert table.update_cell.call_args_list[0].args[0] == "__slot__:1"
 
@@ -901,6 +903,7 @@ def test_apply_size_updates_updates_only_target_slot() -> None:
         PaneEntry("b.txt", "file", path="/path/b.txt", size_label="2 B"),
     )
     pane = MainPane(title="Test", entries=entries, summary=summary)
+    path_row_index = pane._path_row_index
     table = Mock(spec=DataTable)
     pane.query_one = Mock(return_value=table)
 
@@ -916,9 +919,40 @@ def test_apply_size_updates_updates_only_target_slot() -> None:
 
     assert pane._entries[0] is entries[0]
     assert pane._entries[1].size_label == "3 B"
+    assert pane._path_row_index is path_row_index
     table.update_cell.assert_called_once()
     assert table.update_cell.call_args.args[0] == "__slot__:1"
     assert table.update_cell.call_args.args[1] == "size"
+
+
+def test_apply_row_updates_refreshes_path_row_index_when_path_changes() -> None:
+    summary = CurrentSummaryState(item_count=2, selected_count=0, sort_label="Name")
+    entries = (
+        PaneEntry("a.txt", "file", path="/path/a.txt"),
+        PaneEntry("b.txt", "file", path="/path/b.txt"),
+    )
+    pane = MainPane(title="Test", entries=entries, summary=summary)
+    path_row_index = pane._path_row_index
+    table = Mock(spec=DataTable)
+    table.size.width = 80
+    table.cell_padding = 1
+    pane.query_one = Mock(return_value=table)
+
+    pane.apply_row_updates(
+        (
+            CurrentPaneRowUpdate(
+                path="/path/b.txt",
+                entry=PaneEntry("renamed.txt", "file", path="/path/renamed.txt"),
+                row_index=1,
+            ),
+        )
+    )
+
+    assert pane._path_row_index is not path_row_index
+    assert pane._path_row_index == {
+        "/path/a.txt": 0,
+        "/path/renamed.txt": 1,
+    }
 
 
 def test_apply_size_updates_resolves_stale_row_index_by_path_index() -> None:


### PR DESCRIPTION
## Summary
- avoid rebuilding MainPane's path-to-row index for size deltas
- reuse the existing index for row updates when paths are unchanged
- rebuild only when a row update changes its path and add regression coverage

## Issue
- Closes #1113

## Validation
- `uv run ruff check .`
- `uv run pytest tests/test_ui_panes.py -q` (63 passed)
- `uv run pytest` (1469 passed, 9 skipped)
- path-index rebuild timing: 1,000 entries ~0.05 ms, 10,000 ~0.55 ms, 100,000 ~6.83 ms per rebuild
