### PR TITLE
[#1112] Bound directory history size

### DIFF
--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -9,6 +9,8 @@ Transferモードでは、アクティブな転送ペインで実行できるコ
 
 クエリが空の場合は、`Navigate`、`File`、`Search`、`View`、`System`、`Custom actions` の固定カテゴリを表示します。カテゴリ順とコマンド順位は決定的で、利用履歴やテレメトリは使用しません。
 
+Directory History と Go の最近の履歴は、最後に訪問したディレクトリから新しい順に表示します。各タブと Transfer の各ペインは、最新の重複しないディレクトリパスを100件までメモリに保持し、古い項目を自動的に破棄します。
+
 最新の操作に次アクションがある場合、通常の `commands` パレットの先頭に条件付きで `Suggested` を1件だけ表示します。表示優先順位は `Undo`、`Open destination`、安全な `Retry`、`Details` です。StatusBar と条件付き `Suggested` は同じ stable action ID と reducer 経路を共有し、既存キーボード経路は現在の意味を維持します。新しいグローバルキーは追加せず、既存の `Enter` / `r` の意味も変更しません。表示開始から5秒で自動消去するのは最終成功通知だけで、処理中・warning/error・partial success は自動消去しません。
 
 `Retry` は、成功・skip・overwrite がなく、元の `PasteRequest` の conflict resolution が未指定である貼り付け失敗、成功・適用済み変更がない Duplicate 失敗、archive/zip 準備失敗に限定します。Retry は毎回 fresh preparation/preflight を行い、競合や対象変更があれば既存の競合確認・再確認経路へ戻ります。`Details` は失敗件数、対象パス、理由を表示し、`Enter` または `Esc` で閉じます。

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,6 +9,8 @@ In normal browsing, the path bar also exposes clickable breadcrumb segments and 
 
 When the query is empty, the palette shows the fixed `Navigate`, `File`, `Search`, `View`, `System`, and `Custom actions` sections. Category order and command ranking are deterministic and do not use usage history or telemetry.
 
+Directory History and the Go palette's recent-history source show the most recently visited directories first. Each tab and transfer pane keeps the latest 100 unique directory paths in memory; older entries are discarded automatically.
+
 When the latest operation has a next action, the empty `commands` palette conditionally prepends one `Suggested` item. At most one action is exposed, in this order: `Undo`, `Open destination`, safe `Retry`, `Details`. The StatusBar and conditional `Suggested` item share the same stable action ID and reducer path; existing keyboard routes keep their current meanings. No new global key is added, and existing `Enter` / `r` meanings are unchanged. A final success notification auto-dismisses five seconds after display; processing, warning/error, and partial-success notifications do not.
 
 `Retry` is limited to a failed paste with no success/skip/overwrite and an original `PasteRequest` whose conflict resolution is unset, a duplicate with no success or applied changes, or archive/zip preparation failure. Each retry runs fresh preparation/preflight and can return to the existing conflict or reconfirmation flow. `Details` shows failure count, target paths, and reasons, and closes with `Enter` or `Esc`.

--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -354,6 +354,11 @@ class HistoryState:
     visited_all: tuple[str, ...] = ()
 
 
+# Directory history is intentionally bounded so long-running sessions do not
+# accumulate unbounded immutable tuples in every tab and transfer pane.
+DIRECTORY_HISTORY_LIMIT = 100
+
+
 @dataclass(frozen=True)
 class NotificationFailureDetail:
     """One failed target shown by an actionable notification's details view."""

--- a/src/zivo/state/reducer_palette_navigation.py
+++ b/src/zivo/state/reducer_palette_navigation.py
@@ -37,9 +37,9 @@ def handle_begin_history_search(state: AppState) -> ReduceResult:
         )
         if transfer is None:
             return finalize(state)
-        history_items = tuple(dict.fromkeys(transfer.history.visited_all))
+        history_items = tuple(reversed(transfer.history.visited_all))
     else:
-        history_items = tuple(dict.fromkeys(state.history.visited_all))
+        history_items = tuple(reversed(state.history.visited_all))
     return finalize(enter_palette(state, source="history", history_results=history_items))
 
 

--- a/src/zivo/state/reducer_requests.py
+++ b/src/zivo/state/reducer_requests.py
@@ -45,6 +45,7 @@ from .effects import (
     RunZipCompressPreparationEffect,
 )
 from .models import (
+    DIRECTORY_HISTORY_LIMIT,
     ForegroundOperationState,
     HistoryState,
     NotificationAction,
@@ -750,44 +751,57 @@ def build_history_after_snapshot_load(
     next_path: str,
 ) -> HistoryState:
     previous_path = state.current_path
-    new_history = state.history
+    history = state.history
 
-    if not state.history.back and not state.history.forward:
-        if next_path != previous_path:
-            new_history = HistoryState(
-                back=(previous_path,),
-                forward=(),
-                visited_all=(previous_path, next_path),
-            )
-        return new_history
-
-    if next_path != previous_path:
-        history = state.history
-        if history.forward and next_path == history.forward[0]:
-            new_history = HistoryState(
-                back=(*history.back, previous_path),
-                forward=history.forward[1:],
-                visited_all=history.visited_all,
-            )
-        elif history.back and next_path == history.back[-1]:
-            new_history = HistoryState(
-                back=history.back[:-1],
-                forward=(previous_path, *history.forward),
-                visited_all=history.visited_all,
-            )
-        else:
-            visited_all = history.visited_all
-            if not visited_all or visited_all[-1] != next_path:
-                visited_all = (*visited_all, next_path)
-            new_history = HistoryState(
-                back=(*history.back, previous_path),
-                forward=(),
-                visited_all=visited_all,
-            )
-    else:
-        new_history = HistoryState(
-            back=state.history.back,
-            forward=state.history.forward,
-            visited_all=state.history.visited_all,
+    if next_path == previous_path:
+        return HistoryState(
+            back=history.back[-DIRECTORY_HISTORY_LIMIT:],
+            forward=history.forward[:DIRECTORY_HISTORY_LIMIT],
+            visited_all=_normalize_visited_history(history.visited_all),
         )
-    return new_history
+
+    visited_all = _record_visited_path(
+        _record_visited_path(history.visited_all, previous_path),
+        next_path,
+    )
+
+    if not history.back and not history.forward:
+        return HistoryState(
+            back=(previous_path,),
+            forward=(),
+            visited_all=visited_all,
+        )
+
+    if history.forward and next_path == history.forward[0]:
+        return HistoryState(
+            back=(*history.back, previous_path)[-DIRECTORY_HISTORY_LIMIT:],
+            forward=history.forward[1:][:DIRECTORY_HISTORY_LIMIT],
+            visited_all=visited_all,
+        )
+    if history.back and next_path == history.back[-1]:
+        return HistoryState(
+            back=history.back[:-1][-DIRECTORY_HISTORY_LIMIT:],
+            forward=(previous_path, *history.forward)[:DIRECTORY_HISTORY_LIMIT],
+            visited_all=visited_all,
+        )
+    return HistoryState(
+        back=(*history.back, previous_path)[-DIRECTORY_HISTORY_LIMIT:],
+        forward=(),
+        visited_all=visited_all,
+    )
+
+
+def _record_visited_path(paths: tuple[str, ...], path: str) -> tuple[str, ...]:
+    """Move a visited path to the newest position within the bounded history."""
+
+    without_path = tuple(existing for existing in paths if existing != path)
+    return (*without_path, path)[-DIRECTORY_HISTORY_LIMIT:]
+
+
+def _normalize_visited_history(paths: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize legacy or test-created history values to the current invariant."""
+
+    normalized: tuple[str, ...] = ()
+    for path in paths:
+        normalized = _record_visited_path(normalized, path)
+    return normalized

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -95,6 +95,8 @@ from zivo.state.actions import (
     ToggleNarrowPaneView,
     ToggleSelection,
 )
+from zivo.state.models import DIRECTORY_HISTORY_LIMIT
+from zivo.state.reducer_requests import build_history_after_snapshot_load
 from zivo.windows_paths import WINDOWS_DRIVES_ROOT
 
 
@@ -2417,6 +2419,67 @@ def test_browser_snapshot_loaded_does_not_record_history_on_reload() -> None:
     assert next_state.history.back == ()
     assert next_state.history.forward == ()
 
+
+def test_directory_history_is_bounded_when_navigating_to_a_new_path() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_path="/current",
+        history=HistoryState(
+            back=tuple(f"/back/{index}" for index in range(DIRECTORY_HISTORY_LIMIT)),
+            forward=tuple(
+                f"/forward/{index}" for index in range(DIRECTORY_HISTORY_LIMIT)
+            ),
+            visited_all=tuple(
+                f"/visited/{index}" for index in range(DIRECTORY_HISTORY_LIMIT)
+            ),
+        ),
+    )
+
+    next_history = build_history_after_snapshot_load(state, "/new")
+
+    assert len(next_history.back) == DIRECTORY_HISTORY_LIMIT
+    assert next_history.back == (
+        *(f"/back/{index}" for index in range(1, DIRECTORY_HISTORY_LIMIT)),
+        "/current",
+    )
+    assert next_history.forward == ()
+    assert len(next_history.visited_all) == DIRECTORY_HISTORY_LIMIT
+    assert next_history.visited_all[-2:] == ("/current", "/new")
+
+
+def test_back_and_forward_stacks_are_trimmed_when_history_is_already_oversized() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_path="/current",
+        history=HistoryState(
+            back=tuple(f"/back/{index}" for index in range(120)),
+            forward=tuple(f"/forward/{index}" for index in range(120)),
+        ),
+    )
+
+    next_history = build_history_after_snapshot_load(state, "/forward/0")
+
+    assert len(next_history.back) == DIRECTORY_HISTORY_LIMIT
+    assert next_history.back == (
+        *(f"/back/{index}" for index in range(21, 120)),
+        "/current",
+    )
+    assert next_history.forward == tuple(
+        f"/forward/{index}" for index in range(1, DIRECTORY_HISTORY_LIMIT + 1)
+    )
+
+
+def test_revisiting_a_directory_moves_it_to_the_newest_history_position() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_path="/current",
+        history=HistoryState(visited_all=("/old", "/current", "/other")),
+    )
+
+    next_history = build_history_after_snapshot_load(state, "/old")
+
+    assert next_history.visited_all == ("/other", "/current", "/old")
+
 def test_go_back_then_snapshot_loaded_updates_history_correctly() -> None:
     initial_path = "/home/tadashi"
     second_path = "/home/tadashi/develop"
@@ -2530,9 +2593,9 @@ def test_all_visited_directories_enumerable() -> None:
     assert next_state.command_palette is not None
     assert next_state.command_palette.source == "history"
     assert next_state.command_palette.history_and_navigation.history_results == (
-        initial_path,
-        "/tmp/first",
         "/tmp/second",
+        "/tmp/first",
+        initial_path,
     )
 
 def test_history_search_deduplicates_duplicates() -> None:
@@ -2592,9 +2655,9 @@ def test_history_search_deduplicates_duplicates() -> None:
     assert next_state.command_palette is not None
     assert next_state.command_palette.source == "history"
     assert next_state.command_palette.history_and_navigation.history_results == (
+        "/tmp/second",
         initial_path,
         "/tmp/first",
-        "/tmp/second",
     )
 
 def test_browser_snapshot_loaded_clears_filter_when_directory_changes() -> None:

--- a/tests/test_state_reducer_palette_commands.py
+++ b/tests/test_state_reducer_palette_commands.py
@@ -351,10 +351,10 @@ def test_begin_history_search_enters_history_mode() -> None:
     assert next_state.command_palette is not None
     assert next_state.command_palette.source == "history"
     assert next_state.command_palette.history_and_navigation.history_results == (
-        "/home/tadashi/develop/zivo",
-        "/tmp/a",
-        "/tmp/b",
         "/tmp/c",
+        "/tmp/b",
+        "/tmp/a",
+        "/home/tadashi/develop/zivo",
     )
 
 def test_begin_history_search_with_empty_history() -> None:
@@ -364,6 +364,32 @@ def test_begin_history_search_with_empty_history() -> None:
     assert next_state.command_palette is not None
     assert next_state.command_palette.source == "history"
     assert next_state.command_palette.history_and_navigation.history_results == ()
+
+
+def test_begin_history_search_in_transfer_mode_uses_recent_order() -> None:
+    state = replace(
+        build_initial_app_state(),
+        layout_mode="transfer",
+        active_transfer_pane="left",
+        transfer_left=TransferPaneState(
+            pane=PaneState(directory_path="/tmp/a", entries=(), cursor_path="/tmp/a"),
+            current_path="/tmp/a",
+            history=HistoryState(visited_all=("/tmp/a", "/tmp/b", "/tmp/c")),
+        ),
+        transfer_right=TransferPaneState(
+            pane=PaneState(directory_path="/tmp/right", entries=(), cursor_path="/tmp/right"),
+            current_path="/tmp/right",
+        ),
+    )
+
+    next_state = _reduce_state(state, BeginHistorySearch())
+
+    assert next_state.command_palette is not None
+    assert next_state.command_palette.history_and_navigation.history_results == (
+        "/tmp/c",
+        "/tmp/b",
+        "/tmp/a",
+    )
 
 def test_begin_bookmark_search_enters_bookmarks_filtered_go_mode() -> None:
     next_state = _reduce_state(build_initial_app_state(), BeginBookmarkSearch())


### PR DESCRIPTION
## 概要
Issue #1112 に対応し、ディレクトリ履歴を長時間利用しても無制限に増加しないようにしました。

## 変更内容
- back / forward / visited_all を各100件に制限
- 再訪パスを重複保持せず、最近の位置へ移動
- Directory History と Go の履歴候補を新しい順に統一
- Transfer の各ペインにも共通ルールを適用
- 英日コマンド仕様書とReducer回帰テストを更新

## 検証
- uv run ruff check .
- uv run pytest -q
- 1473 passed, 9 skipped

Closes #1112
