### PR TITLE
Fix initial focus for streamed search results

### DIFF
--- a/src/zivo/state/models.py
+++ b/src/zivo/state/models.py
@@ -684,6 +684,7 @@ class CommandPaletteState:
     source: CommandPaletteSource = "commands"
     query: str = ""
     cursor_index: int = 0
+    cursor_navigation_active: bool = False
     file_search: FileSearchPaletteState = field(default_factory=FileSearchPaletteState)
     grep_search: GrepSearchPaletteState = field(default_factory=GrepSearchPaletteState)
     replace_preview: ReplacePreviewPaletteState = field(

--- a/src/zivo/state/reducer_palette.py
+++ b/src/zivo/state/reducer_palette.py
@@ -154,11 +154,20 @@ from .reducer_palette_shared import (
 def _handle_move_palette_cursor(state: AppState, action: MoveCommandPaletteCursor) -> ReduceResult:
     if state.command_palette is None:
         return finalize(state)
+    current_index = normalize_command_palette_cursor(
+        state,
+        state.command_palette.cursor_index,
+    )
+    next_index = normalize_command_palette_cursor(
+        state,
+        state.command_palette.cursor_index + action.delta,
+    )
     next_palette = replace(
         state.command_palette,
-        cursor_index=normalize_command_palette_cursor(
-            state,
-            state.command_palette.cursor_index + action.delta,
+        cursor_index=next_index,
+        cursor_navigation_active=(
+            state.command_palette.cursor_navigation_active
+            or next_index != current_index
         ),
     )
     next_state = replace(state, command_palette=next_palette)

--- a/src/zivo/state/reducer_palette_search.py
+++ b/src/zivo/state/reducer_palette_search.py
@@ -158,6 +158,11 @@ def handle_set_file_search_query(
     next_palette,
     query: str,
 ) -> ReduceResult:
+    next_palette = replace(
+        next_palette,
+        cursor_index=0,
+        cursor_navigation_active=False,
+    )
     stripped_query = query.strip()
     search_target = next_palette.file_search.target
     try:
@@ -302,6 +307,7 @@ def handle_set_grep_search_field(
         next_palette,
         grep_search=replace(next_palette.grep_search, error_message=None),
         cursor_index=0,
+        cursor_navigation_active=False,
     )
     stripped_query = next_palette.grep_search.keyword.strip()
     if not stripped_query:
@@ -729,7 +735,12 @@ def _preserve_search_cursor(
     current: tuple[FileSearchResultState | GrepSearchResultState, ...],
     merged: tuple[FileSearchResultState | GrepSearchResultState, ...],
 ) -> int:
-    if not current or not merged or state.command_palette is None:
+    if (
+        not current
+        or not merged
+        or state.command_palette is None
+        or not state.command_palette.cursor_navigation_active
+    ):
         return 0
     old_index = normalize_command_palette_cursor(state, state.command_palette.cursor_index)
     if old_index >= len(current):

--- a/tests/test_state_reducer_palette_search.py
+++ b/tests/test_state_reducer_palette_search.py
@@ -931,6 +931,34 @@ def test_file_search_partial_results_are_applied_and_keep_request_pending() -> N
     assert result.state.command_palette.file_search.results_truncated is False
 
 
+def test_file_search_streaming_results_keep_first_result_selected_without_navigation() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginFileSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("read"))
+    state = _reduce_state(
+        state,
+        FileSearchResultsUpdated(
+            request_id=1,
+            query="read",
+            results=(FileSearchResultState(path="/tmp/b.txt", display_path="b.txt"),),
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        FileSearchResultsUpdated(
+            request_id=1,
+            query="read",
+            results=(FileSearchResultState(path="/tmp/a.txt", display_path="a.txt"),),
+        ),
+    )
+
+    assert [item.display_path for item in result.state.command_palette.file_search.results] == [
+        "a.txt",
+        "b.txt",
+    ]
+    assert result.state.command_palette.cursor_index == 0
+
+
 def test_file_search_partial_results_preserve_selected_path_when_sorted_order_changes() -> None:
     state = _reduce_state(build_initial_app_state(), BeginFileSearch())
     state = replace(
@@ -945,6 +973,7 @@ def test_file_search_partial_results_preserve_selected_path_when_sorted_order_ch
                     FileSearchResultState(path="/tmp/b.txt", display_path="b.txt"),
                 ),
             ),
+            cursor_navigation_active=True,
         ),
         pending_file_search_request_id=1,
     )
@@ -1010,6 +1039,48 @@ def test_grep_search_partial_results_are_applied_while_search_is_pending() -> No
 
     assert result.state.command_palette.grep_search.results[0].display_path == "README.md"
     assert result.state.pending_grep_search_request_id == 1
+
+
+def test_grep_search_streaming_results_keep_first_result_selected_without_navigation() -> None:
+    state = _reduce_state(build_initial_app_state(), BeginGrepSearch())
+    state = _reduce_state(state, SetCommandPaletteQuery("todo"))
+    state = _reduce_state(
+        state,
+        GrepSearchResultsUpdated(
+            request_id=1,
+            query="todo",
+            results=(
+                GrepSearchResultState(
+                    path="/tmp/b.txt",
+                    display_path="b.txt",
+                    line_number=1,
+                    line_text="TODO",
+                ),
+            ),
+        ),
+    )
+
+    result = reduce_app_state(
+        state,
+        GrepSearchResultsUpdated(
+            request_id=1,
+            query="todo",
+            results=(
+                GrepSearchResultState(
+                    path="/tmp/a.txt",
+                    display_path="a.txt",
+                    line_number=1,
+                    line_text="TODO",
+                ),
+            ),
+        ),
+    )
+
+    assert [item.display_path for item in result.state.command_palette.grep_search.results] == [
+        "a.txt",
+        "b.txt",
+    ]
+    assert result.state.command_palette.cursor_index == 0
 
 
 def test_grep_search_partial_results_filter_selected_scope() -> None:


### PR DESCRIPTION
## Summary\n\n- Keep file search and grep focused on the first sorted result while streamed results arrive when the user has not navigated.\n- Preserve the selected result when the user explicitly moves the palette cursor.\n- Add regression coverage for both search modes.\n\n## Tests\n\n- uv run pytest (1554 passed, 9 skipped)\n- uv run ruff check .\n\n## Follow-up\n\n- None.