### PR TITLE
[#1115] Optimize large side-pane directories

### DIFF
--- a/src/zivo/adapters/__init__.py
+++ b/src/zivo/adapters/__init__.py
@@ -7,12 +7,14 @@ from .filesystem import (
     DirectoryReader,
     DirectorySizeCancelled,
     DirectorySizeReader,
+    DirectorySummaryReader,
     LocalFilesystemAdapter,
 )
 
 __all__ = [
     "DirectoryAttributeReader",
     "DirectoryReader",
+    "DirectorySummaryReader",
     "DirectorySizeCancelled",
     "DirectorySizeReader",
     "ExternalLaunchAdapter",

--- a/src/zivo/adapters/filesystem.py
+++ b/src/zivo/adapters/filesystem.py
@@ -19,6 +19,12 @@ class DirectoryReader(Protocol):
     def list_directory(self, path: str) -> tuple[DirectoryEntryState, ...]: ...
 
 
+class DirectorySummaryReader(Protocol):
+    """Boundary for reading directory entries without detailed stat metadata."""
+
+    def list_directory_summary(self, path: str) -> tuple[DirectoryEntryState, ...]: ...
+
+
 class DirectorySizeReader(Protocol):
     """Boundary for recursive directory-size calculations."""
 
@@ -41,11 +47,27 @@ class LocalFilesystemAdapter:
     """Read and normalize directory contents from the local filesystem."""
 
     def list_directory(self, path: str) -> tuple[DirectoryEntryState, ...]:
+        return self._list_directory(path, include_metadata=True)
+
+    def list_directory_summary(self, path: str) -> tuple[DirectoryEntryState, ...]:
+        """Return entries suitable for side panes without calling stat per entry."""
+
+        return self._list_directory(path, include_metadata=False)
+
+    def _list_directory(
+        self,
+        path: str,
+        *,
+        include_metadata: bool,
+    ) -> tuple[DirectoryEntryState, ...]:
         directory = Path(path).expanduser().resolve()
         entries: list[DirectoryEntryState] = []
         with os.scandir(directory) as iterator:
             for child in iterator:
-                entry = _build_directory_entry_summary(child)
+                entry = _build_directory_entry_summary(
+                    child,
+                    include_metadata=include_metadata,
+                )
                 if entry is not None:
                     entries.append(entry)
         entries.sort(key=lambda entry: (entry.kind != "dir", natural_sort_key(entry.name)))
@@ -69,7 +91,11 @@ class LocalFilesystemAdapter:
         return _calculate_directory_size(directory, is_cancelled=is_cancelled)
 
 
-def _build_directory_entry_summary(entry: os.DirEntry[str]) -> DirectoryEntryState | None:
+def _build_directory_entry_summary(
+    entry: os.DirEntry[str],
+    *,
+    include_metadata: bool = True,
+) -> DirectoryEntryState | None:
     is_symlink = entry.is_symlink()
     hidden = entry.name.startswith(".")
     try:
@@ -101,6 +127,15 @@ def _build_directory_entry_summary(entry: os.DirEntry[str]) -> DirectoryEntrySta
                 hidden=hidden,
                 symlink=True,
             )
+
+    if not include_metadata:
+        return DirectoryEntryState(
+            path=entry.path,
+            name=entry.name,
+            kind=kind,
+            hidden=hidden,
+            symlink=is_symlink,
+        )
 
     try:
         stat_result = entry.stat()

--- a/src/zivo/app_shell.py
+++ b/src/zivo/app_shell.py
@@ -343,13 +343,15 @@ async def refresh_shell(
         )
         current_pane.set_context_input(shell.current_context_input)
         current_pane.set_status(shell.current_pane_status)
-    await parent_pane.set_entries(shell.parent_entries)
-    parent_pane.set_title(shell.parent_heading)
-    await child_pane.set_state(shell.child_pane)
     if app_state.layout_mode == "transfer":
         parent_pane.display = False
         child_pane.display = False
     else:
+        if shell.responsive_layout.show_parent:
+            await parent_pane.set_entries(shell.parent_entries)
+            parent_pane.set_title(shell.parent_heading)
+        if shell.responsive_layout.show_child:
+            await child_pane.set_state(shell.child_pane)
         parent_pane.display = shell.responsive_layout.show_parent
         current_pane.display = shell.responsive_layout.show_current
         child_pane.display = shell.responsive_layout.show_child

--- a/src/zivo/models/shell_data.py
+++ b/src/zivo/models/shell_data.py
@@ -208,6 +208,7 @@ class ChildPaneViewState:
     status: PaneStatusViewState | None = None
     metadata: tuple[MetadataItemViewState, ...] = ()
     header_title: str | None = None
+    total_item_count: int | None = None
 
     @property
     def is_preview(self) -> bool:

--- a/src/zivo/services/browser_snapshot.py
+++ b/src/zivo/services/browser_snapshot.py
@@ -143,7 +143,9 @@ class LiveBrowserSnapshotLoader:
     pdf_preview_loader: "PdfPreviewLoader | None" = None
     image_preview_loader: "ImagePreviewLoader | None" = None
     app_state: "AppState | None" = field(default=None, compare=False, repr=False)
-    _directory_entries_cache: OrderedDict[str, tuple[DirectoryEntryState, ...]] = field(
+    _directory_entries_cache: OrderedDict[
+        tuple[str, bool], tuple[DirectoryEntryState, ...]
+    ] = field(
         default_factory=OrderedDict,
         init=False,
         repr=False,
@@ -229,7 +231,7 @@ class LiveBrowserSnapshotLoader:
         enable_office_preview: bool = True,
     ) -> BrowserSnapshot:
         resolved_path, parent_path = resolve_parent_directory_path(path)
-        current_entries = self._list_directory(resolved_path)
+        current_entries = self._list_directory(resolved_path, detailed=True)
         resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path, show_hidden)
 
         if parent_path is None:
@@ -238,7 +240,7 @@ class LiveBrowserSnapshotLoader:
             parent_cursor_path = None
         else:
             parent_directory_path = parent_path
-            parent_entries = self._list_directory(parent_path)
+            parent_entries = self._list_directory(parent_path, detailed=False)
             parent_cursor_path = (
                 resolved_path if _contains_path(parent_entries, resolved_path) else None
             )
@@ -283,7 +285,10 @@ class LiveBrowserSnapshotLoader:
 
         if is_windows_drive_root(cursor_path):
             try:
-                child_entries = self._list_directory(normalize_windows_path(cursor_path))
+                child_entries = self._list_directory(
+                    normalize_windows_path(cursor_path),
+                    detailed=False,
+                )
                 return PaneState(
                     directory_path=normalize_windows_path(cursor_path),
                     entries=child_entries,
@@ -302,7 +307,7 @@ class LiveBrowserSnapshotLoader:
         child_path = Path(cursor_path).expanduser().resolve()
         if child_path.is_dir():
             try:
-                child_entries = self._list_directory(str(child_path))
+                child_entries = self._list_directory(str(child_path), detailed=False)
                 return PaneState(
                     directory_path=str(child_path),
                     entries=child_entries,
@@ -414,7 +419,7 @@ class LiveBrowserSnapshotLoader:
             (current_path, current_pane, parent_pane)
         """
         resolved_path, parent_path = resolve_parent_directory_path(path)
-        current_entries = self._list_directory(resolved_path)
+        current_entries = self._list_directory(resolved_path, detailed=True)
         resolved_cursor_path = _resolve_cursor_path(current_entries, cursor_path, show_hidden)
 
         if parent_path is None:
@@ -424,7 +429,10 @@ class LiveBrowserSnapshotLoader:
         else:
             parent_directory_path = parent_path
             # Try to load parent from cache for Phase 1
-            parent_entries = self._get_cached_directory_entries(parent_path)
+            parent_entries = self._get_cached_directory_entries(
+                parent_path,
+                detailed=False,
+            )
             if parent_entries is None:
                 # No cache available, use empty parent for now
                 parent_entries = ()
@@ -471,7 +479,7 @@ class LiveBrowserSnapshotLoader:
             parent_cursor_path = None
         else:
             parent_directory_path = parent_path
-            parent_entries = self._list_directory(parent_path)
+            parent_entries = self._list_directory(parent_path, detailed=False)
             parent_cursor_path = (
                 resolved_path if _contains_path(parent_entries, resolved_path) else None
             )
@@ -590,43 +598,60 @@ class LiveBrowserSnapshotLoader:
             if not normalized_paths:
                 self._directory_entries_cache.clear()
                 return
-            for path in normalized_paths:
-                self._directory_entries_cache.pop(path, None)
+            invalidated_paths = frozenset(normalized_paths)
+            stale_keys = tuple(
+                key for key in self._directory_entries_cache if key[0] in invalidated_paths
+            )
+            for key in stale_keys:
+                self._directory_entries_cache.pop(key, None)
 
-    def _list_directory(self, path: str):
+    def _list_directory(self, path: str, *, detailed: bool):
         resolved_path = _normalize_directory_cache_path(path)
-        cached_entries = self._get_cached_directory_entries(resolved_path)
+        cached_entries = self._get_cached_directory_entries(
+            resolved_path,
+            detailed=detailed,
+        )
         if cached_entries is not None:
             return cached_entries
-        entries = self._read_directory(resolved_path)
-        self._store_cached_directory_entries(resolved_path, entries)
+        entries = self._read_directory(resolved_path, detailed=detailed)
+        self._store_cached_directory_entries(
+            resolved_path,
+            entries,
+            detailed=detailed,
+        )
         return entries
 
     def _get_cached_directory_entries(
         self,
         path: str,
+        *,
+        detailed: bool,
     ) -> tuple[DirectoryEntryState, ...] | None:
+        key = (path, detailed)
         with self._directory_entries_cache_lock:
-            entries = self._directory_entries_cache.get(path)
+            entries = self._directory_entries_cache.get(key)
             if entries is None:
                 return None
-            self._directory_entries_cache.move_to_end(path)
+            self._directory_entries_cache.move_to_end(key)
             return entries
 
     def _store_cached_directory_entries(
         self,
         path: str,
         entries: tuple[DirectoryEntryState, ...],
+        *,
+        detailed: bool,
     ) -> None:
         if self.directory_cache_capacity <= 0:
             return
+        key = (path, detailed)
         with self._directory_entries_cache_lock:
-            self._directory_entries_cache[path] = entries
-            self._directory_entries_cache.move_to_end(path)
+            self._directory_entries_cache[key] = entries
+            self._directory_entries_cache.move_to_end(key)
             while len(self._directory_entries_cache) > self.directory_cache_capacity:
                 self._directory_entries_cache.popitem(last=False)
 
-    def _read_directory(self, path: str):
+    def _read_directory(self, path: str, *, detailed: bool):
         # Handle virtual search workspace paths
         if is_search_workspace_path(path):
             return self._read_virtual_search_directory(path)
@@ -641,6 +666,10 @@ class LiveBrowserSnapshotLoader:
                 for drive in list_windows_drive_paths()
             )
         try:
+            if not detailed:
+                list_summary = getattr(self.filesystem, "list_directory_summary", None)
+                if list_summary is not None:
+                    return list_summary(path)
             return self.filesystem.list_directory(path)
         except PermissionError as error:
             raise OSError(f"Permission denied: {path}") from error

--- a/src/zivo/state/reducer_navigation_shared.py
+++ b/src/zivo/state/reducer_navigation_shared.py
@@ -10,6 +10,7 @@ from .models import (
     AppState,
     BrowserTabState,
     CurrentPaneDeltaState,
+    DirectoryEntryState,
     FilterState,
     HistoryState,
     PaneState,
@@ -213,7 +214,21 @@ def can_promote_child_pane(
         and state.pending_child_pane_request_id is None
         and state.child_pane.mode == "entries"
         and state.child_pane.directory_path == entry_path
+        and _child_pane_entries_have_current_metadata(state.child_pane.entries)
     )
+
+
+def _child_pane_entries_have_current_metadata(
+    entries: tuple[DirectoryEntryState, ...],
+) -> bool:
+    """Return whether child entries can safely become the detailed current pane."""
+
+    for entry in entries:
+        if entry.modified_at is None or entry.permissions_mode is None:
+            return False
+        if entry.kind == "file" and entry.size_bytes is None:
+            return False
+    return True
 
 
 def promote_child_pane_to_current(

--- a/src/zivo/state/selectors.py
+++ b/src/zivo/state/selectors.py
@@ -3,6 +3,7 @@
 from dataclasses import replace
 
 from zivo.models import (
+    ChildPaneViewState,
     CurrentSummaryState,
     PaneActionViewState,
     PaneStatusViewState,
@@ -32,6 +33,7 @@ from .selectors_panes import (
     select_current_entries,
     select_current_summary_state,
     select_parent_entries,
+    select_parent_entry_count,
     select_tab_bar_state,
 )
 from .selectors_panes import (
@@ -115,7 +117,12 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
     """Build the display shell data consumed by the UI layer."""
 
     current_pane = _select_current_pane_projection(state)
-    child_pane = _select_child_pane_for_cursor(state, current_pane.cursor_entry)
+    responsive_layout = select_responsive_pane_layout(state)
+    child_pane = (
+        _select_child_pane_for_cursor(state, current_pane.cursor_entry)
+        if responsive_layout.show_child
+        else ChildPaneViewState(title="Child Directory")
+    )
     display_directory_sizes = (
         state.config.display.show_directory_sizes or state.sort.field == "size"
     )
@@ -131,9 +138,11 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
         state.directory_size_delta.changed_paths,
         state.directory_size_delta.revision,
     )
-    responsive_layout = select_responsive_pane_layout(state)
     current_status_label = _current_cursor_status_label(current_pane)
-    parent_entries = select_parent_entries(state)
+    parent_entries = select_parent_entries(state) if responsive_layout.show_parent else ()
+    parent_entry_count = (
+        select_parent_entry_count(state) if responsive_layout.show_parent else 0
+    )
     shell = ThreePaneShellData(
         tab_bar=select_tab_bar_state(state),
         current_path=state.current_pane.directory_path,
@@ -166,7 +175,7 @@ def select_shell_data(state: AppState) -> ThreePaneShellData:
         parent_heading=_format_directory_heading(
             "Parent",
             state.parent_pane.directory_path,
-            len(parent_entries),
+            parent_entry_count,
         ),
         current_context_input=select_input_bar_state(state),
         current_pane_status=_select_current_pane_status(state, current_pane.visible_entries),

--- a/src/zivo/state/selectors_panes.py
+++ b/src/zivo/state/selectors_panes.py
@@ -87,13 +87,24 @@ def select_parent_entries(state: AppState) -> tuple[PaneEntry, ...]:
     """Return display entries for the parent pane."""
 
     visible_entries = _select_side_pane_entry_states(state.parent_pane.entries, state.show_hidden)
-    return _select_side_pane_entries(
+    projected_entries = _project_side_pane_entry_states(
         visible_entries,
+        compute_current_pane_visible_window(state.terminal_height),
+        state.parent_pane.cursor_path,
+    )
+    return _select_side_pane_entries(
+        projected_entries,
         state.directory_size_cache,
         display_directory_sizes=False,
         selected_path=state.parent_pane.cursor_path,
-        cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+        cut_paths=_select_visible_cut_paths(projected_entries, _select_cut_paths(state)),
     )
+
+
+def select_parent_entry_count(state: AppState) -> int:
+    """Return the total visible item count independently of viewport projection."""
+
+    return len(_select_side_pane_entry_states(state.parent_pane.entries, state.show_hidden))
 
 
 def select_current_entries(state: AppState) -> tuple[PaneEntry, ...]:
@@ -301,12 +312,17 @@ def _select_child_pane_for_cursor_base(
         )
 
     visible_entries = _select_side_pane_entry_states(state.child_pane.entries, state.show_hidden)
-    entries = _select_side_pane_entries(
+    projected_entries = _project_side_pane_entry_states(
         visible_entries,
+        compute_current_pane_visible_window(state.terminal_height),
+        None,
+    )
+    entries = _select_side_pane_entries(
+        projected_entries,
         state.directory_size_cache,
         display_directory_sizes=False,
         selected_path=None,
-        cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+        cut_paths=_select_visible_cut_paths(projected_entries, _select_cut_paths(state)),
     )
     if not entries:
         return _build_child_status_view(
@@ -319,6 +335,7 @@ def _select_child_pane_for_cursor_base(
         entries,
         syntax_theme,
         metadata_bar,
+        total_item_count=len(visible_entries),
     )
 
 
@@ -413,7 +430,10 @@ def _format_child_semantic_title(
     if view.is_preview or cursor_entry.kind == "file":
         return f"Preview · {target_name}"
 
-    return f"Contents · {target_name} · {len(view.entries)} items"
+    item_count = view.total_item_count
+    if item_count is None:
+        item_count = len(view.entries)
+    return f"Contents · {target_name} · {item_count} items"
 
 
 def _select_command_palette_preview_pane(
@@ -458,15 +478,24 @@ def _select_file_search_preview_pane(
             visible_entries = _select_side_pane_entry_states(
                 state.child_pane.entries, state.show_hidden
             )
+            projected_entries = _project_side_pane_entry_states(
+                visible_entries,
+                compute_current_pane_visible_window(state.terminal_height),
+                None,
+            )
             return _build_child_entries_view(
                 _select_side_pane_entries(
-                    visible_entries,
+                    projected_entries,
                     state.directory_size_cache,
                     display_directory_sizes=False,
                     selected_path=None,
-                    cut_paths=_select_visible_cut_paths(visible_entries, _select_cut_paths(state)),
+                    cut_paths=_select_visible_cut_paths(
+                        projected_entries,
+                        _select_cut_paths(state),
+                    ),
                 ),
                 syntax_theme,
+                total_item_count=len(visible_entries),
             )
         return _build_child_entries_view((), syntax_theme)
 
@@ -638,6 +667,28 @@ def _project_current_pane_entries(
 
 
 @lru_cache(maxsize=256)
+def _project_side_pane_entry_states(
+    entries: tuple[DirectoryEntryState, ...],
+    visible_window: int,
+    selected_path: str | None,
+) -> tuple[DirectoryEntryState, ...]:
+    """Limit side-pane projection while keeping its selected row visible."""
+
+    if len(entries) <= visible_window:
+        return entries
+    if selected_path is None:
+        return entries[:visible_window]
+
+    selected_index = next(
+        (index for index, entry in enumerate(entries) if entry.path == selected_path),
+        0,
+    )
+    window_start = max(0, selected_index - visible_window // 2)
+    window_start = min(window_start, len(entries) - visible_window)
+    return entries[window_start : window_start + visible_window]
+
+
+@lru_cache(maxsize=256)
 def select_current_pane_update_hint(
     projected_entries: tuple[DirectoryEntryState, ...],
     directory_size_cache: tuple[DirectorySizeCacheEntry, ...],
@@ -804,6 +855,7 @@ def _build_child_entries_view(
     entries: tuple[PaneEntry, ...],
     syntax_theme: str,
     metadata_bar: tuple[MetadataItemViewState, ...] = (),
+    total_item_count: int | None = None,
 ) -> ChildPaneViewState:
     return ChildPaneViewState(
         title="Child Directory",
@@ -811,6 +863,7 @@ def _build_child_entries_view(
         syntax_theme=syntax_theme,
         metadata_bar=metadata_bar,
         view_kind="entries",
+        total_item_count=total_item_count,
     )
 
 

--- a/tests/state_selectors_cases.py
+++ b/tests/state_selectors_cases.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import replace
 from stat import S_IFREG
 
+import pytest
+
 import zivo.state.selectors as selectors_module
 from tests.state_test_helpers import entry, pane, reduce_state
 from zivo.models import (
@@ -1312,6 +1314,67 @@ def test_select_shell_data_viewport_projection_limits_rendered_entries() -> None
     ]
     assert shell.current_cursor_index == 0
     assert shell.current_summary.item_count == len(current_entries)
+
+
+def test_select_shell_data_limits_parent_and_child_panes_to_visible_window() -> None:
+    root = "/tmp/zivo-side-viewport"
+    parent_entries = tuple(
+        entry(f"/tmp/sibling_{index:02d}", name=f"sibling_{index:02d}", kind="dir")
+        for index in range(12)
+    )
+    current_directory = parent_entries[10]
+    child_entries = tuple(
+        entry(f"{root}/child_{index:02d}", name=f"child_{index:02d}")
+        for index in range(12)
+    )
+    state = replace(
+        build_initial_app_state(current_pane_projection_mode="viewport"),
+        terminal_width=120,
+        terminal_height=12,
+        parent_pane=pane(
+            "/tmp",
+            parent_entries,
+            cursor_path=current_directory.path,
+        ),
+        current_pane=pane(
+            root,
+            (entry(f"{root}/selected", name="selected", kind="dir"),),
+            cursor_path=f"{root}/selected",
+        ),
+        child_pane=pane(f"{root}/selected", child_entries),
+    )
+
+    shell = select_shell_data(state)
+
+    visible_window = compute_current_pane_visible_window(state.terminal_height)
+    assert len(shell.parent_entries) == visible_window
+    assert current_directory.path in {item.path for item in shell.parent_entries}
+    assert len(shell.child_pane.entries) == visible_window
+    assert shell.child_pane.display_title == "Contents · selected · 12 items"
+
+
+def test_select_shell_data_skips_hidden_side_pane_projection(monkeypatch) -> None:
+    state = replace(
+        build_initial_app_state(current_pane_projection_mode="viewport"),
+        terminal_width=79,
+        narrow_pane_view="current",
+    )
+
+    monkeypatch.setattr(
+        selectors_module,
+        "select_parent_entries",
+        lambda _state: pytest.fail("hidden parent pane must not be projected"),
+    )
+    monkeypatch.setattr(
+        selectors_module,
+        "_select_child_pane_for_cursor",
+        lambda _state, _entry: pytest.fail("hidden child pane must not be projected"),
+    )
+
+    shell = select_shell_data(state)
+
+    assert shell.parent_entries == ()
+    assert shell.child_pane.entries == ()
 
 
 def test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_inside_window(

--- a/tests/test_adapters_filesystem.py
+++ b/tests/test_adapters_filesystem.py
@@ -34,6 +34,7 @@ class _FakeDirEntry:
         self._kind = kind
         self._fail_is_dir = fail_is_dir
         self._fail_stat = fail_stat
+        self.stat_calls = 0
 
     def is_symlink(self) -> bool:
         return False
@@ -44,6 +45,7 @@ class _FakeDirEntry:
         return self._kind == "dir"
 
     def stat(self):
+        self.stat_calls += 1
         if self._fail_stat:
             raise PermissionError("permission denied")
         return SimpleNamespace(st_size=12, st_mtime=0, st_mode=0o100644)
@@ -133,6 +135,27 @@ def test_local_filesystem_adapter_skips_entries_with_permission_denied_metadata(
     entries = adapter.list_directory("/mnt/c")
 
     assert [entry.name for entry in entries] == ["docs", "README.md"]
+
+
+def test_local_filesystem_adapter_summary_skips_per_entry_stat(monkeypatch) -> None:
+    entries = tuple(
+        _FakeDirEntry(
+            name=f"item-{index}.txt",
+            path=f"/mnt/c/item-{index}.txt",
+        )
+        for index in range(10_000)
+    )
+
+    monkeypatch.setattr(os, "scandir", lambda _directory: _FakeScandir(entries))
+    adapter = LocalFilesystemAdapter()
+
+    summaries = adapter.list_directory_summary("/mnt/c")
+
+    assert len(summaries) == 10_000
+    assert sum(entry.stat_calls for entry in entries) == 0
+    assert all(summary.size_bytes is None for summary in summaries)
+    assert all(summary.modified_at is None for summary in summaries)
+    assert all(summary.permissions_mode is None for summary in summaries)
 
 
 def test_local_filesystem_adapter_inspect_entry_loads_detailed_metadata(tmp_path) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -992,7 +992,7 @@ async def test_app_live_snapshot_highlights_current_directory_in_parent_pane(tmp
     (tmp_path / "README.md").write_text("readme\n", encoding="utf-8")
     app = create_app(initial_path=tmp_path)
 
-    async with app.run_test():
+    async with app.run_test(size=(240, 20)):
         await _wait_for_snapshot_loaded(app, str(tmp_path))
         await _wait_for_row_count(app, 2)
 
@@ -1002,7 +1002,10 @@ async def test_app_live_snapshot_highlights_current_directory_in_parent_pane(tmp
 
         assert app.app_state.parent_pane.cursor_path == str(tmp_path)
         assert isinstance(parent_renderable, Text)
-        assert tmp_path.name in parent_renderable.plain.splitlines()
+        assert any(
+            line.startswith(tmp_path.name[:12])
+            for line in parent_renderable.plain.splitlines()
+        )
         assert _text_has_style(
             parent_renderable,
             _style_without_background(parent_pane.get_component_rich_style("ft-directory-sel")),
@@ -4817,7 +4820,7 @@ async def test_app_config_dialog_save_updates_theme(monkeypatch) -> None:
         initial_path=path,
     )
 
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(240, 24)) as pilot:
         await _wait_for_snapshot_loaded(app, path)
         parent_pane = app.query_one("#parent-pane", SidePane)
         child_pane = app.query_one("#child-pane", ChildPane)
@@ -5622,7 +5625,7 @@ async def test_app_sort_shortcuts_keep_side_panes_fixed_and_update_status_bar() 
         ),
     )
 
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(240, 24)) as pilot:
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 3)
 
@@ -6341,10 +6344,16 @@ async def test_app_cursor_move_refreshes_large_child_pane_without_remount(
     )
     app = create_app(snapshot_loader=loader, initial_path=path)
 
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(80, 24)) as pilot:
         await _wait_for_snapshot_loaded(app, path)
         await _wait_for_row_count(app, 2)
-        await _wait_for_child_list_label(app, "child-0999.txt", index=999, timeout=2.0)
+        visible_window = compute_current_pane_visible_window(app.app_state.terminal_height)
+        await _wait_for_child_list_label(
+            app,
+            f"child-{visible_window - 1:04d}.txt",
+            index=visible_window - 1,
+            timeout=2.0,
+        )
 
         child_list = app.query_one("#child-pane-list", Static)
         original_update = Static.update
@@ -6359,10 +6368,15 @@ async def test_app_cursor_move_refreshes_large_child_pane_without_remount(
         monkeypatch.setattr(Static, "update", counting_update)
 
         await pilot.press("down")
-        await _wait_for_child_list_label(app, "module-0999.py", index=999, timeout=2.0)
+        await _wait_for_child_list_label(
+            app,
+            f"module-{visible_window - 1:04d}.py",
+            index=visible_window - 1,
+            timeout=2.0,
+        )
 
         assert app.query_one("#child-pane-list", Static) is child_list
-        assert len(_side_pane_lines(child_list)) == 1000
+        assert len(_side_pane_lines(child_list)) == visible_window
         assert update_calls == 1
 
 

--- a/tests/test_services_browser_snapshot.py
+++ b/tests/test_services_browser_snapshot.py
@@ -20,9 +20,17 @@ class StubFilesystemAdapter:
     entries_by_path: dict[str, tuple[DirectoryEntryState, ...]] = field(default_factory=dict)
     errors_by_path: dict[str, Exception] = field(default_factory=dict)
     list_directory_calls: list[str] = field(default_factory=list)
+    list_directory_summary_calls: list[str] = field(default_factory=list)
 
     def list_directory(self, path: str) -> tuple[DirectoryEntryState, ...]:
         self.list_directory_calls.append(path)
+        if path in self.errors_by_path:
+            raise self.errors_by_path[path]
+        return self.entries_by_path[path]
+
+    def list_directory_summary(self, path: str) -> tuple[DirectoryEntryState, ...]:
+        self.list_directory_calls.append(path)
+        self.list_directory_summary_calls.append(path)
         if path in self.errors_by_path:
             raise self.errors_by_path[path]
         return self.entries_by_path[path]
@@ -87,6 +95,19 @@ def test_live_browser_snapshot_loader_builds_three_pane_snapshot(tmp_path) -> No
     assert snapshot.current_pane.cursor_path == str(docs)
     assert snapshot.child_pane.directory_path == str(docs)
     assert [entry.name for entry in snapshot.child_pane.entries] == ["spec.md"]
+
+
+def test_live_browser_snapshot_loader_uses_lightweight_side_pane_listings(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    docs = project / "docs"
+    docs.mkdir()
+    filesystem = _build_stub_filesystem(str(project), str(tmp_path), str(docs))
+    loader = LiveBrowserSnapshotLoader(filesystem=filesystem)
+
+    loader.load_browser_snapshot(str(project), cursor_path=str(docs))
+
+    assert filesystem.list_directory_summary_calls == [str(tmp_path), str(docs)]
 
 
 def test_live_browser_snapshot_loader_uses_cursor_path_for_child_pane(tmp_path) -> None:

--- a/tests/test_state_reducer.py
+++ b/tests/test_state_reducer.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from datetime import datetime
 from pathlib import Path
 
 from tests.state_test_helpers import reduce_state
@@ -475,8 +476,21 @@ def test_enter_cursor_directory_promotes_matching_child_pane() -> None:
         child_pane=PaneState(
             directory_path="/tmp/project/docs",
             entries=(
-                DirectoryEntryState("/tmp/project/docs/api", "api", "dir"),
-                DirectoryEntryState("/tmp/project/docs/guide.md", "guide.md", "file"),
+                DirectoryEntryState(
+                    "/tmp/project/docs/api",
+                    "api",
+                    "dir",
+                    modified_at=datetime(2026, 1, 1),
+                    permissions_mode=0o40755,
+                ),
+                DirectoryEntryState(
+                    "/tmp/project/docs/guide.md",
+                    "guide.md",
+                    "file",
+                    size_bytes=42,
+                    modified_at=datetime(2026, 1, 1),
+                    permissions_mode=0o100644,
+                ),
             ),
         ),
         directory_size_cache=(
@@ -523,6 +537,36 @@ def test_enter_cursor_directory_promotes_matching_child_pane() -> None:
         RunDirectorySizeEffect(
             request_id=2,
             paths=("/tmp/project/docs/api",),
+        ),
+    )
+
+
+def test_enter_cursor_directory_does_not_promote_lightweight_child_entries() -> None:
+    state = replace(
+        build_initial_app_state(),
+        current_path="/tmp/project",
+        current_pane=PaneState(
+            directory_path="/tmp/project",
+            entries=(DirectoryEntryState("/tmp/project/docs", "docs", "dir"),),
+            cursor_path="/tmp/project/docs",
+        ),
+        child_pane=PaneState(
+            directory_path="/tmp/project/docs",
+            entries=(
+                DirectoryEntryState("/tmp/project/docs/guide.md", "guide.md", "file"),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(state, EnterCursorDirectory())
+
+    assert result.state.pending_browser_snapshot_request_id == 1
+    assert result.effects == (
+        LoadBrowserSnapshotEffect(
+            request_id=1,
+            path="/tmp/project/docs",
+            cursor_path=None,
+            blocking=True,
         ),
     )
 

--- a/tests/test_state_selectors_panes.py
+++ b/tests/test_state_selectors_panes.py
@@ -136,6 +136,12 @@ test_select_shell_data_reuses_pane_entries_when_only_notification_changes = (
 test_select_shell_data_viewport_projection_limits_rendered_entries = (
     cases.test_select_shell_data_viewport_projection_limits_rendered_entries
 )
+test_select_shell_data_limits_parent_and_child_panes_to_visible_window = (
+    cases.test_select_shell_data_limits_parent_and_child_panes_to_visible_window
+)
+test_select_shell_data_skips_hidden_side_pane_projection = (
+    cases.test_select_shell_data_skips_hidden_side_pane_projection
+)
 test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_inside_window = (
     cases.test_select_shell_data_viewport_projection_reuses_window_for_cursor_move_inside_window
 )


### PR DESCRIPTION
## Summary

- add lightweight parent/child directory listings that avoid per-entry `stat`
- cache lightweight and detailed listings independently
- project parent/child panes to the visible terminal window while preserving total counts
- skip selector projection and widget updates for responsive-hidden side panes

## Verification

- `uv run ruff check .`
- `uv run pytest` (`1479 passed, 9 skipped`)
- deterministic 10,000-entry test verifies zero per-entry `stat` calls for lightweight listings
- 1,000-entry UI test verifies child rendering is bounded to the visible window

## Follow-up

The current pane continues loading detailed metadata to preserve Size/Modified columns and executable markers. Viewport-scoped asynchronous hydration can be evaluated separately if measurements show current-pane `stat` remains dominant.

Refs #1115