### PR TITLE
[#1160] Document Windows CI regression scope

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -85,28 +85,11 @@ jobs:
       - name: Lint
         run: uv run ruff check .
 
-      - name: Test (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Test (all platforms)
         env:
           TMPDIR: ${{ runner.temp }}/zivo-tmp
           TMP: ${{ runner.temp }}/zivo-tmp
           TEMP: ${{ runner.temp }}/zivo-tmp
+        # Keep the Windows job on the full suite so regressions outside the
+        # historical file-operation subset are caught before release.
         run: uv run pytest
-
-      - name: Test (Windows regression subset)
-        if: runner.os == 'Windows'
-        env:
-          TMPDIR: ${{ runner.temp }}/zivo-tmp
-          TMP: ${{ runner.temp }}/zivo-tmp
-          TEMP: ${{ runner.temp }}/zivo-tmp
-        run: >
-          uv run pytest
-          tests/test_adapters_file_operations.py
-          tests/test_services_clipboard_operations.py
-          tests/test_services_file_mutations.py
-          tests/test_services_archive_extract.py
-          tests/test_services_zip_compress.py
-          tests/test_services_file_search.py
-          tests/test_services_grep_search.py
-          tests/test_services_text_replace.py
-          tests/test_services_config.py

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -85,11 +85,33 @@ jobs:
       - name: Lint
         run: uv run ruff check .
 
-      - name: Test (all platforms)
+      - name: Test (Linux/macOS full suite)
+        if: runner.os != 'Windows'
         env:
           TMPDIR: ${{ runner.temp }}/zivo-tmp
           TMP: ${{ runner.temp }}/zivo-tmp
           TEMP: ${{ runner.temp }}/zivo-tmp
-        # Keep the Windows job on the full suite so regressions outside the
-        # historical file-operation subset are caught before release.
         run: uv run pytest
+
+      - name: Test (Windows supported regression scope)
+        if: runner.os == 'Windows'
+        env:
+          TMPDIR: ${{ runner.temp }}/zivo-tmp
+          TMP: ${{ runner.temp }}/zivo-tmp
+          TEMP: ${{ runner.temp }}/zivo-tmp
+        # The full suite was evaluated for Issue #1160. It currently has
+        # 24 native-Windows failures (POSIX path/newline assumptions,
+        # chmod/chown semantics, and platform-specific UI timing). Keep the
+        # established file-operation/search/config regression scope explicit
+        # until those tests are ported.
+        run: >
+          uv run pytest
+          tests/test_adapters_file_operations.py
+          tests/test_services_clipboard_operations.py
+          tests/test_services_file_mutations.py
+          tests/test_services_archive_extract.py
+          tests/test_services_zip_compress.py
+          tests/test_services_file_search.py
+          tests/test_services_grep_search.py
+          tests/test_services_text_replace.py
+          tests/test_services_config.py

--- a/docs/platforms.ja.md
+++ b/docs/platforms.ja.md
@@ -28,6 +28,10 @@ zivo 本体の起動は `uv` だけで行えますが、一部の機能は `PATH
 これらのプレビュー用コマンドは任意依存です。不足時はコマンド名を表示し、tracebackで終了せず、概要メタデータと利用可能な代替Actionを表示します。
 | grep 検索 | `ripgrep` |
 
+### CI のテスト範囲
+
+CI の matrix では Ubuntu、macOS、ネイティブ Windows のすべてで `pytest` のフルスイートを実行します。Windows でテストを skip する場合は、symlink 権限や権限セマンティクスなど、OS 固有の制約を理由としてテスト側に明記します。
+
 ### OS 別のインストール例
 
 ```bash

--- a/docs/platforms.ja.md
+++ b/docs/platforms.ja.md
@@ -30,7 +30,9 @@ zivo 本体の起動は `uv` だけで行えますが、一部の機能は `PATH
 
 ### CI のテスト範囲
 
-CI の matrix では Ubuntu、macOS、ネイティブ Windows のすべてで `pytest` のフルスイートを実行します。Windows でテストを skip する場合は、symlink 権限や権限セマンティクスなど、OS 固有の制約を理由としてテスト側に明記します。
+CI の matrix では Ubuntu と macOS で `pytest` のフルスイートを実行します。ネイティブ Windows では、ファイル操作、クリップボード、アーカイブ展開・圧縮、ファイル検索・grep 検索、テキスト置換、設定を対象にしたサポート対象の回帰テスト範囲を実行します（`tests/test_adapters_file_operations.py`、`tests/test_services_clipboard_operations.py`、`tests/test_services_file_mutations.py`、`tests/test_services_archive_extract.py`、`tests/test_services_zip_compress.py`、`tests/test_services_file_search.py`、`tests/test_services_grep_search.py`、`tests/test_services_text_replace.py`、`tests/test_services_config.py`）。
+
+Issue #1160 でフルスイートも検証しましたが、POSIX パス・改行の前提、chmod/chown のセマンティクス、OS 固有の UI タイミングにより、ネイティブ Windows で 24 件の失敗がありました。これらのテストを移植するまで、Windows の対象範囲は意図的に制限します。Windows でテストを skip する場合は、symlink 権限や権限セマンティクスなど、OS 固有の制約を理由としてテスト側に明記します。
 
 ### OS 別のインストール例
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -28,6 +28,10 @@ zivo itself can be installed and started with `uv`, but some features depend on 
 These preview tools are optional. When one is unavailable, zivo names the missing command, keeps the application running, and shows compact metadata plus an available fallback action instead of a traceback.
 | Grep search | `ripgrep` |
 
+### CI coverage
+
+The CI matrix runs the full `pytest` suite on Ubuntu, macOS, and native Windows. A test may be skipped on Windows only when its reason documents an OS-specific limitation, such as symlink privileges or permission semantics.
+
 ### OS-specific installation examples
 
 ```bash

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -30,7 +30,9 @@ These preview tools are optional. When one is unavailable, zivo names the missin
 
 ### CI coverage
 
-The CI matrix runs the full `pytest` suite on Ubuntu, macOS, and native Windows. A test may be skipped on Windows only when its reason documents an OS-specific limitation, such as symlink privileges or permission semantics.
+The CI matrix runs the full `pytest` suite on Ubuntu and macOS. Native Windows runs the supported regression scope covering file operations, clipboard, archive extraction/compression, file and grep search, text replacement, and configuration (`tests/test_adapters_file_operations.py`, `tests/test_services_clipboard_operations.py`, `tests/test_services_file_mutations.py`, `tests/test_services_archive_extract.py`, `tests/test_services_zip_compress.py`, `tests/test_services_file_search.py`, `tests/test_services_grep_search.py`, `tests/test_services_text_replace.py`, and `tests/test_services_config.py`).
+
+The full suite was evaluated for Issue #1160 and currently has 24 native-Windows failures caused by POSIX path/newline assumptions, chmod/chown semantics, and platform-specific UI timing. The Windows scope remains intentionally limited until those tests are ported. A test may be skipped on Windows only when its reason documents an OS-specific limitation, such as symlink privileges or permission semantics.
 
 ### OS-specific installation examples
 


### PR DESCRIPTION
## Summary

- Evaluate the full pytest suite on `windows-latest` for the v1.0 gate.
- Keep the explicit nine-module Windows regression scope after the trial found 24 native-Windows failures.
- Document the supported scope, failure categories, and porting prerequisites in English and Japanese platform docs.

## Validation

- `uv run ruff check .`
- `uv run pytest` — 1546 passed, 9 skipped locally
- Windows full-suite trial — 24 failed, 1485 passed, 46 skipped
- Windows supported regression scope — pending in the updated CI run

Closes #1160