### PR TITLE
[#1188] Fix Kitty image preview overflow

### DIFF
--- a/src/zivo/services/previews/core.py
+++ b/src/zivo/services/previews/core.py
@@ -414,6 +414,7 @@ class ImagePreviewLoader(Protocol):
         path: Path,
         *,
         preview_columns: int,
+        preview_rows: int | None = None,
         image_preview_format: str = "symbols",
         cancel_callback: CancelCallback | None = None,
     ) -> FilePreviewState | None: ...
@@ -565,6 +566,7 @@ class ChafaImagePreviewLoader:
         path: Path,
         *,
         preview_columns: int,
+        preview_rows: int | None = None,
         image_preview_format: str = "symbols",
         cancel_callback: CancelCallback | None = None,
     ) -> FilePreviewState | None:
@@ -578,6 +580,7 @@ class ChafaImagePreviewLoader:
             chafa,
             path,
             preview_columns=preview_columns,
+            preview_rows=preview_rows,
             chafa_format=image_preview_format,
         )
         try:
@@ -611,6 +614,7 @@ class ChafaImagePreviewLoader:
                 chafa,
                 path,
                 preview_columns=preview_columns,
+                preview_rows=preview_rows,
                 chafa_format=image_preview_format,
             )
             try:
@@ -660,6 +664,7 @@ class ChafaImagePreviewLoader:
         path: Path,
         *,
         preview_columns: int,
+        preview_rows: int | None = None,
         chafa_format: str = "symbols",
     ) -> list[str]:
         args = [
@@ -673,13 +678,10 @@ class ChafaImagePreviewLoader:
             args.extend(["--duration", "0"])
         else:
             args.extend(["--animate", "off"])
-        args.extend(
-            [
-                "--size",
-                f"{max(1, preview_columns)}x",
-                str(path),
-            ]
-        )
+        size = f"{max(1, preview_columns)}x"
+        if chafa_format == "kitty" and preview_rows is not None:
+            size += str(max(1, preview_rows))
+        args.extend(["--size", size, str(path)])
         return args
 
     def _should_retry_without_animate(

--- a/src/zivo/ui/child_pane.py
+++ b/src/zivo/ui/child_pane.py
@@ -202,9 +202,10 @@ class ChildPane(Vertical):
         )
         self._chafa_cached_content: str | None = None
         self._last_chafa_width: int = 0
+        self._last_kitty_height: int | None = None
         self._chafa_resize_timer: Timer | None = None
         self._chafa_resize_request_id = 0
-        self._pending_chafa_resize_key: tuple[str, int, str] | None = None
+        self._pending_chafa_resize_key: tuple[str, int, int | None, str] | None = None
         self._image_preview_loader = image_preview_loader or ChafaImagePreviewLoader()
         self._resize_debouncer = ResizeDebouncer(
             self,
@@ -446,6 +447,7 @@ class ChildPane(Vertical):
             object.__setattr__(self, "_kitty_cached", None)
             object.__setattr__(self, "_last_kitty_path", None)
             object.__setattr__(self, "_last_kitty_width", None)
+            object.__setattr__(self, "_last_kitty_height", None)
             if state.is_preview:
                 self.call_after_refresh(lambda: scroll_widget.scroll_home(animate=False))
 
@@ -496,10 +498,20 @@ class ChildPane(Vertical):
                     self._last_render_width = render_width
                     self._last_render_signature = render_signature
                     return True
+                kitty_viewport_changed = False
+                if self._state.preview_kind == "kitty":
+                    try:
+                        kitty_viewport_changed = (
+                            self._preview_scroll_widget().size.height
+                            != getattr(self, "_last_kitty_height", None)
+                        )
+                    except NoMatches:
+                        pass
                 if (
                     not force
                     and render_width == self._last_render_width
                     and render_signature == self._last_render_signature
+                    and not kitty_viewport_changed
                 ):
                     return True
                 if (
@@ -794,8 +806,8 @@ class ChildPane(Vertical):
     def _write_kitty_content(self, content: str) -> None:
         """Write Kitty graphics protocol escape sequence to the terminal.
 
-        Re-runs chafa when the available preview width changes so the
-        image always fills the pane without overflowing the terminal.
+        Re-runs chafa when the available preview viewport changes so the
+        image stays inside the pane instead of overflowing the terminal.
         """
         try:
             from zivo.services.previews.core import resolve_image_preview_format
@@ -805,7 +817,10 @@ class ChildPane(Vertical):
             if region.x < 0 or region.y < 0:
                 return
 
+            if scroll.size.width <= 0 or scroll.size.height <= 0:
+                return
             pane_width = max(1, scroll.size.width - 2)
+            pane_height = max(1, scroll.size.height)
 
             mode = getattr(self._state, "image_preview_mode", "auto")
             fmt = resolve_image_preview_format(mode)
@@ -814,18 +829,28 @@ class ChildPane(Vertical):
 
             path = self._state.preview_path
             last_width = getattr(self, "_last_kitty_width", None)
+            last_height = getattr(self, "_last_kitty_height", None)
             last_path = getattr(self, "_last_kitty_path", None)
 
-            if path == last_path and pane_width != last_width and path:
+            if (
+                path
+                and (
+                    path != last_path
+                    or pane_width != last_width
+                    or pane_height != last_height
+                )
+            ):
                 self._schedule_chafa_resize_preview(
                     path,
                     pane_width,
                     "kitty",
+                    preview_rows=pane_height,
                 )
-            else:
-                cached = getattr(self, "_kitty_cached", None)
-                if path == last_path and cached is not None:
-                    content = cached
+                return
+
+            cached = getattr(self, "_kitty_cached", None)
+            if path == last_path and cached is not None:
+                content = cached
 
             if not content:
                 return
@@ -833,6 +858,7 @@ class ChildPane(Vertical):
             object.__setattr__(self, "_kitty_cached", content)
             object.__setattr__(self, "_last_kitty_path", path)
             object.__setattr__(self, "_last_kitty_width", pane_width)
+            object.__setattr__(self, "_last_kitty_height", pane_height)
 
             row = region.y + 1
             col = region.x + 1
@@ -846,8 +872,10 @@ class ChildPane(Vertical):
         path: str,
         preview_columns: int,
         image_preview_format: str,
+        *,
+        preview_rows: int | None = None,
     ) -> None:
-        key = (path, preview_columns, image_preview_format)
+        key = (path, preview_columns, preview_rows, image_preview_format)
         if self._pending_chafa_resize_key == key:
             return
         self._chafa_resize_request_id += 1
@@ -862,6 +890,7 @@ class ChildPane(Vertical):
                 path,
                 preview_columns,
                 image_preview_format,
+                preview_rows=preview_rows,
             ),
             name=f"chafa-resize-debounce:{request_id}",
         )
@@ -872,23 +901,33 @@ class ChildPane(Vertical):
         path: str,
         preview_columns: int,
         image_preview_format: str,
+        *,
+        preview_rows: int | None = None,
     ) -> None:
         self._chafa_resize_timer = None
         if (
             request_id != self._chafa_resize_request_id
             or self._pending_chafa_resize_key
-            != (path, preview_columns, image_preview_format)
+            != (path, preview_columns, preview_rows, image_preview_format)
         ):
             return
 
         def _load_preview() -> None:
             content: str | None = None
             try:
-                result = self._image_preview_loader.load_preview(
-                    FsPath(path),
-                    preview_columns=preview_columns,
-                    image_preview_format=image_preview_format,
-                )
+                if preview_rows is None:
+                    result = self._image_preview_loader.load_preview(
+                        FsPath(path),
+                        preview_columns=preview_columns,
+                        image_preview_format=image_preview_format,
+                    )
+                else:
+                    result = self._image_preview_loader.load_preview(
+                        FsPath(path),
+                        preview_columns=preview_columns,
+                        preview_rows=preview_rows,
+                        image_preview_format=image_preview_format,
+                    )
                 if result and result.content:
                     content = result.content
             except Exception:
@@ -901,6 +940,7 @@ class ChildPane(Vertical):
                     preview_columns,
                     image_preview_format,
                     content,
+                    preview_rows=preview_rows,
                 )
             except Exception:
                 pass
@@ -921,8 +961,10 @@ class ChildPane(Vertical):
         preview_columns: int,
         image_preview_format: str,
         content: str | None,
+        *,
+        preview_rows: int | None = None,
     ) -> None:
-        key = (path, preview_columns, image_preview_format)
+        key = (path, preview_columns, preview_rows, image_preview_format)
         if (
             request_id != self._chafa_resize_request_id
             or self._pending_chafa_resize_key != key
@@ -955,6 +997,7 @@ class ChildPane(Vertical):
             object.__setattr__(self, "_kitty_cached", content)
         object.__setattr__(self, "_last_kitty_path", path)
         object.__setattr__(self, "_last_kitty_width", preview_columns)
+        object.__setattr__(self, "_last_kitty_height", preview_rows)
         self._pending_chafa_resize_key = None
         if content:
             self._write_kitty_content(content)

--- a/tests/test_preview_resource_budget.py
+++ b/tests/test_preview_resource_budget.py
@@ -123,6 +123,41 @@ def test_image_preview_uses_a_relaxed_format_specific_budget(
     assert captured["timeout_seconds"] == budget.image_timeout_seconds
 
 
+def test_kitty_image_preview_uses_the_bounded_preview_height(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    image = tmp_path / "image.png"
+    image.write_bytes(b"PNG")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("zivo.services.previews.core.shutil.which", lambda _: "/fake/chafa")
+
+    def _run(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return ShellCommandResult(
+            exit_code=0,
+            stdout="\033_Gf=100;AAAA\033\\",
+        )
+
+    monkeypatch.setattr("zivo.services.previews.core.run_bounded_process", _run)
+
+    preview = ChafaImagePreviewLoader().load_preview(
+        image,
+        preview_columns=40,
+        preview_rows=12,
+        image_preview_format="kitty",
+    )
+
+    assert preview == FilePreviewState.with_content(
+        "\033_Gf=100;AAAA\033\\",
+        False,
+        content_kind="kitty",
+    )
+    assert captured["command"][-3:] == ["--size", "40x12", str(image)]
+
+
 def test_preview_resource_config_converts_user_units_to_process_limits() -> None:
     budget = PreviewResourceBudget.from_config(
         PreviewResourceConfig(

--- a/tests/test_ui_panes.py
+++ b/tests/test_ui_panes.py
@@ -426,9 +426,9 @@ def test_child_pane_reuses_image_preview_loader_for_resize_workers() -> None:
     pane.run_worker = lambda worker, **_kwargs: worker()  # type: ignore[method-assign]
 
     pane._chafa_resize_request_id = 1
-    pane._pending_chafa_resize_key = ("/tmp/image.png", 40, "symbols")
+    pane._pending_chafa_resize_key = ("/tmp/image.png", 40, None, "symbols")
     pane._start_chafa_resize_worker(1, "/tmp/image.png", 40, "symbols")
-    pane._pending_chafa_resize_key = ("/tmp/image.png", 60, "symbols")
+    pane._pending_chafa_resize_key = ("/tmp/image.png", 60, None, "symbols")
     pane._start_chafa_resize_worker(1, "/tmp/image.png", 60, "symbols")
 
     assert loader.calls == [
@@ -1226,7 +1226,7 @@ def test_child_pane_clears_kitty_preview_on_unmount() -> None:
     writer.assert_called_once_with("\033_Ga=d,d=A\033\\")
 
 
-def test_child_pane_writes_new_kitty_content_when_path_changes_same_width(
+def test_child_pane_schedules_bounded_kitty_preview_when_path_changes(
     monkeypatch,
 ) -> None:
     pane = ChildPane(
@@ -1240,13 +1240,16 @@ def test_child_pane_writes_new_kitty_content_when_path_changes_same_width(
     )
     scroll_widget = SimpleNamespace(
         region=SimpleNamespace(x=4, y=2),
-        size=SimpleNamespace(width=42),
+        size=SimpleNamespace(width=42, height=10),
     )
     writer = Mock()
+    resize = Mock()
     pane._preview_scroll_widget = lambda: scroll_widget  # type: ignore[method-assign]
     pane._write_terminal_content = writer  # type: ignore[method-assign]
+    pane._schedule_chafa_resize_preview = resize  # type: ignore[method-assign]
     object.__setattr__(pane, "_last_kitty_path", "/tmp/old.png")
     object.__setattr__(pane, "_last_kitty_width", 40)
+    object.__setattr__(pane, "_last_kitty_height", 10)
     object.__setattr__(pane, "_kitty_cached", "\033_Gf=100;OLD\033\\")
     monkeypatch.setattr(
         "zivo.services.previews.core.resolve_image_preview_format",
@@ -1255,6 +1258,10 @@ def test_child_pane_writes_new_kitty_content_when_path_changes_same_width(
 
     pane._write_kitty_content("\033_Gf=100;NEW\033\\")
 
-    writer.assert_called_once()
-    assert "NEW" in writer.call_args.args[0]
-    assert "OLD" not in writer.call_args.args[0]
+    resize.assert_called_once_with(
+        "/tmp/new.png",
+        40,
+        "kitty",
+        preview_rows=10,
+    )
+    writer.assert_not_called()


### PR DESCRIPTION
## 概要
画像プレビュー（Kitty graphics）が preview 領域を超えて表示される問題を修正します。

## 変更内容
- Kitty 用 `chafa` に preview の幅・高さを渡すよう変更
- 初期表示、パス変更、端末リサイズ時に viewport 内サイズで再生成
- 古い再生成結果や未制限の画像データを直接描画しないよう状態管理を拡張
- Kitty のサイズ制限と ChildPane の再生成をテスト

## 検証
- `uv run ruff check .`
- `uv run pytest -q`（1575 passed, 9 skipped）
- `git diff --check`

Closes #1188