### PR TITLE
[1104-1108] Optimize selector and resize hot paths

### DIFF
--- a/src/zivo/app.py
+++ b/src/zivo/app.py
@@ -104,8 +104,7 @@ from zivo.state.actions import (
     RequestBrowserSnapshot,
     SetCursorPath,
     SetSort,
-    SetTerminalHeight,
-    SetTerminalWidth,
+    SetTerminalSize,
     SetTransferCursorPath,
     ShowAttributes,
 )
@@ -338,8 +337,7 @@ class zivoApp(App[None]):
         """Load the initial directory snapshot after the UI mounts."""
 
         await self.dispatch_actions((
-            SetTerminalHeight(height=self.size.height),
-            SetTerminalWidth(width=self.size.width),
+            SetTerminalSize(height=self.size.height, width=self.size.width),
             RequestBrowserSnapshot(self._initial_path, blocking=True),
         ))
         self.call_after_refresh(lambda: sync_overlay_layout(self))
@@ -697,8 +695,7 @@ class zivoApp(App[None]):
         """Update terminal dimensions and responsive pane layout on resize."""
 
         await self.dispatch_actions((
-            SetTerminalHeight(height=event.size.height),
-            SetTerminalWidth(width=event.size.width),
+            SetTerminalSize(height=event.size.height, width=event.size.width),
         ))
         sync_overlay_layout(self, event.size.width)
 

--- a/src/zivo/state/actions.py
+++ b/src/zivo/state/actions.py
@@ -308,6 +308,7 @@ from .actions_ui import (
     SetNotification,
     SetPendingKeySequence,
     SetTerminalHeight,
+    SetTerminalSize,
     SetTerminalWidth,
     SetUiMode,
     ToggleNarrowPaneView,
@@ -322,6 +323,7 @@ Action = (
     | ActivateNotificationAction
     | DismissNotification
     | SetTerminalHeight
+    | SetTerminalSize
     | SetTerminalWidth
     | ToggleNarrowPaneView
     | BeginFileSearch

--- a/src/zivo/state/actions_ui.py
+++ b/src/zivo/state/actions_ui.py
@@ -69,5 +69,13 @@ class SetTerminalWidth:
 
 
 @dataclass(frozen=True)
+class SetTerminalSize:
+    """Update the stored terminal dimensions in one state transition."""
+
+    height: int
+    width: int
+
+
+@dataclass(frozen=True)
 class ToggleNarrowPaneView:
     """Toggle the Current/Details presentation used below the narrow breakpoint."""

--- a/src/zivo/state/input_browsing.py
+++ b/src/zivo/state/input_browsing.py
@@ -151,6 +151,17 @@ BROWSING_HELP_LINES = (
     ),
 )
 
+BROWSING_HELP_LINES_WITH_DETAILS = (
+    BROWSING_HELP_LINES[0],
+    BROWSING_HELP_LINES[1],
+    (*BROWSING_HELP_LINES[2], ("tab", "details")),
+)
+BROWSING_HELP_LINES_WITH_FILE_LIST = (
+    BROWSING_HELP_LINES[0],
+    BROWSING_HELP_LINES[1],
+    (*BROWSING_HELP_LINES[2], ("tab", "file-list")),
+)
+
 SEARCH_WORKSPACE_HELP_LINES = (
     (
         ("enter", "open"),

--- a/src/zivo/state/reducer_terminal_config.py
+++ b/src/zivo/state/reducer_terminal_config.py
@@ -33,6 +33,7 @@ from .actions import (
     SetShellCommandCursor,
     SetShellCommandValue,
     SetTerminalHeight,
+    SetTerminalSize,
     SetTerminalWidth,
     ShellCommandCompleted,
     ShellCommandFailed,
@@ -788,6 +789,32 @@ def _handle_set_terminal_width(
     return finalize(replace(state, terminal_width=width, narrow_pane_view=next_view))
 
 
+def _handle_set_terminal_size(
+    state: AppState,
+    action: SetTerminalSize,
+    reduce_state: ReducerFn,
+) -> ReduceResult:
+    del reduce_state
+    width = max(0, action.width)
+    next_view = state.narrow_pane_view
+    if (state.terminal_width < 80) != (width < 80):
+        next_view = "current"
+    if (
+        action.height == state.terminal_height
+        and width == state.terminal_width
+        and next_view == state.narrow_pane_view
+    ):
+        return finalize(state)
+    return finalize(
+        replace(
+            state,
+            terminal_height=action.height,
+            terminal_width=width,
+            narrow_pane_view=next_view,
+        )
+    )
+
+
 def _handle_toggle_narrow_pane_view(
     state: AppState,
     action: ToggleNarrowPaneView,
@@ -840,6 +867,7 @@ _TERMINAL_CONFIG_HANDLERS: dict[type[Action], _TerminalConfigHandler] = {
     ConfigSaveCompleted: _handle_config_save_completed,
     ConfigSaveFailed: _handle_config_save_failed,
     SetTerminalHeight: _handle_set_terminal_height,
+    SetTerminalSize: _handle_set_terminal_size,
     SetTerminalWidth: _handle_set_terminal_width,
     ToggleNarrowPaneView: _handle_toggle_narrow_pane_view,
 }

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -133,11 +133,12 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
     )
     responsive_layout = select_responsive_pane_layout(state)
     current_status_label = _current_cursor_status_label(current_pane)
+    parent_entries = select_parent_entries(state)
     shell = ThreePaneShellData(
         tab_bar=select_tab_bar_state(state),
         current_path=state.current_pane.directory_path,
         path_bar=select_path_bar_state(state),
-        parent_entries=select_parent_entries(state),
+        parent_entries=parent_entries,
         current_entries=(
             _select_current_pane_entries(
                 current_pane.projected_entries,
@@ -165,7 +166,7 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
         parent_heading=_format_directory_heading(
             "Parent",
             state.parent_pane.directory_path,
-            len(select_parent_entries(state)),
+            len(parent_entries),
         ),
         current_context_input=select_input_bar_state(state),
         current_pane_status=_select_current_pane_status(state, current_pane.visible_entries),
@@ -267,13 +268,9 @@ def _pane_width_class(width: int) -> str:
 
 
 def _current_cursor_status_label(projection: _CurrentPaneProjection) -> str | None:
-    if projection.cursor_entry is None:
+    if projection.global_cursor_index is None:
         return None
-    try:
-        index = projection.visible_entries.index(projection.cursor_entry)
-    except ValueError:
-        return None
-    return f"{index + 1}/{len(projection.visible_entries)}"
+    return f"{projection.global_cursor_index + 1}/{len(projection.visible_entries)}"
 
 
 def _format_directory_heading(role: str, path: str, item_count: int) -> str:
@@ -418,6 +415,7 @@ def _select_current_pane_projection(state: AppState) -> _CurrentPaneProjection:
         visible_entries=visible_entries,
         projected_entries=projected_entries,
         cursor_index=cursor_index,
+        global_cursor_index=global_cursor_index,
         cursor_entry=cursor_entry,
         summary=select_current_summary_state(state),
     )

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -65,6 +65,7 @@ class CurrentPaneProjection:
     visible_entries: tuple[DirectoryEntryState, ...]
     projected_entries: tuple[DirectoryEntryState, ...]
     cursor_index: int | None
+    global_cursor_index: int | None
     cursor_entry: DirectoryEntryState | None
     summary: CurrentSummaryState
 
@@ -185,6 +186,7 @@ def select_current_pane_projection(state: AppState) -> CurrentPaneProjection:
         visible_entries=visible_entries,
         projected_entries=projected_entries,
         cursor_index=cursor_index,
+        global_cursor_index=global_cursor_index,
         cursor_entry=cursor_entry,
         summary=_build_current_summary(
             len(visible_entries),
@@ -371,10 +373,7 @@ def select_child_pane_for_cursor(
     return _with_child_header(view, _format_child_semantic_title(state, view, cursor_entry))
 
 
-@lru_cache(maxsize=4096)
 def _with_child_header(view: ChildPaneViewState, title: str) -> ChildPaneViewState:
-    if view.header_title == title:
-        return view
     return replace(view, header_title=title)
 
 

--- a/src/zivo/state/selectors_ui.py
+++ b/src/zivo/state/selectors_ui.py
@@ -289,15 +289,18 @@ def select_help_bar_state(state: AppState) -> HelpBarState:
             tuple(_format_help_line(line) for line in SEARCH_WORKSPACE_HELP_LINES)
         )
     split_terminal_hint = " | t term" if is_split_terminal_supported() else ""
-    from .input_browsing import BROWSING_HELP_LINES
+    from .input_browsing import (
+        BROWSING_HELP_LINES,
+        BROWSING_HELP_LINES_WITH_DETAILS,
+        BROWSING_HELP_LINES_WITH_FILE_LIST,
+    )
 
     browsing_lines = BROWSING_HELP_LINES
     if state.terminal_width < 80 and state.current_pane.cursor_path is not None:
-        view_hint = "file-list" if state.narrow_pane_view == "details" else "details"
         browsing_lines = (
-            BROWSING_HELP_LINES[0],
-            BROWSING_HELP_LINES[1],
-            (*BROWSING_HELP_LINES[2], ("tab", view_hint)),
+            BROWSING_HELP_LINES_WITH_FILE_LIST
+            if state.narrow_pane_view == "details"
+            else BROWSING_HELP_LINES_WITH_DETAILS
         )
 
     return HelpBarState(

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -1082,6 +1082,7 @@ def test_select_shell_data_exposes_visible_cursor_index() -> None:
 
     assert shell.current_path == "/home/tadashi/develop/zivo"
     assert shell.current_cursor_index == 2
+    assert shell.current_heading.status_label == "3/5"
     assert shell.current_cursor_visible is True
 
 
@@ -1249,7 +1250,24 @@ def test_select_shell_data_reuses_pane_entries_when_only_notification_changes() 
 
     assert updated_shell.parent_entries is initial_shell.parent_entries
     assert updated_shell.current_entries is initial_shell.current_entries
-    assert updated_shell.child_pane is initial_shell.child_pane
+    assert updated_shell.child_pane == initial_shell.child_pane
+
+
+def test_select_shell_data_selects_parent_entries_once(monkeypatch) -> None:
+    state = build_initial_app_state()
+    original = selectors_module.select_parent_entries
+    calls = 0
+
+    def wrapped(current_state):
+        nonlocal calls
+        calls += 1
+        return original(current_state)
+
+    monkeypatch.setattr(selectors_module, "select_parent_entries", wrapped)
+
+    select_shell_data(state)
+
+    assert calls == 1
 
 
 def test_select_shell_data_reuses_current_entries_when_only_cursor_changes() -> None:
@@ -1417,7 +1435,7 @@ def test_select_shell_data_rebuilds_only_current_entries_when_selection_changes(
     )
 
     assert updated_shell.parent_entries is initial_shell.parent_entries
-    assert updated_shell.child_pane is initial_shell.child_pane
+    assert updated_shell.child_pane == initial_shell.child_pane
     assert updated_shell.current_entries is not initial_shell.current_entries
 
 
@@ -1527,6 +1545,24 @@ def test_select_help_bar_defaults_to_browsing_shortcuts() -> None:
         "space select | c copy | x cut | v paste | d delete | r rename | z undo\n"
         f"f find | g grep | n new-file | N new-dir{split_terminal_hint} | : palette"
     )
+
+
+def test_select_help_bar_narrow_view_uses_prebuilt_view_hint_lines() -> None:
+    initial = build_initial_app_state()
+    state = replace(
+        initial,
+        terminal_width=79,
+        current_pane=replace(
+            initial.current_pane,
+            cursor_path="/home/tadashi/develop/zivo/README.md",
+        ),
+    )
+
+    current = select_help_bar_state(state)
+    details = select_help_bar_state(replace(state, narrow_pane_view="details"))
+
+    assert current.lines[-1].endswith("tab details")
+    assert details.lines[-1].endswith("tab file-list")
 
 
 def test_select_help_bar_for_search_workspace_shows_available_actions_only() -> None:

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -89,6 +89,7 @@ from zivo.state.actions import (
     SetPendingKeySequence,
     SetSort,
     SetTerminalHeight,
+    SetTerminalSize,
     SetTerminalWidth,
     SetUiMode,
     ToggleHiddenFiles,
@@ -2094,6 +2095,28 @@ class TestSetTerminalHeight:
 
 
 class TestResponsivePaneState:
+    def test_set_terminal_size_updates_both_dimensions_once(self) -> None:
+        state = replace(
+            build_initial_app_state(),
+            terminal_height=24,
+            terminal_width=72,
+            narrow_pane_view="details",
+        )
+
+        next_state = _reduce_state(state, SetTerminalSize(height=30, width=80))
+
+        assert next_state.terminal_height == 30
+        assert next_state.terminal_width == 80
+        assert next_state.narrow_pane_view == "current"
+
+    def test_set_terminal_size_no_change_returns_same_state(self) -> None:
+        state = build_initial_app_state()
+
+        assert _reduce_state(
+            state,
+            SetTerminalSize(height=state.terminal_height, width=state.terminal_width),
+        ) is state
+
     def test_updates_terminal_width_and_resets_narrow_view_at_breakpoint(self) -> None:
         state = replace(
             build_initial_app_state(),


### PR DESCRIPTION
## Summary
- remove duplicate parent-entry selection and cursor status linear search
- remove ineffective child-header cache and prebuild narrow help variants
- combine terminal height/width updates into one resize action

## Issues
- Closes #1104
- Closes #1105
- Closes #1106
- Closes #1107
- Closes #1108

## Verification
- `uv run ruff check .`
- `uv run pytest -q` (1475 passed, 9 skipped)